### PR TITLE
P18 M4.6 seal: stabilize Windows real-process lock certification

### DIFF
--- a/tests/test_p18_m4_real_process.py
+++ b/tests/test_p18_m4_real_process.py
@@ -215,7 +215,10 @@ def test_m4_real_process_case_d_high_fault_500_steps_with_network_timeouts_lock_
         "--mode", "hold-lock",
         "--artifact", str(lock_file),
         "--ready", str(lock_ready),
-        "--hold-seconds", "4",
+        # Keep the real OS lock alive beyond this test's own 20s ready + 45s
+        # first-process barrier bounds. The parent terminates the holder in the
+        # finally block, so this increases determinism without adding wall time.
+        "--hold-seconds", "90",
     ])
     try:
         _wait_for(lock_ready, timeout=20)


### PR DESCRIPTION
Follow-up to PR #11 after the post-merge `main` Architecture Gate exposed one Windows-only timing race in the M4.4 certification harness.

Failure evidence on main SHA `f2b1fe233e4a171e267aa7a3950a9750bd50c221`:
- 3069 passed, 30 skipped, 804 subtests passed
- sole failure: `test_m4_real_process_case_d_high_fault_500_steps_with_network_timeouts_lock_and_torn_tail`
- expected `file_lock_blocks == 1`, observed `0`

Root cause: the test-only lock-holder lifetime was 4 seconds, shorter than the bounded Windows CI process-start/database path to the step-150 lock probe. The production lock implementation and execution authority were not changed.

Fix: extend the test-only holder lifetime to 90 seconds, which exceeds the test's own 20s ready + 45s first-process barrier bounds. The parent process still terminates the holder immediately in `finally`, so the change adds no intended wall-clock delay.

No Runtime/Scheduler/Store/Gateway/Authority semantics are changed. Required Ubuntu/Windows source-authority and full-repository gates must pass before merge.