### PR TITLE
修复全盘模式仍受工作区限制及删除失败

### DIFF
--- a/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "readable-python-source/omni_body_skill",
-  "tree_sha256": "b6198a3bdbcc1991694ab89fe971d9e43ad0d03aff973fc08845c3e47bbb8ef2",
+  "tree_sha256": "6cef0b37a10eaa6c075a1db0c8547b13ed81117f712ec22653593c398efbf685",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/SKILL.md
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/SKILL.md
@@ -25,7 +25,7 @@ are complete.
 | file.mkdir | Create a directory |
 | file.copy | Copy; destination in `args.destination` |
 | file.move / file.rename | Move or rename; destination in `args.destination` |
-| file.delete_to_trash | Move file/directory to trash; confirmation may be required |
+| file.delete_to_trash | Move file/directory into governed trash; A4 reversible action, no legacy confirmation |
 
 There is no `file.exists` action. Use `file.list`, `file.read`, or
 `system.action_schema` and treat a successful result as evidence.
@@ -50,7 +50,7 @@ and `git.diff`.
 | action | what it does |
 |--------|-------------|
 | docx.create | Create a Word `.docx` from structured content |
-| pptx.create | Create a PowerPoint `.pptx` from slide specs |
+| pptx.create | Create a PowerPoint `.pptx` deck from slide specs |
 | pptx.read | Inspect slide text, 16:9 dimensions, placeholders, fonts, and meaningful visuals |
 | sheet.create / sheet.read | Create or read Excel workbooks |
 | pdf.extract_text | Extract text from PDF |
@@ -108,6 +108,7 @@ There is no `knowledge.search` action in the current registry.
 3. **Real artifacts.** Deliveries must produce real local files; package large multi-file output with `deliverable.package`.
 4. **Long-chain continuity.** At lease checkpoints, state a concise visible continuation reason and immediately issue the next tool call.
 5. **Repair before finish.** Failed tests/QC require repair and rerun, not narrative completion.
+6. **Authorization stays host-owned.** A1-A4 actions do not use the retired confirmation flow; never invent `confirmed`, `confirmation`, or capability-grant fields. A5 and hard-deny paths remain blocked by the host/gateway.
 
 ## Call shape
 

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/novel-creation/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/novel-creation/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "managed-novel-skill-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "readable-python-source/bundled-skills/novel-creation",
-  "tree_sha256": "5f0ca06c4524cff7f677628fb7250c73c15ab430a840ad879fa66610641d5ff4",
+  "tree_sha256": "4230ea2e44c1df4aa2dc4996a1a88432e4b5fb81085ae42ce2df7cd4f443c925",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "readable-python-source/omni_body_skill",
-  "tree_sha256": "b6198a3bdbcc1991694ab89fe971d9e43ad0d03aff973fc08845c3e47bbb8ef2",
+  "tree_sha256": "6cef0b37a10eaa6c075a1db0c8547b13ed81117f712ec22653593c398efbf685",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/SKILL.md
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/SKILL.md
@@ -25,7 +25,7 @@ are complete.
 | file.mkdir | Create a directory |
 | file.copy | Copy; destination in `args.destination` |
 | file.move / file.rename | Move or rename; destination in `args.destination` |
-| file.delete_to_trash | Move file/directory to trash; confirmation may be required |
+| file.delete_to_trash | Move file/directory into governed trash; A4 reversible action, no legacy confirmation |
 
 There is no `file.exists` action. Use `file.list`, `file.read`, or
 `system.action_schema` and treat a successful result as evidence.
@@ -50,7 +50,7 @@ and `git.diff`.
 | action | what it does |
 |--------|-------------|
 | docx.create | Create a Word `.docx` from structured content |
-| pptx.create | Create a PowerPoint `.pptx` from slide specs |
+| pptx.create | Create a PowerPoint `.pptx` deck from slide specs |
 | pptx.read | Inspect slide text, 16:9 dimensions, placeholders, fonts, and meaningful visuals |
 | sheet.create / sheet.read | Create or read Excel workbooks |
 | pdf.extract_text | Extract text from PDF |
@@ -108,6 +108,7 @@ There is no `knowledge.search` action in the current registry.
 3. **Real artifacts.** Deliveries must produce real local files; package large multi-file output with `deliverable.package`.
 4. **Long-chain continuity.** At lease checkpoints, state a concise visible continuation reason and immediately issue the next tool call.
 5. **Repair before finish.** Failed tests/QC require repair and rerun, not narrative completion.
+6. **Authorization stays host-owned.** A1-A4 actions do not use the retired confirmation flow; never invent `confirmed`, `confirmation`, or capability-grant fields. A5 and hard-deny paths remain blocked by the host/gateway.
 
 ## Call shape
 

--- a/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "readable-python-source/omni_body_skill",
-  "tree_sha256": "b6198a3bdbcc1991694ab89fe971d9e43ad0d03aff973fc08845c3e47bbb8ef2",
+  "tree_sha256": "6cef0b37a10eaa6c075a1db0c8547b13ed81117f712ec22653593c398efbf685",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/omni_body_skill/SKILL.md
+++ b/app/backend/tiangong-backend/omni_body_skill/SKILL.md
@@ -25,7 +25,7 @@ are complete.
 | file.mkdir | Create a directory |
 | file.copy | Copy; destination in `args.destination` |
 | file.move / file.rename | Move or rename; destination in `args.destination` |
-| file.delete_to_trash | Move file/directory to trash; confirmation may be required |
+| file.delete_to_trash | Move file/directory into governed trash; A4 reversible action, no legacy confirmation |
 
 There is no `file.exists` action. Use `file.list`, `file.read`, or
 `system.action_schema` and treat a successful result as evidence.
@@ -50,7 +50,7 @@ and `git.diff`.
 | action | what it does |
 |--------|-------------|
 | docx.create | Create a Word `.docx` from structured content |
-| pptx.create | Create a PowerPoint `.pptx` from slide specs |
+| pptx.create | Create a PowerPoint `.pptx` deck from slide specs |
 | pptx.read | Inspect slide text, 16:9 dimensions, placeholders, fonts, and meaningful visuals |
 | sheet.create / sheet.read | Create or read Excel workbooks |
 | pdf.extract_text | Extract text from PDF |
@@ -108,6 +108,7 @@ There is no `knowledge.search` action in the current registry.
 3. **Real artifacts.** Deliveries must produce real local files; package large multi-file output with `deliverable.package`.
 4. **Long-chain continuity.** At lease checkpoints, state a concise visible continuation reason and immediately issue the next tool call.
 5. **Repair before finish.** Failed tests/QC require repair and rerun, not narrative completion.
+6. **Authorization stays host-owned.** A1-A4 actions do not use the retired confirmation flow; never invent `confirmed`, `confirmation`, or capability-grant fields. A5 and hard-deny paths remain blocked by the host/gateway.
 
 ## Call shape
 

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "readable-python-source/omni_body_skill",
-  "tree_sha256": "b6198a3bdbcc1991694ab89fe971d9e43ad0d03aff973fc08845c3e47bbb8ef2",
+  "tree_sha256": "6cef0b37a10eaa6c075a1db0c8547b13ed81117f712ec22653593c398efbf685",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/SKILL.md
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/SKILL.md
@@ -25,7 +25,7 @@ are complete.
 | file.mkdir | Create a directory |
 | file.copy | Copy; destination in `args.destination` |
 | file.move / file.rename | Move or rename; destination in `args.destination` |
-| file.delete_to_trash | Move file/directory to trash; confirmation may be required |
+| file.delete_to_trash | Move file/directory into governed trash; A4 reversible action, no legacy confirmation |
 
 There is no `file.exists` action. Use `file.list`, `file.read`, or
 `system.action_schema` and treat a successful result as evidence.
@@ -50,7 +50,7 @@ and `git.diff`.
 | action | what it does |
 |--------|-------------|
 | docx.create | Create a Word `.docx` from structured content |
-| pptx.create | Create a PowerPoint `.pptx` from slide specs |
+| pptx.create | Create a PowerPoint `.pptx` deck from slide specs |
 | pptx.read | Inspect slide text, 16:9 dimensions, placeholders, fonts, and meaningful visuals |
 | sheet.create / sheet.read | Create or read Excel workbooks |
 | pdf.extract_text | Extract text from PDF |
@@ -108,6 +108,7 @@ There is no `knowledge.search` action in the current registry.
 3. **Real artifacts.** Deliveries must produce real local files; package large multi-file output with `deliverable.package`.
 4. **Long-chain continuity.** At lease checkpoints, state a concise visible continuation reason and immediately issue the next tool call.
 5. **Repair before finish.** Failed tests/QC require repair and rerun, not narrative completion.
+6. **Authorization stays host-owned.** A1-A4 actions do not use the retired confirmation flow; never invent `confirmed`, `confirmation`, or capability-grant fields. A5 and hard-deny paths remain blocked by the host/gateway.
 
 ## Call shape
 

--- a/app/backend/tiangong-backend/v3/permission_settings.py
+++ b/app/backend/tiangong-backend/v3/permission_settings.py
@@ -171,6 +171,18 @@ def _normalize_roots(value: Any) -> list[str]:
     return roots
 
 
+def _workspace_mode() -> str:
+    """Return the path-scope authority injected by the desktop main process.
+
+    ``permission_mode`` controls autonomous A0-A4 execution policy.  It is not
+    the filesystem scope.  The desktop workspace transaction owns
+    ``TIANGONG_WORKSPACE_MODE`` and restarts the gateway/backend with the same
+    value, so prompts and policy diagnostics must read that exact authority
+    rather than reconstructing an independent workspace gate.
+    """
+    return "full" if str(os.environ.get("TIANGONG_WORKSPACE_MODE") or "").strip().lower() == "full" else "workspace"
+
+
 def duqu_permission_settings() -> dict[str, Any]:
     raw = _load_raw()
     merged = {**DEFAULT_SETTINGS, **raw}
@@ -228,6 +240,7 @@ def permission_status(*, refresh: bool = False) -> dict[str, Any]:
         "downloads": env.get("downloads") or "",
         "documents": env.get("documents") or "",
         "workspace": env.get("workspace") or "",
+        "workspace_mode": _workspace_mode(),
         "drive_roots": env.get("drive_roots") or [],
     }
 
@@ -237,16 +250,37 @@ def runtime_context_needed(message: str) -> bool:
     return any(item.lower() in lowered for item in RUNTIME_CONTEXT_KEYWORDS)
 
 
+def _runtime_path_policy_lines(status: dict[str, Any]) -> list[str]:
+    workspace = status.get("workspace") or ""
+    workspace_mode = "full" if status.get("workspace_mode") == "full" else "workspace"
+    hard_deny = (
+        "- \u786c\u7981\u533a\u59cb\u7ec8\u62d2\u7edd\uff1aWindows \u6838\u5fc3\u7cfb\u7edf\u76ee\u5f55\u3001\u78c1\u76d8\u6839\u3001"
+        "\u51ed\u636e\u76ee\u5f55\uff08.ssh/.aws/.gnupg/.azure/.config\uff09\u4e0e\u4efb\u4f55 .env \u6587\u4ef6\uff1b"
+        "\u8fd9\u4e9b\u8fb9\u754c\u4e0d\u56e0 full/full_access \u653e\u5bbd\u3002"
+    )
+    if workspace_mode == "full":
+        return [
+            "[\u8def\u5f84\u89c4\u5219]",
+            f"- \u5199\u5165\u8303\u56f4: \u5168\u76d8 (full)\uff1b\u5de5\u4f5c\u533a {workspace} \u53ea\u662f\u76f8\u5bf9\u8def\u5f84\u7684\u89e3\u6790\u57fa\u51c6\uff0c\u4e0d\u662f\u8bbf\u95ee\u6743\u9650\u8fb9\u754c\u3002",
+            "- \u9664\u786c\u7981\u533a/A5 \u5916\uff0c\u5141\u8bb8\u4f7f\u7528\u7edd\u5bf9\u8def\u5f84\u8bfb\u53d6\u3001\u5199\u5165\u3001\u79fb\u52a8\u3001\u91cd\u547d\u540d\u548c\u5220\u9664\u5230 trash\uff1b\u4e0d\u8981\u81ea\u884c\u9000\u56de\u5de5\u4f5c\u533a\u3002",
+            "- A1-A4 \u4e0d\u4f7f\u7528\u65e7 confirmation \u6d41\u7a0b\u3002file.delete_to_trash \u662f A4 \u53ef\u56de\u6eda\u5220\u9664\uff0c\u76f4\u63a5\u8c03\u7528\uff1b\u4e0d\u8981\u6784\u9020 confirmed/confirmation \u7b49\u6388\u6743\u5b57\u6bb5\u3002",
+            hard_deny,
+        ]
+    return [
+        "[\u8def\u5f84\u89c4\u5219]",
+        f"- \u5199\u5165\u8303\u56f4: \u5de5\u4f5c\u533a (workspace)\uff1b\u5de5\u4f5c\u533a {workspace} \u662f\u9ed8\u8ba4\u8def\u5f84\u8fb9\u754c\uff0c\u76f8\u5bf9\u8def\u5f84\u4ee5\u6b64\u89e3\u6790\u3002",
+        "- \u7528\u6237\u672c\u8f6e\u660e\u786e\u6307\u5b9a\u7684\u5de5\u4f5c\u533a\u5916\u8def\u5f84\u53ef\u7531\u7f51\u5173 object grant \u6388\u6743\u540e\u539f\u6837\u4f20\u9012\uff1b\u4e0d\u8981\u81ea\u884c\u6269\u5c55\u5230\u5176\u4ed6\u533a\u5916\u8def\u5f84\u3002",
+        "- A1-A4 \u4e0d\u4f7f\u7528\u65e7 confirmation \u6d41\u7a0b\uff1b\u672a\u83b7\u5f97 object grant \u7684\u533a\u5916\u8def\u5f84\u7531\u6267\u884c contract \u62d2\u7edd\uff0c\u4e0d\u8981\u751f\u6210\u65e0\u6cd5\u5151\u4ed8\u7684\u786e\u8ba4\u5361\u3002",
+        hard_deny,
+    ]
+
+
 def build_runtime_context_prompt(message: str = "", *, force: bool = False) -> str:
     status = permission_status()
-    # 常驻边界（不依赖关键词触发，保持简短防 token 挤压）：
-    # 工作区边界 / 用户指定直通 / 区外写需确认 / 禁区。
-    policy_lines = [
-        "[\u8def\u5f84\u89c4\u5219]",
-        f"- \u5de5\u4f5c\u533a: {status.get('workspace') or ''}\uff1b\u9ed8\u8ba4\u53ea\u5728\u5de5\u4f5c\u533a\u5185\u8bfb\u5199\uff0c\u7edd\u5bf9\u8def\u5f84\u539f\u6837\u4f20\u9012\u4e0d\u505a\u6539\u5199\u3002",
-        "- \u7528\u6237\u672c\u8f6e\u6d88\u606f\u91cc\u660e\u786e\u7ed9\u51fa\u7684\u8def\u5f84\uff08\u7edd\u5bf9\u8def\u5f84/\u76d8\u7b26/\u684c\u9762\u7b49\u522b\u540d/\u6587\u4ef6\u540d\uff09\u89c6\u4e3a\u7528\u6237\u6307\u5b9a\uff0c\u53ef\u76f4\u901a\u3002",
-        "- \u5de5\u4f5c\u533a\u5916\u4e14\u7528\u6237\u672a\u6307\u5b9a\u7684\u5199\u5165\u5fc5\u987b\u5148\u5411\u7528\u6237\u786e\u8ba4\uff1b\u51ed\u636e\u76ee\u5f55\uff08.ssh/.aws/.gnupg\uff09\u4e0e\u4efb\u4f55 .env \u6587\u4ef6\u8bfb\u5199\u7686\u62d2\u3002",
-    ]
+    # Path scope is owned by the desktop workspace authority.  Do not recreate
+    # the retired workspace/outside-confirm gate in prompt text: doing so can
+    # make a healthy full-disk capability look workspace-only to the model.
+    policy_lines = _runtime_path_policy_lines(status)
     if not force and not runtime_context_needed(message):
         return "\n".join(policy_lines)
     lowered_message = str(message or "").lower()
@@ -256,6 +290,8 @@ def build_runtime_context_prompt(message: str = "", *, force: bool = False) -> s
     mode_label = status.get("mode_label") or status.get("permission_mode") or ""
     mode_value = status.get("permission_mode") or ""
     mode_text = mode_label if not mode_value or mode_value == mode_label else f"{mode_label} ({mode_value})"
+    workspace_mode = "full" if status.get("workspace_mode") == "full" else "workspace"
+    workspace_mode_text = "\u5168\u76d8 (full)" if workspace_mode == "full" else "\u5de5\u4f5c\u533a (workspace)"
     lines = [
         "[\u8fd0\u884c\u73af\u5883\u4e8b\u5b9e]",
         f"- \u5f53\u524d\u7528\u6237: {user.get('whoami') or user.get('username') or ''}",
@@ -264,10 +300,11 @@ def build_runtime_context_prompt(message: str = "", *, force: bool = False) -> s
         f"- \u4e0b\u8f7d: {status.get('downloads') or ''}",
         f"- \u6587\u6863: {status.get('documents') or ''}",
         f"- \u5de5\u4f5c\u533a: {status.get('workspace') or ''}",
+        f"- \u5199\u5165\u8303\u56f4: {workspace_mode_text}",
         f"- \u53ef\u7528\u76d8: {drives}",
-        f"- \u6743\u9650\u6a21\u5f0f: {mode_text}",
+        f"- \u52a8\u4f5c\u6743\u9650\u6a21\u5f0f: {mode_text}",
         "- \u8def\u5f84\u89e3\u6790: \u4e0d\u731c\u7528\u6237\u76ee\u5f55\u6216\u76d8\u7b26\uff1b\u6d89\u53ca\u8def\u5f84\u65f6\u5148\u6309\u8fd0\u884c\u65f6\u4e8b\u5b9e\u89e3\u6790\u3002",
-        "- \u6743\u9650\u8fb9\u754c: full_access/\u5b8c\u5168\u8bbf\u95ee\u6743\u9650\u53ea\u8868\u793a\u666e\u901a\u8bfb\u5199\u548c\u5de5\u5177\u8c03\u7528\u53ef\u81ea\u52a8\u653e\u884c\uff1bA5\u3001\u9ad8\u5371\u3001\u7cfb\u7edf\u6839\u76ee\u5f55\u6216\u76d8\u7b26\u6839\u76ee\u5f55\u7684\u7834\u574f\u6027\u64cd\u4f5c\u4ecd\u5fc5\u987b\u963b\u65ad\uff0c\u4e0d\u56e0 full_access \u653e\u884c\u3002",
+        "- \u6743\u9650\u5206\u5c42: permission_mode \u51b3\u5b9a A0-A4 \u52a8\u4f5c\u662f\u5426\u81ea\u4e3b\u6267\u884c\uff1bworkspace_mode \u51b3\u5b9a\u8def\u5f84\u8303\u56f4\u3002A5/\u786c\u7981\u533a\u59cb\u7ec8\u7531\u4e3b\u6743\u95f8\u95e8\u62d2\u7edd\u3002",
         *policy_lines[1:],
     ]
     if "\u684c\u9762" in lowered_message or "desktop" in lowered_message:
@@ -291,7 +328,7 @@ def _action_kind(tool_name: str, args: dict[str, Any]) -> str:
     if name != "omni_body":
         return "execute"
     action = str((args or {}).get("action") or "").strip().lower()
-    if action in NETWORK_ACTIONS or action.startswith("browser."):
+    if action in NETWORK_ACTIONS or action.startswith(("browser.")):
         return "network"
     if action in TERMINAL_ACTIONS:
         return "terminal"
@@ -424,6 +461,7 @@ def check_tool_permission(tool_name: str, tool_args: dict[str, Any] | None, ying
     action = _action_kind(tool_name, rewritten)
     details = {
         "permission_mode": settings.get("permission_mode"),
+        "workspace_mode": _workspace_mode(),
         "mode_label": settings.get("mode_label"),
         "rewritten_args": rewritten,
         "resolved_paths": paths,
@@ -452,6 +490,7 @@ def check_tool_permission(tool_name: str, tool_args: dict[str, Any] | None, ying
         action=action,
         details=details,
     )
+
 
 def policy_check_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
     payload = payload if isinstance(payload, dict) else {}

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "917938874f317d3382eff5775b76605beaa2618b3639cdd91b8efa1767cf3e71",
+  "tree_sha256": "ee1342593e3bd9850d2a2618f1573c510f18c75594b10cb778adcffd8cd55ba8",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/readable-python-source/omni_body_skill/SKILL.md
+++ b/readable-python-source/omni_body_skill/SKILL.md
@@ -25,7 +25,7 @@ are complete.
 | file.mkdir | Create a directory |
 | file.copy | Copy; destination in `args.destination` |
 | file.move / file.rename | Move or rename; destination in `args.destination` |
-| file.delete_to_trash | Move file/directory to trash; confirmation may be required |
+| file.delete_to_trash | Move file/directory into governed trash; A4 reversible action, no legacy confirmation |
 
 There is no `file.exists` action. Use `file.list`, `file.read`, or
 `system.action_schema` and treat a successful result as evidence.
@@ -50,7 +50,7 @@ and `git.diff`.
 | action | what it does |
 |--------|-------------|
 | docx.create | Create a Word `.docx` from structured content |
-| pptx.create | Create a PowerPoint `.pptx` from slide specs |
+| pptx.create | Create a PowerPoint `.pptx` deck from slide specs |
 | pptx.read | Inspect slide text, 16:9 dimensions, placeholders, fonts, and meaningful visuals |
 | sheet.create / sheet.read | Create or read Excel workbooks |
 | pdf.extract_text | Extract text from PDF |
@@ -108,6 +108,7 @@ There is no `knowledge.search` action in the current registry.
 3. **Real artifacts.** Deliveries must produce real local files; package large multi-file output with `deliverable.package`.
 4. **Long-chain continuity.** At lease checkpoints, state a concise visible continuation reason and immediately issue the next tool call.
 5. **Repair before finish.** Failed tests/QC require repair and rerun, not narrative completion.
+6. **Authorization stays host-owned.** A1-A4 actions do not use the retired confirmation flow; never invent `confirmed`, `confirmation`, or capability-grant fields. A5 and hard-deny paths remain blocked by the host/gateway.
 
 ## Call shape
 

--- a/tests/test_workspace_full_disk_mode.py
+++ b/tests/test_workspace_full_disk_mode.py
@@ -111,22 +111,22 @@ class RuntimePromptWorkspaceModeTests(unittest.TestCase):
 
 
 class ToolContractFullDiskTests(unittest.TestCase):
-    def _validate(self, target: str, mode: str, action: str = "file.write"):
+    def _validate(self, target: str | Path, mode: str, workspace: str | Path, action: str = "file.write"):
         from omni_body_skill.tool_contracts import validate_tool_request
 
         args = {"action": action}
         if action == "file.write":
             args["content"] = "hello"
-        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+        with mock.patch.dict(
             os.environ,
             {"TIANGONG_WORKSPACE_MODE": mode},
             clear=False,
         ):
             return validate_tool_request(
                 action,
-                target,
+                str(target),
                 args,
-                workspace=tmp,
+                workspace=str(workspace),
             )
 
     def _has_outside_workspace(self, result: dict) -> bool:
@@ -135,40 +135,84 @@ class ToolContractFullDiskTests(unittest.TestCase):
             for issue in (result.get("issues") or [])
         )
 
-    def test_workspace_mode_blocks_desktop(self) -> None:
-        result = self._validate(r"C:\Users\someone\Desktop\a.md", "workspace")
+    def test_workspace_mode_blocks_native_outside_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            target = root / "outside" / "a.md"
+            result = self._validate(target, "workspace", workspace)
         self.assertTrue(self._has_outside_workspace(result))
 
-    def test_full_mode_allows_desktop(self) -> None:
-        result = self._validate(r"C:\Users\someone\Desktop\a.md", "full")
+    def test_full_mode_allows_native_outside_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            target = root / "outside" / "a.md"
+            result = self._validate(target, "full", workspace)
         self.assertFalse(self._has_outside_workspace(result))
         self.assertTrue(bool(result.get("ok")))
 
-    def test_workspace_mode_blocks_outside_delete(self) -> None:
-        result = self._validate(r"D:\outside\delete-me.txt", "workspace", "file.delete_to_trash")
+    def test_workspace_mode_blocks_native_outside_delete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            target = root / "outside" / "delete-me.txt"
+            result = self._validate(target, "workspace", workspace, "file.delete_to_trash")
         self.assertTrue(self._has_outside_workspace(result))
 
-    def test_full_mode_allows_outside_delete_to_trash(self) -> None:
-        result = self._validate(r"D:\outside\delete-me.txt", "full", "file.delete_to_trash")
+    def test_full_mode_allows_native_outside_delete_to_trash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            target = root / "outside" / "delete-me.txt"
+            result = self._validate(target, "full", workspace, "file.delete_to_trash")
         self.assertFalse(self._has_outside_workspace(result))
         self.assertTrue(bool(result.get("ok")))
 
+    def test_full_mode_still_blocks_credential_dir_cross_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            target = root / ".ssh" / "id_rsa"
+            result = self._validate(target, "full", workspace)
+        self.assertTrue(self._has_outside_workspace(result))
+
+    def test_full_mode_still_blocks_env_file_cross_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            target = root / "outside" / "service.env"
+            result = self._validate(target, "full", workspace)
+        self.assertTrue(self._has_outside_workspace(result))
+
+    @unittest.skipUnless(os.name == "nt", "Windows core-path contract is Windows-specific")
     def test_full_mode_still_blocks_windows_core(self) -> None:
-        result = self._validate(r"C:\Windows\System32\drivers\etc\hosts", "full")
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._validate(
+                r"C:\Windows\System32\drivers\etc\hosts",
+                "full",
+                Path(tmp) / "workspace",
+            )
         self.assertTrue(self._has_outside_workspace(result))
 
-    def test_full_mode_still_blocks_credential_dir(self) -> None:
-        result = self._validate(r"C:\Users\someone\.ssh\id_rsa", "full")
-        self.assertTrue(self._has_outside_workspace(result))
-
+    @unittest.skipUnless(os.name == "nt", "Windows core-path contract is Windows-specific")
     def test_full_mode_still_blocks_delete_in_windows_core(self) -> None:
-        result = self._validate(
-            r"C:\Windows\System32\drivers\etc\hosts",
-            "full",
-            "file.delete_to_trash",
-        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._validate(
+                r"C:\Windows\System32\drivers\etc\hosts",
+                "full",
+                Path(tmp) / "workspace",
+                "file.delete_to_trash",
+            )
         self.assertTrue(self._has_outside_workspace(result))
 
+    @unittest.skipUnless(os.name == "nt", "Windows shell hard-deny contract is Windows-specific")
     def test_full_mode_blocks_hard_deny_in_shell_command(self) -> None:
         from omni_body_skill.tool_contracts import validate_tool_request
 

--- a/tests/test_workspace_full_disk_mode.py
+++ b/tests/test_workspace_full_disk_mode.py
@@ -61,19 +61,71 @@ class WorkspaceSettingsModeTests(unittest.TestCase):
             self.assertEqual(duqu_workspace_settings()["workspace_mode"], "workspace")
 
 
+class RuntimePromptWorkspaceModeTests(unittest.TestCase):
+    def _status(self, mode: str) -> dict:
+        return {
+            "ok": True,
+            "workspace": r"C:\TiangongWorkspace",
+            "workspace_mode": mode,
+            "permission_mode": "full_access",
+            "mode_label": "完全访问权限",
+            "home": r"C:\Users\someone",
+            "desktop": r"C:\Users\someone\Desktop",
+            "downloads": r"C:\Users\someone\Downloads",
+            "documents": r"C:\Users\someone\Documents",
+            "drive_roots": ["C:\\", "D:\\"],
+            "runtime": {"user": {"username": "someone"}},
+        }
+
+    def test_full_mode_prompt_does_not_reinstate_workspace_gate(self) -> None:
+        from v3 import permission_settings
+
+        with mock.patch.object(permission_settings, "permission_status", return_value=self._status("full")):
+            prompt = permission_settings.build_runtime_context_prompt("删除 D 盘文件", force=True)
+        self.assertIn("写入范围: 全盘 (full)", prompt)
+        self.assertIn("不是访问权限边界", prompt)
+        self.assertIn("file.delete_to_trash", prompt)
+        self.assertIn("A1-A4", prompt)
+        self.assertNotIn("默认只在工作区内读写", prompt)
+        self.assertNotIn("必须先向用户确认", prompt)
+
+    def test_workspace_mode_prompt_uses_object_grant_not_retired_confirmation(self) -> None:
+        from v3 import permission_settings
+
+        with mock.patch.object(permission_settings, "permission_status", return_value=self._status("workspace")):
+            prompt = permission_settings.build_runtime_context_prompt("操作文件", force=True)
+        self.assertIn("写入范围: 工作区 (workspace)", prompt)
+        self.assertIn("object grant", prompt)
+        self.assertNotIn("必须先向用户确认", prompt)
+
+    def test_permission_status_reports_runtime_workspace_mode(self) -> None:
+        from v3 import permission_settings
+
+        with mock.patch.dict(os.environ, {"TIANGONG_WORKSPACE_MODE": "full"}, clear=False), mock.patch.object(
+            permission_settings,
+            "runtime_environment_summary",
+            return_value={"workspace": r"C:\ws", "drive_roots": []},
+        ):
+            status = permission_settings.permission_status()
+        self.assertEqual(status["workspace_mode"], "full")
+
+
 class ToolContractFullDiskTests(unittest.TestCase):
-    def _validate(self, target: str, mode: str):
+    def _validate(self, target: str, mode: str, action: str = "file.write"):
         from omni_body_skill.tool_contracts import validate_tool_request
 
+        args = {"action": action}
+        if action == "file.write":
+            args["content"] = "hello"
         with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
             os.environ,
             {"TIANGONG_WORKSPACE_MODE": mode},
             clear=False,
         ):
             return validate_tool_request(
-                "file.write",
+                action,
                 target,
-                {"content": "hello", "action": "file.write"},
+                args,
                 workspace=tmp,
             )
 
@@ -92,12 +144,29 @@ class ToolContractFullDiskTests(unittest.TestCase):
         self.assertFalse(self._has_outside_workspace(result))
         self.assertTrue(bool(result.get("ok")))
 
+    def test_workspace_mode_blocks_outside_delete(self) -> None:
+        result = self._validate(r"D:\outside\delete-me.txt", "workspace", "file.delete_to_trash")
+        self.assertTrue(self._has_outside_workspace(result))
+
+    def test_full_mode_allows_outside_delete_to_trash(self) -> None:
+        result = self._validate(r"D:\outside\delete-me.txt", "full", "file.delete_to_trash")
+        self.assertFalse(self._has_outside_workspace(result))
+        self.assertTrue(bool(result.get("ok")))
+
     def test_full_mode_still_blocks_windows_core(self) -> None:
         result = self._validate(r"C:\Windows\System32\drivers\etc\hosts", "full")
         self.assertTrue(self._has_outside_workspace(result))
 
     def test_full_mode_still_blocks_credential_dir(self) -> None:
         result = self._validate(r"C:\Users\someone\.ssh\id_rsa", "full")
+        self.assertTrue(self._has_outside_workspace(result))
+
+    def test_full_mode_still_blocks_delete_in_windows_core(self) -> None:
+        result = self._validate(
+            r"C:\Windows\System32\drivers\etc\hosts",
+            "full",
+            "file.delete_to_trash",
+        )
         self.assertTrue(self._has_outside_workspace(result))
 
     def test_full_mode_blocks_hard_deny_in_shell_command(self) -> None:


### PR DESCRIPTION
## 问题
设置“写入范围=全盘”后，运行时仍向模型注入旧的“默认只在工作区内读写 / 区外写入需确认”语义；同时 Omni Body 技能文档仍把 `file.delete_to_trash` 描述为可能需要旧确认。上层 A1-A4 权限门实际上已退役 confirmation，导致路径范围、动作权限与模型指导不一致。

## 修复
- 让运行时提示直接读取桌面权威 `TIANGONG_WORKSPACE_MODE`。
- 明确分离 `permission_mode`（A0-A4 自主执行）与 `workspace_mode`（路径范围）。
- `full` 下工作区仅作为相对路径基准，不再作为访问权限边界；A5/硬禁区继续硬拦截。
- `file.delete_to_trash` 明确为 A4 可逆删除，不再走已退役 confirmation。
- workspace 模式的区外路径改为明确依赖 gateway object grant，不生成无法兑付的旧确认卡。
- 增加全盘区外写入/删除、旧提示回归、Windows/凭据硬禁区等测试。
- 更新 Omni Body 权威技能说明并按 generated-source 规则同步镜像。

## 安全边界
未放宽 A5、Windows 核心目录、磁盘根、凭据目录或 `.env` 等硬禁区。