### PR TITLE
fix: repo-wide QC round 1+2 — 31 verified fixes (framework, logic, math)

### DIFF
--- a/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "9ebff3aa2d592b67ac0603c60ee3e3ad6cda516e8dbb953df5c85707f99fda52",
+  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/delivery_kernel.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/delivery_kernel.py
@@ -830,7 +830,14 @@ def _qc_code(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str
             issues.append(_issue("miniapp_test_command_required","小程序工程必须提供可执行的离线测试命令。","critical","提供 node 测试脚本或项目自带测试命令。"))
             command=[]
         elif not command:
-            command=[sys.executable,"-m","pytest","-q"]
+            # Delayed import: omni_body_tool imports this module at load time.
+            # In frozen builds sys.executable is the backend exe, never reuse it.
+            try:
+                from .omni_body_tool import _resolve_python_interpreter
+                command=[_resolve_python_interpreter(),"-m","pytest","-q"]
+            except Exception as exc:
+                issues.append(_issue("tests_not_executable",f"测试无法执行：{exc}","critical","修复测试环境和命令。"))
+                command=[]
         if isinstance(command,str): command=command.split()
         if command:
             try:
@@ -1081,10 +1088,16 @@ def _deliverable_package(runtime: Any, target: str | None, args: Dict[str, Any])
             child_resolved = child.resolve(strict=True)
             if child_resolved == output_resolved:
                 raise ValueError("deliverable.package input and output must be different paths")
+            # Items may live in user-authorized roots outside the workspace;
+            # those are archived relative to their own source directory.
             archive_name = (
                 child.name
                 if source.is_file()
-                else child.relative_to(runtime.workspace).as_posix()
+                else (
+                    child.relative_to(runtime.workspace).as_posix()
+                    if child.is_relative_to(runtime.workspace)
+                    else f"{source.name}/{child.relative_to(source).as_posix()}"
+                )
             )
             folded = archive_name.casefold()
             if folded in seen_archives or folded == "delivery_manifest.json":

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/omni_body_v3.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/omni_body_v3.py
@@ -297,7 +297,10 @@ def run_omni_body(args: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(result, dict):
         result = {"result": result, "success": True}
 
-    ok = bool(result.get("success", result.get("ok", False)))
+    if result.get("ok") is False:
+        ok = False
+    else:
+        ok = bool(result.get("success", result.get("ok", False)))
     evidence = _extract_evidence(result, target, workspace)
     response: dict[str, Any] = {
         "schema": TOOL_SCHEMA,

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/pro_apps_v34.py
@@ -718,7 +718,16 @@ def _office_native_action(runtime: Any, action: str, target: str | None, args: D
         tmp = _resolve(runtime, f".omni_temp/office_{int(time.time())}.py")
         tmp.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(script, encoding="utf-8")
-        res = subprocess.run([sys.executable, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
+        # Delayed import: omni_body_tool imports this module chain at load time.
+        # In frozen builds sys.executable is the backend exe, never reuse it.
+        try:
+            from .omni_body_tool import _resolve_python_interpreter
+            interpreter = _resolve_python_interpreter()
+        except Exception:
+            interpreter = None
+        if interpreter is None:
+            return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})
+        res = subprocess.run([interpreter, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
         return {"success": res.returncode == 0, "result": {"stdout": res.stdout, "stderr": res.stderr, "returncode": res.returncode}, "evidence": {"path": args.get("output") or "", "exists": bool(args.get("output") and _resolve(runtime, args.get("output")).exists())}}
     # Professional behavior: return executable bridge, not fake PDF/export.
     return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/sandbox_runtime.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/sandbox_runtime.py
@@ -472,24 +472,31 @@ class SandboxRunner:
                     ) from exc
         if run_root.exists():
             shutil.rmtree(run_root, ignore_errors=True)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
-        before = _snapshot(sandbox_workspace)
-        real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
-        sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
-        sandbox_cwd.mkdir(parents=True, exist_ok=True)
-        rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
-        if os.name == "nt":
-            rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
-        limits = SandboxLimits(
-            timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
-            max_workspace_bytes=self.limits.max_workspace_bytes,
-            max_changed_bytes=self.limits.max_changed_bytes,
-            max_output_bytes=self.limits.max_output_bytes,
-            max_memory_bytes=self.limits.max_memory_bytes,
-            max_processes=self.limits.max_processes,
-        )
-        env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        # Preparation failures (workspace copy, snapshot, shell rewrite) must
+        # not leak run_root: the main try/finally below only covers execution.
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
+            before = _snapshot(sandbox_workspace)
+            real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
+            sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
+            sandbox_cwd.mkdir(parents=True, exist_ok=True)
+            rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
+            if os.name == "nt":
+                rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
+            limits = SandboxLimits(
+                timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
+                max_workspace_bytes=self.limits.max_workspace_bytes,
+                max_changed_bytes=self.limits.max_changed_bytes,
+                max_output_bytes=self.limits.max_output_bytes,
+                max_memory_bytes=self.limits.max_memory_bytes,
+                max_processes=self.limits.max_processes,
+            )
+            env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        except BaseException:
+            if os.environ.get("TIANGONG_KEEP_SANDBOX", "0").strip().lower() not in {"1", "true", "yes", "on"}:
+                shutil.rmtree(run_root, ignore_errors=True)
+            raise
         started = time.monotonic()
         try:
             if os.name == "nt":

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/novel-creation/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/novel-creation/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "managed-novel-skill-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/bundled_skills/novel-creation",
-  "tree_sha256": "5f0ca06c4524cff7f677628fb7250c73c15ab430a840ad879fa66610641d5ff4",
+  "tree_sha256": "b1fd16a941851af4d2202d169156677a3a1e4cea7f3ef867e2b2549e937d70fb",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/novel-creation/scripts/novel_tool.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/novel-creation/scripts/novel_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import sys
 from datetime import datetime
@@ -58,14 +59,20 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8-sig")
 
 
-def write_text(path: Path, text: str) -> None:
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via temp file + rename so a crash cannot leave a half-written file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_text(path: Path, text: str) -> None:
+    _atomic_write(path, text)
 
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    _atomic_write(path, json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -74,7 +81,10 @@ def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, An
     try:
         data = json.loads(read_text(path))
         return data if isinstance(data, dict) else dict(default or {})
-    except Exception:
+    except Exception as exc:
+        # A corrupt file silently resetting the contract to defaults is worse
+        # than a loud warning; keep the default-return behavior but report it.
+        print(f"[novel_tool] read_json failed ({path}): {exc}", file=sys.stderr)
         return dict(default or {})
 
 

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "9ebff3aa2d592b67ac0603c60ee3e3ad6cda516e8dbb953df5c85707f99fda52",
+  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/delivery_kernel.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/delivery_kernel.py
@@ -830,7 +830,14 @@ def _qc_code(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str
             issues.append(_issue("miniapp_test_command_required","小程序工程必须提供可执行的离线测试命令。","critical","提供 node 测试脚本或项目自带测试命令。"))
             command=[]
         elif not command:
-            command=[sys.executable,"-m","pytest","-q"]
+            # Delayed import: omni_body_tool imports this module at load time.
+            # In frozen builds sys.executable is the backend exe, never reuse it.
+            try:
+                from .omni_body_tool import _resolve_python_interpreter
+                command=[_resolve_python_interpreter(),"-m","pytest","-q"]
+            except Exception as exc:
+                issues.append(_issue("tests_not_executable",f"测试无法执行：{exc}","critical","修复测试环境和命令。"))
+                command=[]
         if isinstance(command,str): command=command.split()
         if command:
             try:
@@ -1081,10 +1088,16 @@ def _deliverable_package(runtime: Any, target: str | None, args: Dict[str, Any])
             child_resolved = child.resolve(strict=True)
             if child_resolved == output_resolved:
                 raise ValueError("deliverable.package input and output must be different paths")
+            # Items may live in user-authorized roots outside the workspace;
+            # those are archived relative to their own source directory.
             archive_name = (
                 child.name
                 if source.is_file()
-                else child.relative_to(runtime.workspace).as_posix()
+                else (
+                    child.relative_to(runtime.workspace).as_posix()
+                    if child.is_relative_to(runtime.workspace)
+                    else f"{source.name}/{child.relative_to(source).as_posix()}"
+                )
             )
             folded = archive_name.casefold()
             if folded in seen_archives or folded == "delivery_manifest.json":

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/omni_body_v3.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/omni_body_v3.py
@@ -297,7 +297,10 @@ def run_omni_body(args: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(result, dict):
         result = {"result": result, "success": True}
 
-    ok = bool(result.get("success", result.get("ok", False)))
+    if result.get("ok") is False:
+        ok = False
+    else:
+        ok = bool(result.get("success", result.get("ok", False)))
     evidence = _extract_evidence(result, target, workspace)
     response: dict[str, Any] = {
         "schema": TOOL_SCHEMA,

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
@@ -718,7 +718,16 @@ def _office_native_action(runtime: Any, action: str, target: str | None, args: D
         tmp = _resolve(runtime, f".omni_temp/office_{int(time.time())}.py")
         tmp.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(script, encoding="utf-8")
-        res = subprocess.run([sys.executable, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
+        # Delayed import: omni_body_tool imports this module chain at load time.
+        # In frozen builds sys.executable is the backend exe, never reuse it.
+        try:
+            from .omni_body_tool import _resolve_python_interpreter
+            interpreter = _resolve_python_interpreter()
+        except Exception:
+            interpreter = None
+        if interpreter is None:
+            return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})
+        res = subprocess.run([interpreter, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
         return {"success": res.returncode == 0, "result": {"stdout": res.stdout, "stderr": res.stderr, "returncode": res.returncode}, "evidence": {"path": args.get("output") or "", "exists": bool(args.get("output") and _resolve(runtime, args.get("output")).exists())}}
     # Professional behavior: return executable bridge, not fake PDF/export.
     return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/sandbox_runtime.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/sandbox_runtime.py
@@ -472,24 +472,31 @@ class SandboxRunner:
                     ) from exc
         if run_root.exists():
             shutil.rmtree(run_root, ignore_errors=True)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
-        before = _snapshot(sandbox_workspace)
-        real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
-        sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
-        sandbox_cwd.mkdir(parents=True, exist_ok=True)
-        rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
-        if os.name == "nt":
-            rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
-        limits = SandboxLimits(
-            timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
-            max_workspace_bytes=self.limits.max_workspace_bytes,
-            max_changed_bytes=self.limits.max_changed_bytes,
-            max_output_bytes=self.limits.max_output_bytes,
-            max_memory_bytes=self.limits.max_memory_bytes,
-            max_processes=self.limits.max_processes,
-        )
-        env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        # Preparation failures (workspace copy, snapshot, shell rewrite) must
+        # not leak run_root: the main try/finally below only covers execution.
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
+            before = _snapshot(sandbox_workspace)
+            real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
+            sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
+            sandbox_cwd.mkdir(parents=True, exist_ok=True)
+            rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
+            if os.name == "nt":
+                rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
+            limits = SandboxLimits(
+                timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
+                max_workspace_bytes=self.limits.max_workspace_bytes,
+                max_changed_bytes=self.limits.max_changed_bytes,
+                max_output_bytes=self.limits.max_output_bytes,
+                max_memory_bytes=self.limits.max_memory_bytes,
+                max_processes=self.limits.max_processes,
+            )
+            env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        except BaseException:
+            if os.environ.get("TIANGONG_KEEP_SANDBOX", "0").strip().lower() not in {"1", "true", "yes", "on"}:
+                shutil.rmtree(run_root, ignore_errors=True)
+            raise
         started = time.monotonic()
         try:
             if os.name == "nt":

--- a/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "9ebff3aa2d592b67ac0603c60ee3e3ad6cda516e8dbb953df5c85707f99fda52",
+  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/omni_body_skill/tools/delivery_kernel.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/delivery_kernel.py
@@ -830,7 +830,14 @@ def _qc_code(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str
             issues.append(_issue("miniapp_test_command_required","小程序工程必须提供可执行的离线测试命令。","critical","提供 node 测试脚本或项目自带测试命令。"))
             command=[]
         elif not command:
-            command=[sys.executable,"-m","pytest","-q"]
+            # Delayed import: omni_body_tool imports this module at load time.
+            # In frozen builds sys.executable is the backend exe, never reuse it.
+            try:
+                from .omni_body_tool import _resolve_python_interpreter
+                command=[_resolve_python_interpreter(),"-m","pytest","-q"]
+            except Exception as exc:
+                issues.append(_issue("tests_not_executable",f"测试无法执行：{exc}","critical","修复测试环境和命令。"))
+                command=[]
         if isinstance(command,str): command=command.split()
         if command:
             try:
@@ -1081,10 +1088,16 @@ def _deliverable_package(runtime: Any, target: str | None, args: Dict[str, Any])
             child_resolved = child.resolve(strict=True)
             if child_resolved == output_resolved:
                 raise ValueError("deliverable.package input and output must be different paths")
+            # Items may live in user-authorized roots outside the workspace;
+            # those are archived relative to their own source directory.
             archive_name = (
                 child.name
                 if source.is_file()
-                else child.relative_to(runtime.workspace).as_posix()
+                else (
+                    child.relative_to(runtime.workspace).as_posix()
+                    if child.is_relative_to(runtime.workspace)
+                    else f"{source.name}/{child.relative_to(source).as_posix()}"
+                )
             )
             folded = archive_name.casefold()
             if folded in seen_archives or folded == "delivery_manifest.json":

--- a/app/backend/tiangong-backend/omni_body_skill/tools/omni_body_v3.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/omni_body_v3.py
@@ -297,7 +297,10 @@ def run_omni_body(args: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(result, dict):
         result = {"result": result, "success": True}
 
-    ok = bool(result.get("success", result.get("ok", False)))
+    if result.get("ok") is False:
+        ok = False
+    else:
+        ok = bool(result.get("success", result.get("ok", False)))
     evidence = _extract_evidence(result, target, workspace)
     response: dict[str, Any] = {
         "schema": TOOL_SCHEMA,

--- a/app/backend/tiangong-backend/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/pro_apps_v34.py
@@ -718,7 +718,16 @@ def _office_native_action(runtime: Any, action: str, target: str | None, args: D
         tmp = _resolve(runtime, f".omni_temp/office_{int(time.time())}.py")
         tmp.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(script, encoding="utf-8")
-        res = subprocess.run([sys.executable, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
+        # Delayed import: omni_body_tool imports this module chain at load time.
+        # In frozen builds sys.executable is the backend exe, never reuse it.
+        try:
+            from .omni_body_tool import _resolve_python_interpreter
+            interpreter = _resolve_python_interpreter()
+        except Exception:
+            interpreter = None
+        if interpreter is None:
+            return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})
+        res = subprocess.run([interpreter, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
         return {"success": res.returncode == 0, "result": {"stdout": res.stdout, "stderr": res.stderr, "returncode": res.returncode}, "evidence": {"path": args.get("output") or "", "exists": bool(args.get("output") and _resolve(runtime, args.get("output")).exists())}}
     # Professional behavior: return executable bridge, not fake PDF/export.
     return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})

--- a/app/backend/tiangong-backend/omni_body_skill/tools/sandbox_runtime.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/sandbox_runtime.py
@@ -472,24 +472,31 @@ class SandboxRunner:
                     ) from exc
         if run_root.exists():
             shutil.rmtree(run_root, ignore_errors=True)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
-        before = _snapshot(sandbox_workspace)
-        real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
-        sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
-        sandbox_cwd.mkdir(parents=True, exist_ok=True)
-        rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
-        if os.name == "nt":
-            rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
-        limits = SandboxLimits(
-            timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
-            max_workspace_bytes=self.limits.max_workspace_bytes,
-            max_changed_bytes=self.limits.max_changed_bytes,
-            max_output_bytes=self.limits.max_output_bytes,
-            max_memory_bytes=self.limits.max_memory_bytes,
-            max_processes=self.limits.max_processes,
-        )
-        env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        # Preparation failures (workspace copy, snapshot, shell rewrite) must
+        # not leak run_root: the main try/finally below only covers execution.
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
+            before = _snapshot(sandbox_workspace)
+            real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
+            sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
+            sandbox_cwd.mkdir(parents=True, exist_ok=True)
+            rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
+            if os.name == "nt":
+                rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
+            limits = SandboxLimits(
+                timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
+                max_workspace_bytes=self.limits.max_workspace_bytes,
+                max_changed_bytes=self.limits.max_changed_bytes,
+                max_output_bytes=self.limits.max_output_bytes,
+                max_memory_bytes=self.limits.max_memory_bytes,
+                max_processes=self.limits.max_processes,
+            )
+            env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        except BaseException:
+            if os.environ.get("TIANGONG_KEEP_SANDBOX", "0").strip().lower() not in {"1", "true", "yes", "on"}:
+                shutil.rmtree(run_root, ignore_errors=True)
+            raise
         started = time.monotonic()
         try:
             if os.name == "nt":

--- a/app/backend/tiangong-backend/v3/bundled_skills/novel-creation/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/v3/bundled_skills/novel-creation/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "managed-novel-skill-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/bundled_skills/novel-creation",
-  "tree_sha256": "5f0ca06c4524cff7f677628fb7250c73c15ab430a840ad879fa66610641d5ff4",
+  "tree_sha256": "b1fd16a941851af4d2202d169156677a3a1e4cea7f3ef867e2b2549e937d70fb",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/v3/bundled_skills/novel-creation/scripts/novel_tool.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/novel-creation/scripts/novel_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import sys
 from datetime import datetime
@@ -58,14 +59,20 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8-sig")
 
 
-def write_text(path: Path, text: str) -> None:
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via temp file + rename so a crash cannot leave a half-written file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_text(path: Path, text: str) -> None:
+    _atomic_write(path, text)
 
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    _atomic_write(path, json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -74,7 +81,10 @@ def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, An
     try:
         data = json.loads(read_text(path))
         return data if isinstance(data, dict) else dict(default or {})
-    except Exception:
+    except Exception as exc:
+        # A corrupt file silently resetting the contract to defaults is worse
+        # than a loud warning; keep the default-return behavior but report it.
+        print(f"[novel_tool] read_json failed ({path}): {exc}", file=sys.stderr)
         return dict(default or {})
 
 

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "9ebff3aa2d592b67ac0603c60ee3e3ad6cda516e8dbb953df5c85707f99fda52",
+  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/delivery_kernel.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/delivery_kernel.py
@@ -830,7 +830,14 @@ def _qc_code(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str
             issues.append(_issue("miniapp_test_command_required","小程序工程必须提供可执行的离线测试命令。","critical","提供 node 测试脚本或项目自带测试命令。"))
             command=[]
         elif not command:
-            command=[sys.executable,"-m","pytest","-q"]
+            # Delayed import: omni_body_tool imports this module at load time.
+            # In frozen builds sys.executable is the backend exe, never reuse it.
+            try:
+                from .omni_body_tool import _resolve_python_interpreter
+                command=[_resolve_python_interpreter(),"-m","pytest","-q"]
+            except Exception as exc:
+                issues.append(_issue("tests_not_executable",f"测试无法执行：{exc}","critical","修复测试环境和命令。"))
+                command=[]
         if isinstance(command,str): command=command.split()
         if command:
             try:
@@ -1081,10 +1088,16 @@ def _deliverable_package(runtime: Any, target: str | None, args: Dict[str, Any])
             child_resolved = child.resolve(strict=True)
             if child_resolved == output_resolved:
                 raise ValueError("deliverable.package input and output must be different paths")
+            # Items may live in user-authorized roots outside the workspace;
+            # those are archived relative to their own source directory.
             archive_name = (
                 child.name
                 if source.is_file()
-                else child.relative_to(runtime.workspace).as_posix()
+                else (
+                    child.relative_to(runtime.workspace).as_posix()
+                    if child.is_relative_to(runtime.workspace)
+                    else f"{source.name}/{child.relative_to(source).as_posix()}"
+                )
             )
             folded = archive_name.casefold()
             if folded in seen_archives or folded == "delivery_manifest.json":

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/omni_body_v3.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/omni_body_v3.py
@@ -297,7 +297,10 @@ def run_omni_body(args: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(result, dict):
         result = {"result": result, "success": True}
 
-    ok = bool(result.get("success", result.get("ok", False)))
+    if result.get("ok") is False:
+        ok = False
+    else:
+        ok = bool(result.get("success", result.get("ok", False)))
     evidence = _extract_evidence(result, target, workspace)
     response: dict[str, Any] = {
         "schema": TOOL_SCHEMA,

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
@@ -718,7 +718,16 @@ def _office_native_action(runtime: Any, action: str, target: str | None, args: D
         tmp = _resolve(runtime, f".omni_temp/office_{int(time.time())}.py")
         tmp.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(script, encoding="utf-8")
-        res = subprocess.run([sys.executable, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
+        # Delayed import: omni_body_tool imports this module chain at load time.
+        # In frozen builds sys.executable is the backend exe, never reuse it.
+        try:
+            from .omni_body_tool import _resolve_python_interpreter
+            interpreter = _resolve_python_interpreter()
+        except Exception:
+            interpreter = None
+        if interpreter is None:
+            return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})
+        res = subprocess.run([interpreter, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
         return {"success": res.returncode == 0, "result": {"stdout": res.stdout, "stderr": res.stderr, "returncode": res.returncode}, "evidence": {"path": args.get("output") or "", "exists": bool(args.get("output") and _resolve(runtime, args.get("output")).exists())}}
     # Professional behavior: return executable bridge, not fake PDF/export.
     return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/sandbox_runtime.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/sandbox_runtime.py
@@ -472,24 +472,31 @@ class SandboxRunner:
                     ) from exc
         if run_root.exists():
             shutil.rmtree(run_root, ignore_errors=True)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
-        before = _snapshot(sandbox_workspace)
-        real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
-        sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
-        sandbox_cwd.mkdir(parents=True, exist_ok=True)
-        rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
-        if os.name == "nt":
-            rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
-        limits = SandboxLimits(
-            timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
-            max_workspace_bytes=self.limits.max_workspace_bytes,
-            max_changed_bytes=self.limits.max_changed_bytes,
-            max_output_bytes=self.limits.max_output_bytes,
-            max_memory_bytes=self.limits.max_memory_bytes,
-            max_processes=self.limits.max_processes,
-        )
-        env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        # Preparation failures (workspace copy, snapshot, shell rewrite) must
+        # not leak run_root: the main try/finally below only covers execution.
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
+            before = _snapshot(sandbox_workspace)
+            real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
+            sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
+            sandbox_cwd.mkdir(parents=True, exist_ok=True)
+            rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
+            if os.name == "nt":
+                rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
+            limits = SandboxLimits(
+                timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
+                max_workspace_bytes=self.limits.max_workspace_bytes,
+                max_changed_bytes=self.limits.max_changed_bytes,
+                max_output_bytes=self.limits.max_output_bytes,
+                max_memory_bytes=self.limits.max_memory_bytes,
+                max_processes=self.limits.max_processes,
+            )
+            env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        except BaseException:
+            if os.environ.get("TIANGONG_KEEP_SANDBOX", "0").strip().lower() not in {"1", "true", "yes", "on"}:
+                shutil.rmtree(run_root, ignore_errors=True)
+            raise
         started = time.monotonic()
         try:
             if os.name == "nt":

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "e222de7fae13934b63fd1ba51112c129ebe87b0ac792e4e7c8bb79487c17595d",
+  "tree_sha256": "7270c448a8e8141e42eb995b3782b2bd3ab252babd6f6aa70bf3d995d7cac99b",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/affect.py
+++ b/app/life-service/runtime314/life_service/affect.py
@@ -92,9 +92,9 @@ def evaluate_affect_gate(
 ) -> AffectGateDecision:
     if repetition_count < 1:
         raise ValueError("affect repetition count is invalid")
-    # Exponential habituation reaches zero after bounded repeats, so identical
-    # content cannot self-excite forever even if an upstream feed loops.
-    repetition_factor = 1000 // (1 << min(repetition_count - 1, 20))
+    # Exponential habituation reaches zero after 11 repeats (2^10 = 1024 > 1000),
+    # so identical content cannot self-excite forever even if an upstream feed loops.
+    repetition_factor = 1000 // (1 << min(repetition_count - 1, 10))
     reason = "affect.accepted"
     if signal.prompt_injection_detected:
         reason = "affect.rejected.prompt_injection"

--- a/app/life-service/runtime314/life_service/cognition.py
+++ b/app/life-service/runtime314/life_service/cognition.py
@@ -176,6 +176,26 @@ class UnifiedCognitionShadow:
                 "event_id": item["event_id"],
                 "decision": dict(decision),
             }
+        except Exception:
+            # A crashing decider pass must not strand the stimulus in
+            # `selected` forever. Record a `failed` shadow and consume the
+            # stimulus so the queue keeps flowing; releasing it back to
+            # pending would re-select the same failing item head-of-line.
+            self._record_shadow(
+                life_id,
+                item,
+                root_experience_id=root_experience_id,
+                status="failed",
+                slot_no=1,
+                now_ms=now_ms,
+            )
+            self._store.commit_stimulus(
+                life_id,
+                enqueue_seq=int(item["enqueue_seq"]),
+                claim_token=claim,
+                now_ms=now_ms,
+            )
+            raise
         finally:
             self._store.release_lane(life_id, str(item["lane"]), lease_id=lease)
 

--- a/app/life-service/runtime314/life_service/complete_core.py
+++ b/app/life-service/runtime314/life_service/complete_core.py
@@ -923,6 +923,24 @@ class SemanticJournal:
         with self._lock:
             return self._read_events_strict(life_id)
 
+    def event_by_idempotency_key(
+        self, life_id: str, idempotency_key: str
+    ) -> dict[str, Any] | None:
+        """Return the already-recorded event for a key, or None.
+
+        Callers use this to converge retries: when the journal committed but a
+        later projection step failed, re-appending with the same key would hit
+        ``journal_idempotency_conflict`` because fresh timestamps change the
+        payload. Looking the event up first lets the caller replay the side
+        effects instead of the journal append.
+        """
+        if not idempotency_key:
+            return None
+        for event in reversed(self.events(life_id)):
+            if str(event.get("idempotency_key") or "") == idempotency_key:
+                return event
+        return None
+
     def _verify_chain_only(self, life_id: str, events: list[dict[str, Any]]) -> dict[str, Any]:
         previous = self.GENESIS_SHA256
         for index, event in enumerate(events, 1):

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -2120,7 +2120,10 @@ class EmbeddedLifeRuntime:
             return {"created": 0, "deduped": 0, "coalesced": 0}
         triggers = self._cognition_trigger_candidates(life_id)
         stats = shadow.enqueue_many(life_id, triggers)
-        if self._cognition_decider is not None and stats["created"]:
+        # Start the worker when anything is pending, not only on fresh enqueues:
+        # a backlog with fully deduped triggers would otherwise never drain.
+        pending = int(self._contract_store().cognition_health(life_id).get("pending") or 0)
+        if self._cognition_decider is not None and (stats["created"] or pending > 0):
             worker = threading.Thread(
                 target=self._cognition_worker,
                 args=(life_id,),
@@ -2132,7 +2135,7 @@ class EmbeddedLifeRuntime:
 
     def _cognition_worker(self, life_id: str) -> None:
         try:
-            self.run_cognition_shadow_pass(life_id)
+            self.run_cognition_shadow_drain(life_id)
         except Exception:
             # Shadow diagnostics never crash the heartbeat.
             return
@@ -2151,6 +2154,21 @@ class EmbeddedLifeRuntime:
         )
         owner = self._lease.instance_id if self._lease is not None else "life"
         return shadow.run_pass(life_id, owner_instance_id=owner)
+
+    def run_cognition_shadow_drain(self, life_id: str) -> dict[str, Any]:
+        """Drain the whole pending cognition shadow backlog (worker entry)."""
+        store = self._contract_store()
+        shadow = UnifiedCognitionShadow(
+            store,
+            cognition_decider=self._cognition_decider,
+            binding_factory=(
+                lambda current_life_id, event_id, now_ms: self._cognition_binding_factory(
+                    store, current_life_id, event_id, now_ms
+                )
+            ),
+        )
+        owner = self._lease.instance_id if self._lease is not None else "life"
+        return shadow.run_drain(life_id, owner_instance_id=owner)
 
     def _cognition_binding_factory(
         self,
@@ -2499,8 +2517,8 @@ class EmbeddedLifeRuntime:
         risk_rank = {"A0": 0, "A1": 1, "A2": 2, "A3": 3, "A4": 4}
         configured_risk = str(settings.get("autonomous_risk_max") or "A4")
         configured_risk_rank = risk_rank.get(configured_risk, 0)
-        success_limit = max(0, int(settings.get("llm_daily_budget") or 20))
-        attempt_limit = max(0, int(settings.get("llm_daily_attempt_budget") or 30))
+        success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
+        attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
         if (
             (success_limit and int(scheduler.get("model_successes") or 0) >= success_limit)
             or (attempt_limit and int(scheduler.get("model_attempts") or 0) >= attempt_limit)
@@ -3212,6 +3230,14 @@ class EmbeddedLifeRuntime:
                 "proactive_model_skipped": 0,
             })
 
+    @staticmethod
+    def _daily_limit_setting(settings: Mapping[str, Any], key: str, default: int) -> int:
+        """Daily budget limits: 0 is a valid value (means disabled); only missing/None falls back."""
+        value = settings.get(key)
+        if value is None:
+            return default
+        return max(0, int(value))
+
     def _reserve_proactive_model_call_locked(
         self,
         *,
@@ -3220,10 +3246,10 @@ class EmbeddedLifeRuntime:
     ) -> bool:
         """Reserve one real LLM call against both global and proactive pools."""
         self._reset_proactive_model_budget_if_needed(scheduler)
-        global_success_limit = max(0, int(settings.get("llm_daily_budget") or 20))
-        global_attempt_limit = max(0, int(settings.get("llm_daily_attempt_budget") or 30))
-        proactive_success_limit = max(0, int(settings.get("proactive_llm_daily_budget") or 6))
-        proactive_attempt_limit = max(0, int(settings.get("proactive_llm_daily_attempt_budget") or 8))
+        global_success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
+        global_attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
+        proactive_success_limit = self._daily_limit_setting(settings, "proactive_llm_daily_budget", 6)
+        proactive_attempt_limit = self._daily_limit_setting(settings, "proactive_llm_daily_attempt_budget", 8)
         exhausted = (
             (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
             or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
@@ -4719,7 +4745,13 @@ class EmbeddedLifeRuntime:
                 journal_event, memory_id=contract_id
             ),
             causal_utility_milli=500 if classification.get("causal") else 0,
-            user_importance_milli=max(0, min(1000, priority)),
+            # priority is the -3000..5000 contract scale (contracts/memory.py
+            # MemoryAssertionV3.priority); map it linearly onto milli so the
+            # full range stays distinguishable instead of clamping 76% of it
+            # to saturation: -3000 -> 0, 0 -> 375, 5000 -> 1000.
+            user_importance_milli=max(
+                0, min(1000, ((priority + 3000) * 1000) // 8000)
+            ),
             verification_strength_milli=max(0, min(1000, confidence)),
             future_dependency_milli=(
                 500 if assertion_kind in {"goal", "hard_constraint"} else 0
@@ -5804,6 +5836,24 @@ class EmbeddedLifeRuntime:
             raise EmbeddedLifeError("life.memory.not_found", status=404)
         if row.get("status") == "deleted":
             raise EmbeddedLifeError("life.memory.deleted_immutable", status=409)
+        # The idempotency key includes the transition origin (the row's
+        # pre-transition updated_at): re-entering the same status from a
+        # different state is a new transition, not a replay of the old one.
+        retry_key = (
+            f"memory.status:{memory_id}:{status}:{str(row.get('updated_at') or '')}"
+        )
+        prior_status_change = self.system.journal.event_by_idempotency_key(
+            life_id, retry_key
+        )
+        if prior_status_change is not None and row.get("status") != status:
+            # Journal committed this transition but a later step failed and
+            # rolled the scope back: converge the projection, never re-append.
+            prior_payload = prior_status_change.get("payload")
+            prior_updated_at = ""
+            if isinstance(prior_payload, Mapping):
+                prior_updated_at = str(prior_payload.get("updated_at") or "")
+            row["status"] = status
+            row["updated_at"] = prior_updated_at or str(row.get("updated_at") or "")
         if row.get("status") == status:
             self._ensure_memory_contract_synced(life_id)
             contract_memory_id, change_seq = self._contract_store_assert(
@@ -5826,7 +5876,9 @@ class EmbeddedLifeRuntime:
                 "memory.status_changed",
                 {"memory_id": memory_id, "status": status, "updated_at": updated_at},
                 actor=str(payload.get("actor") or "user"),
-                idempotency_key=f"memory.status:{memory_id}:{status}",
+                idempotency_key=(
+                    f"memory.status:{memory_id}:{status}:{previous.get('updated_at') or ''}"
+                ),
             )
             contract_memory_id, change_seq = self._contract_store_assert(
                 life_id,
@@ -5931,6 +5983,21 @@ class EmbeddedLifeRuntime:
         row = scope["memories"].get(memory_id)
         if not isinstance(row, dict):
             raise EmbeddedLifeError("life.memory.not_found", status=404)
+        prior_delete = self.system.journal.event_by_idempotency_key(
+            life_id, f"memory.delete:{memory_id}"
+        )
+        if prior_delete is not None and row.get("status") != "deleted":
+            # The journal already committed this deletion (a later projection
+            # step failed and rolled back the scope). Converge the projection
+            # instead of re-appending: the same key with a fresh timestamp
+            # would be rejected as journal_idempotency_conflict forever.
+            prior_payload = prior_delete.get("payload")
+            prior_updated_at = ""
+            if isinstance(prior_payload, Mapping):
+                prior_updated_at = str(prior_payload.get("updated_at") or "")
+            row["status"] = "deleted"
+            row["content"] = {"tombstone": True}
+            row["updated_at"] = prior_updated_at or str(row.get("updated_at") or "")
         if row.get("status") == "deleted":
             contract_memory_id, change_seq, tombstone_id = self._contract_store_delete(
                 life_id, memory_id, updated_at=str(row.get("updated_at") or "")

--- a/app/life-service/runtime314/life_service/memory_coordinator.py
+++ b/app/life-service/runtime314/life_service/memory_coordinator.py
@@ -43,6 +43,7 @@ from .legacy_layer_migration import (
     legacy_layer_for_assertion,
 )
 from .store import LifeShadowStore, LifeShadowStoreError
+from .complete_core import utc_now
 
 
 L1_POLICY_VERSION = "p15-l1-v1"
@@ -1359,7 +1360,9 @@ class MemoryCoordinator:
                 state,
                 evidence_refs=(derivation.derivation_id,),
                 trait_delta_micro=deltas,
-                updated_at=str(now_ms),
+                # temperament state stores ISO-8601 timestamps like every
+                # other writer here; a raw millisecond string breaks the format.
+                updated_at=utc_now(),
             )
             delta_sha256 = str(outcome.get("trait_delta_sha256") or "")
             self._store.put_temperament_receipt(

--- a/app/life-service/runtime314/life_service/store.py
+++ b/app/life-service/runtime314/life_service/store.py
@@ -629,12 +629,19 @@ class LifeShadowStore:
         try:
             connection.execute("BEGIN IMMEDIATE")
             existing = connection.execute(
-                "SELECT status FROM cognition_lane_leases WHERE life_id=? AND lane=?",
+                "SELECT status, expires_at_ms FROM cognition_lane_leases WHERE life_id=? AND lane=?",
                 (life_id, lane),
             ).fetchone()
             if existing is not None and str(existing["status"]) == "active":
-                connection.execute("COMMIT")
-                return None
+                if int(existing["expires_at_ms"]) > now_ms:
+                    connection.execute("COMMIT")
+                    return None
+                # An active lease past its deadline means the holder died
+                # without releasing: preempt it so the lane can never deadlock.
+                connection.execute(
+                    "DELETE FROM cognition_lane_leases WHERE life_id=? AND lane=? AND status='active'",
+                    (life_id, lane),
+                )
             if lane == "foreground":
                 connection.execute(
                     "DELETE FROM cognition_lane_leases WHERE life_id=? AND lane='background' AND status='active'",

--- a/app/life-service/runtime314/life_service/transient_affect.py
+++ b/app/life-service/runtime314/life_service/transient_affect.py
@@ -283,7 +283,7 @@ def _signal_scores(text: str) -> dict[str, int]:
         matches = sum(min(2, clean.count(term.casefold())) for term in terms)
         if matches:
             scores[emotion] = min(1000, 310 + matches * 145)
-    if "!" in text or "！" in text:
+    if "!" in clean or "！" in clean:
         scores["vigilance"] = min(1000, scores["vigilance"] + 100)
         if scores["frustration"]:
             scores["frustration"] = min(1000, scores["frustration"] + 100)
@@ -321,7 +321,7 @@ def appraise_user_turn(
         if score <= 0:
             continue
         retained = int(before[emotion] * 0.72)
-        state["emotions"][emotion] = max(retained, min(1000, retained + int(score * 0.85)))
+        state["emotions"][emotion] = min(1000, retained + int(score * 0.85))
     strongest_negative = max((scores[name] for name in _NEGATIVE), default=0)
     strongest_positive = max((scores[name] for name in _POSITIVE), default=0)
     if strongest_negative >= 450:

--- a/app/life-service/runtime314/life_service/viability.py
+++ b/app/life-service/runtime314/life_service/viability.py
@@ -230,7 +230,9 @@ def compute_viability_deficit(
         for name in normalized_weights
     ) // weight_total
     critical = max(by_name[name] for name in CRITICAL_DIMENSIONS)
-    total = weighted + (critical * critical_weight_milli // 1000)
+    # Keep the total inside the milli convention [0, 1000]: weighted and the
+    # critical contribution are each independently bounded by 1000.
+    total = min(1000, weighted + (critical * critical_weight_milli // 1000))
     policy_sha256 = canonical_sha256(
         {
             "critical_dimensions": sorted(CRITICAL_DIMENSIONS),

--- a/app/main.js
+++ b/app/main.js
@@ -1268,7 +1268,14 @@ async function applyWorkspaceRootChange(workspace, expectedRevision, workspaceMo
     process.env.TIANGONG_FORCE_WORKSPACE_ROOT = previousWorkspace;
     process.env.TIANGONG_OMNI_BODY_WORKSPACE = previousWorkspace;
     process.env.TIANGONG_WORKSPACE_MODE = previousMode;
-    const rollbackServices = await startServicesForWorkspaceChange();
+    let rollbackServices;
+    try {
+      rollbackServices = await startServicesForWorkspaceChange();
+    } finally {
+      // Restore the supervisor watchdog even when the rollback restart itself
+      // fails; otherwise nothing will ever bring the gateway back up.
+      if (mainWindow && !mainWindow.isDestroyed()) startBackendWatchdog();
+    }
     const rolledBack = sameWindowsPath(
       process.env.TIANGONG_DESKTOP_WORKSPACE_ROOT || previousWorkspace,
       previousWorkspace,
@@ -2271,6 +2278,7 @@ function serviceListenerPids(rawUrl, fallbackPort) {
     const output = execFileSync("netstat", ["-ano", "-p", "tcp"], {
       encoding: "utf8",
       windowsHide: true,
+      timeout: 10_000,
       stdio: ["ignore", "pipe", "ignore"],
     });
     const pids = new Set();
@@ -3682,6 +3690,7 @@ function backendListenerPids() {
     const output = execFileSync("netstat", ["-ano", "-p", "tcp"], {
       encoding: "utf8",
       windowsHide: true,
+      timeout: 10_000,
       stdio: ["ignore", "pipe", "ignore"],
     });
     const pids = new Set();
@@ -3707,6 +3716,7 @@ function killProcessTreeSync(pid) {
     if (process.platform === "win32") {
       execFileSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
         windowsHide: true,
+        timeout: 10_000,
         stdio: "ignore",
       });
     } else {

--- a/readable-python-source/bundled-skills/novel-creation/.tiangong-generated-source.json
+++ b/readable-python-source/bundled-skills/novel-creation/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "managed-novel-skill-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/bundled_skills/novel-creation",
-  "tree_sha256": "5f0ca06c4524cff7f677628fb7250c73c15ab430a840ad879fa66610641d5ff4",
+  "tree_sha256": "b1fd16a941851af4d2202d169156677a3a1e4cea7f3ef867e2b2549e937d70fb",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/readable-python-source/bundled-skills/novel-creation/scripts/novel_tool.py
+++ b/readable-python-source/bundled-skills/novel-creation/scripts/novel_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import sys
 from datetime import datetime
@@ -58,14 +59,20 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8-sig")
 
 
-def write_text(path: Path, text: str) -> None:
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via temp file + rename so a crash cannot leave a half-written file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_text(path: Path, text: str) -> None:
+    _atomic_write(path, text)
 
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    _atomic_write(path, json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -74,7 +81,10 @@ def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, An
     try:
         data = json.loads(read_text(path))
         return data if isinstance(data, dict) else dict(default or {})
-    except Exception:
+    except Exception as exc:
+        # A corrupt file silently resetting the contract to defaults is worse
+        # than a loud warning; keep the default-return behavior but report it.
+        print(f"[novel_tool] read_json failed ({path}): {exc}", file=sys.stderr)
         return dict(default or {})
 
 

--- a/readable-python-source/omni_body_skill/.tiangong-generated-source.json
+++ b/readable-python-source/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "9ebff3aa2d592b67ac0603c60ee3e3ad6cda516e8dbb953df5c85707f99fda52",
+  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/readable-python-source/omni_body_skill/tools/delivery_kernel.py
+++ b/readable-python-source/omni_body_skill/tools/delivery_kernel.py
@@ -830,7 +830,14 @@ def _qc_code(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str
             issues.append(_issue("miniapp_test_command_required","小程序工程必须提供可执行的离线测试命令。","critical","提供 node 测试脚本或项目自带测试命令。"))
             command=[]
         elif not command:
-            command=[sys.executable,"-m","pytest","-q"]
+            # Delayed import: omni_body_tool imports this module at load time.
+            # In frozen builds sys.executable is the backend exe, never reuse it.
+            try:
+                from .omni_body_tool import _resolve_python_interpreter
+                command=[_resolve_python_interpreter(),"-m","pytest","-q"]
+            except Exception as exc:
+                issues.append(_issue("tests_not_executable",f"测试无法执行：{exc}","critical","修复测试环境和命令。"))
+                command=[]
         if isinstance(command,str): command=command.split()
         if command:
             try:
@@ -1081,10 +1088,16 @@ def _deliverable_package(runtime: Any, target: str | None, args: Dict[str, Any])
             child_resolved = child.resolve(strict=True)
             if child_resolved == output_resolved:
                 raise ValueError("deliverable.package input and output must be different paths")
+            # Items may live in user-authorized roots outside the workspace;
+            # those are archived relative to their own source directory.
             archive_name = (
                 child.name
                 if source.is_file()
-                else child.relative_to(runtime.workspace).as_posix()
+                else (
+                    child.relative_to(runtime.workspace).as_posix()
+                    if child.is_relative_to(runtime.workspace)
+                    else f"{source.name}/{child.relative_to(source).as_posix()}"
+                )
             )
             folded = archive_name.casefold()
             if folded in seen_archives or folded == "delivery_manifest.json":

--- a/readable-python-source/omni_body_skill/tools/omni_body_v3.py
+++ b/readable-python-source/omni_body_skill/tools/omni_body_v3.py
@@ -297,7 +297,10 @@ def run_omni_body(args: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(result, dict):
         result = {"result": result, "success": True}
 
-    ok = bool(result.get("success", result.get("ok", False)))
+    if result.get("ok") is False:
+        ok = False
+    else:
+        ok = bool(result.get("success", result.get("ok", False)))
     evidence = _extract_evidence(result, target, workspace)
     response: dict[str, Any] = {
         "schema": TOOL_SCHEMA,

--- a/readable-python-source/omni_body_skill/tools/pro_apps_v34.py
+++ b/readable-python-source/omni_body_skill/tools/pro_apps_v34.py
@@ -718,7 +718,16 @@ def _office_native_action(runtime: Any, action: str, target: str | None, args: D
         tmp = _resolve(runtime, f".omni_temp/office_{int(time.time())}.py")
         tmp.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(script, encoding="utf-8")
-        res = subprocess.run([sys.executable, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
+        # Delayed import: omni_body_tool imports this module chain at load time.
+        # In frozen builds sys.executable is the backend exe, never reuse it.
+        try:
+            from .omni_body_tool import _resolve_python_interpreter
+            interpreter = _resolve_python_interpreter()
+        except Exception:
+            interpreter = None
+        if interpreter is None:
+            return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})
+        res = subprocess.run([interpreter, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
         return {"success": res.returncode == 0, "result": {"stdout": res.stdout, "stderr": res.stderr, "returncode": res.returncode}, "evidence": {"path": args.get("output") or "", "exists": bool(args.get("output") and _resolve(runtime, args.get("output")).exists())}}
     # Professional behavior: return executable bridge, not fake PDF/export.
     return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})

--- a/readable-python-source/omni_body_skill/tools/sandbox_runtime.py
+++ b/readable-python-source/omni_body_skill/tools/sandbox_runtime.py
@@ -472,24 +472,31 @@ class SandboxRunner:
                     ) from exc
         if run_root.exists():
             shutil.rmtree(run_root, ignore_errors=True)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
-        before = _snapshot(sandbox_workspace)
-        real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
-        sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
-        sandbox_cwd.mkdir(parents=True, exist_ok=True)
-        rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
-        if os.name == "nt":
-            rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
-        limits = SandboxLimits(
-            timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
-            max_workspace_bytes=self.limits.max_workspace_bytes,
-            max_changed_bytes=self.limits.max_changed_bytes,
-            max_output_bytes=self.limits.max_output_bytes,
-            max_memory_bytes=self.limits.max_memory_bytes,
-            max_processes=self.limits.max_processes,
-        )
-        env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        # Preparation failures (workspace copy, snapshot, shell rewrite) must
+        # not leak run_root: the main try/finally below only covers execution.
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
+            before = _snapshot(sandbox_workspace)
+            real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
+            sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
+            sandbox_cwd.mkdir(parents=True, exist_ok=True)
+            rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
+            if os.name == "nt":
+                rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
+            limits = SandboxLimits(
+                timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
+                max_workspace_bytes=self.limits.max_workspace_bytes,
+                max_changed_bytes=self.limits.max_changed_bytes,
+                max_output_bytes=self.limits.max_output_bytes,
+                max_memory_bytes=self.limits.max_memory_bytes,
+                max_processes=self.limits.max_processes,
+            )
+            env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        except BaseException:
+            if os.environ.get("TIANGONG_KEEP_SANDBOX", "0").strip().lower() not in {"1", "true", "yes", "on"}:
+                shutil.rmtree(run_root, ignore_errors=True)
+            raise
         started = time.monotonic()
         try:
             if os.name == "nt":

--- a/src/bundled_skills/novel-creation/scripts/novel_tool.py
+++ b/src/bundled_skills/novel-creation/scripts/novel_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import sys
 from datetime import datetime
@@ -58,14 +59,20 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8-sig")
 
 
-def write_text(path: Path, text: str) -> None:
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via temp file + rename so a crash cannot leave a half-written file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_text(path: Path, text: str) -> None:
+    _atomic_write(path, text)
 
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    _atomic_write(path, json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -74,7 +81,10 @@ def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, An
     try:
         data = json.loads(read_text(path))
         return data if isinstance(data, dict) else dict(default or {})
-    except Exception:
+    except Exception as exc:
+        # A corrupt file silently resetting the contract to defaults is worse
+        # than a loud warning; keep the default-return behavior but report it.
+        print(f"[novel_tool] read_json failed ({path}): {exc}", file=sys.stderr)
         return dict(default or {})
 
 

--- a/src/communication_service/attachment_quarantine.py
+++ b/src/communication_service/attachment_quarantine.py
@@ -279,19 +279,22 @@ class AttachmentQuarantineLedger:
         if now_ms < 0 or self._closed:
             return AttachmentLedgerHealth(False, "attachment.ledger.closed", None)
         try:
-            check = "integrity_check" if full else "quick_check"
-            if self._connection.execute(f"PRAGMA {check}").fetchone()[0] != "ok":
-                raise AttachmentQuotaError("attachment.ledger.sqlite_corrupt")
-            if _schema_sha256(self._connection) != expected_attachment_ledger_schema_sha256():
-                raise AttachmentQuotaError("attachment.ledger.schema_mismatch")
-            self._verify_rows()
-            with self._transaction():
-                self._connection.execute("SELECT 1")
-            return AttachmentLedgerHealth(
-                True,
-                "attachment.ledger.ok",
-                expected_attachment_ledger_schema_sha256(),
-            )
+            # Hold the instance lock: the sqlite connection is shared with
+            # admit/expire on other threads (same pattern as the other ledgers).
+            with self._lock:
+                check = "integrity_check" if full else "quick_check"
+                if self._connection.execute(f"PRAGMA {check}").fetchone()[0] != "ok":
+                    raise AttachmentQuotaError("attachment.ledger.sqlite_corrupt")
+                if _schema_sha256(self._connection) != expected_attachment_ledger_schema_sha256():
+                    raise AttachmentQuotaError("attachment.ledger.schema_mismatch")
+                self._verify_rows()
+                with self._transaction():
+                    self._connection.execute("SELECT 1")
+                return AttachmentLedgerHealth(
+                    True,
+                    "attachment.ledger.ok",
+                    expected_attachment_ledger_schema_sha256(),
+                )
         except Exception:
             return AttachmentLedgerHealth(False, "attachment.ledger.check_failed", None)
 

--- a/src/communication_service/feishu_worker.py
+++ b/src/communication_service/feishu_worker.py
@@ -300,9 +300,24 @@ class FeishuProductionAdapter:
                 "classification": outcome.classification,
                 "forwarded": False,
             }
+        if outcome.duplicate:
+            # Platform redelivery: re-ACK with the receipt already recorded
+            # for this permit. A fresh acceptance carries a new accepted_at_ms;
+            # ACKing with it raises AckConflictError, the SDK answers 500, and
+            # the platform redelivers the same event forever.
+            stored_receipt = self._inbox.ack_permit_receipt(
+                outcome.ack_permit.permit_id
+            )
+            receipt_sha256 = (
+                stored_receipt
+                if stored_receipt is not None
+                else canonical_sha256(evidence)
+            )
+        else:
+            receipt_sha256 = canonical_sha256(evidence)
         self._inbox.mark_acknowledged(
             outcome.ack_permit.permit_id,
-            platform_receipt_sha256=canonical_sha256(evidence),
+            platform_receipt_sha256=receipt_sha256,
             acknowledged_at_ms=self._clock_ms(),
         )
 

--- a/src/communication_service/inbox.py
+++ b/src/communication_service/inbox.py
@@ -642,6 +642,22 @@ class CommunicationInbox:
                 raise InboxCorruptionError("ACK permit and inbox state disagree")
         return True
 
+    def ack_permit_receipt(self, permit_id: str) -> str | None:
+        """Return the stored platform receipt digest for an ACK permit, if any.
+
+        Redelivery handlers use this to re-ACK with the originally recorded
+        receipt instead of a freshly generated one, which would collide.
+        """
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT platform_receipt_sha256 FROM ack_permits WHERE permit_id = ?",
+                (permit_id,),
+            ).fetchone()
+            if row is None:
+                raise InboxConflictError("ACK permit does not exist")
+            digest = row["platform_receipt_sha256"]
+            return str(digest) if digest is not None else None
+
     def get_cursor(self, cursor_stream_key: str) -> CursorSnapshot | None:
         with self._lock:
             row = self._connection.execute(

--- a/src/communication_service/wechat_media.py
+++ b/src/communication_service/wechat_media.py
@@ -368,8 +368,10 @@ class WechatMediaDownloader:
         if not self.staging_root.exists():
             return 0
         removed = 0
-        for path in self.staging_root.glob("*.part"):
-            if path.is_file() and not path.is_symlink():
+        # iterdir instead of glob("*.part"): glob skips dot-prefixed names, so
+        # the ".wechat-*.cipher.part" staging files would never be cleaned.
+        for path in self.staging_root.iterdir():
+            if path.name.endswith(".part") and path.is_file() and not path.is_symlink():
                 path.unlink()
                 removed += 1
         return removed

--- a/src/communication_service/wechat_worker.py
+++ b/src/communication_service/wechat_worker.py
@@ -341,9 +341,24 @@ class WechatProductionAdapter:
                             "forwarded": False,
                             "decision_sha256": outcome.decision.decision_sha256,
                         }
+                    if outcome.inbox_duplicate:
+                        # Re-polled duplicate: re-ACK with the receipt already
+                        # recorded for this permit. A fresh acceptance changes
+                        # the digest and would raise AckConflictError, looping
+                        # the poller in error state forever.
+                        stored_receipt = self._inbox.ack_permit_receipt(
+                            outcome.ack_permit.permit_id
+                        )
+                        receipt_sha256 = (
+                            stored_receipt
+                            if stored_receipt is not None
+                            else canonical_sha256(evidence)
+                        )
+                    else:
+                        receipt_sha256 = canonical_sha256(evidence)
                     self._inbox.mark_acknowledged(
                         outcome.ack_permit.permit_id,
-                        platform_receipt_sha256=canonical_sha256(evidence),
+                        platform_receipt_sha256=receipt_sha256,
                         acknowledged_at_ms=self._clock_ms(),
                     )
                 self._set_state("ready")

--- a/src/life_service/affect.py
+++ b/src/life_service/affect.py
@@ -92,9 +92,9 @@ def evaluate_affect_gate(
 ) -> AffectGateDecision:
     if repetition_count < 1:
         raise ValueError("affect repetition count is invalid")
-    # Exponential habituation reaches zero after bounded repeats, so identical
-    # content cannot self-excite forever even if an upstream feed loops.
-    repetition_factor = 1000 // (1 << min(repetition_count - 1, 20))
+    # Exponential habituation reaches zero after 11 repeats (2^10 = 1024 > 1000),
+    # so identical content cannot self-excite forever even if an upstream feed loops.
+    repetition_factor = 1000 // (1 << min(repetition_count - 1, 10))
     reason = "affect.accepted"
     if signal.prompt_injection_detected:
         reason = "affect.rejected.prompt_injection"

--- a/src/life_service/cognition.py
+++ b/src/life_service/cognition.py
@@ -176,6 +176,26 @@ class UnifiedCognitionShadow:
                 "event_id": item["event_id"],
                 "decision": dict(decision),
             }
+        except Exception:
+            # A crashing decider pass must not strand the stimulus in
+            # `selected` forever. Record a `failed` shadow and consume the
+            # stimulus so the queue keeps flowing; releasing it back to
+            # pending would re-select the same failing item head-of-line.
+            self._record_shadow(
+                life_id,
+                item,
+                root_experience_id=root_experience_id,
+                status="failed",
+                slot_no=1,
+                now_ms=now_ms,
+            )
+            self._store.commit_stimulus(
+                life_id,
+                enqueue_seq=int(item["enqueue_seq"]),
+                claim_token=claim,
+                now_ms=now_ms,
+            )
+            raise
         finally:
             self._store.release_lane(life_id, str(item["lane"]), lease_id=lease)
 

--- a/src/life_service/complete_core.py
+++ b/src/life_service/complete_core.py
@@ -923,6 +923,24 @@ class SemanticJournal:
         with self._lock:
             return self._read_events_strict(life_id)
 
+    def event_by_idempotency_key(
+        self, life_id: str, idempotency_key: str
+    ) -> dict[str, Any] | None:
+        """Return the already-recorded event for a key, or None.
+
+        Callers use this to converge retries: when the journal committed but a
+        later projection step failed, re-appending with the same key would hit
+        ``journal_idempotency_conflict`` because fresh timestamps change the
+        payload. Looking the event up first lets the caller replay the side
+        effects instead of the journal append.
+        """
+        if not idempotency_key:
+            return None
+        for event in reversed(self.events(life_id)):
+            if str(event.get("idempotency_key") or "") == idempotency_key:
+                return event
+        return None
+
     def _verify_chain_only(self, life_id: str, events: list[dict[str, Any]]) -> dict[str, Any]:
         previous = self.GENESIS_SHA256
         for index, event in enumerate(events, 1):

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -2120,7 +2120,10 @@ class EmbeddedLifeRuntime:
             return {"created": 0, "deduped": 0, "coalesced": 0}
         triggers = self._cognition_trigger_candidates(life_id)
         stats = shadow.enqueue_many(life_id, triggers)
-        if self._cognition_decider is not None and stats["created"]:
+        # Start the worker when anything is pending, not only on fresh enqueues:
+        # a backlog with fully deduped triggers would otherwise never drain.
+        pending = int(self._contract_store().cognition_health(life_id).get("pending") or 0)
+        if self._cognition_decider is not None and (stats["created"] or pending > 0):
             worker = threading.Thread(
                 target=self._cognition_worker,
                 args=(life_id,),
@@ -2132,7 +2135,7 @@ class EmbeddedLifeRuntime:
 
     def _cognition_worker(self, life_id: str) -> None:
         try:
-            self.run_cognition_shadow_pass(life_id)
+            self.run_cognition_shadow_drain(life_id)
         except Exception:
             # Shadow diagnostics never crash the heartbeat.
             return
@@ -2151,6 +2154,21 @@ class EmbeddedLifeRuntime:
         )
         owner = self._lease.instance_id if self._lease is not None else "life"
         return shadow.run_pass(life_id, owner_instance_id=owner)
+
+    def run_cognition_shadow_drain(self, life_id: str) -> dict[str, Any]:
+        """Drain the whole pending cognition shadow backlog (worker entry)."""
+        store = self._contract_store()
+        shadow = UnifiedCognitionShadow(
+            store,
+            cognition_decider=self._cognition_decider,
+            binding_factory=(
+                lambda current_life_id, event_id, now_ms: self._cognition_binding_factory(
+                    store, current_life_id, event_id, now_ms
+                )
+            ),
+        )
+        owner = self._lease.instance_id if self._lease is not None else "life"
+        return shadow.run_drain(life_id, owner_instance_id=owner)
 
     def _cognition_binding_factory(
         self,
@@ -2499,8 +2517,8 @@ class EmbeddedLifeRuntime:
         risk_rank = {"A0": 0, "A1": 1, "A2": 2, "A3": 3, "A4": 4}
         configured_risk = str(settings.get("autonomous_risk_max") or "A4")
         configured_risk_rank = risk_rank.get(configured_risk, 0)
-        success_limit = max(0, int(settings.get("llm_daily_budget") or 20))
-        attempt_limit = max(0, int(settings.get("llm_daily_attempt_budget") or 30))
+        success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
+        attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
         if (
             (success_limit and int(scheduler.get("model_successes") or 0) >= success_limit)
             or (attempt_limit and int(scheduler.get("model_attempts") or 0) >= attempt_limit)
@@ -3212,6 +3230,14 @@ class EmbeddedLifeRuntime:
                 "proactive_model_skipped": 0,
             })
 
+    @staticmethod
+    def _daily_limit_setting(settings: Mapping[str, Any], key: str, default: int) -> int:
+        """Daily budget limits: 0 is a valid value (means disabled); only missing/None falls back."""
+        value = settings.get(key)
+        if value is None:
+            return default
+        return max(0, int(value))
+
     def _reserve_proactive_model_call_locked(
         self,
         *,
@@ -3220,10 +3246,10 @@ class EmbeddedLifeRuntime:
     ) -> bool:
         """Reserve one real LLM call against both global and proactive pools."""
         self._reset_proactive_model_budget_if_needed(scheduler)
-        global_success_limit = max(0, int(settings.get("llm_daily_budget") or 20))
-        global_attempt_limit = max(0, int(settings.get("llm_daily_attempt_budget") or 30))
-        proactive_success_limit = max(0, int(settings.get("proactive_llm_daily_budget") or 6))
-        proactive_attempt_limit = max(0, int(settings.get("proactive_llm_daily_attempt_budget") or 8))
+        global_success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
+        global_attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
+        proactive_success_limit = self._daily_limit_setting(settings, "proactive_llm_daily_budget", 6)
+        proactive_attempt_limit = self._daily_limit_setting(settings, "proactive_llm_daily_attempt_budget", 8)
         exhausted = (
             (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
             or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
@@ -4719,7 +4745,13 @@ class EmbeddedLifeRuntime:
                 journal_event, memory_id=contract_id
             ),
             causal_utility_milli=500 if classification.get("causal") else 0,
-            user_importance_milli=max(0, min(1000, priority)),
+            # priority is the -3000..5000 contract scale (contracts/memory.py
+            # MemoryAssertionV3.priority); map it linearly onto milli so the
+            # full range stays distinguishable instead of clamping 76% of it
+            # to saturation: -3000 -> 0, 0 -> 375, 5000 -> 1000.
+            user_importance_milli=max(
+                0, min(1000, ((priority + 3000) * 1000) // 8000)
+            ),
             verification_strength_milli=max(0, min(1000, confidence)),
             future_dependency_milli=(
                 500 if assertion_kind in {"goal", "hard_constraint"} else 0
@@ -5804,6 +5836,24 @@ class EmbeddedLifeRuntime:
             raise EmbeddedLifeError("life.memory.not_found", status=404)
         if row.get("status") == "deleted":
             raise EmbeddedLifeError("life.memory.deleted_immutable", status=409)
+        # The idempotency key includes the transition origin (the row's
+        # pre-transition updated_at): re-entering the same status from a
+        # different state is a new transition, not a replay of the old one.
+        retry_key = (
+            f"memory.status:{memory_id}:{status}:{str(row.get('updated_at') or '')}"
+        )
+        prior_status_change = self.system.journal.event_by_idempotency_key(
+            life_id, retry_key
+        )
+        if prior_status_change is not None and row.get("status") != status:
+            # Journal committed this transition but a later step failed and
+            # rolled the scope back: converge the projection, never re-append.
+            prior_payload = prior_status_change.get("payload")
+            prior_updated_at = ""
+            if isinstance(prior_payload, Mapping):
+                prior_updated_at = str(prior_payload.get("updated_at") or "")
+            row["status"] = status
+            row["updated_at"] = prior_updated_at or str(row.get("updated_at") or "")
         if row.get("status") == status:
             self._ensure_memory_contract_synced(life_id)
             contract_memory_id, change_seq = self._contract_store_assert(
@@ -5826,7 +5876,9 @@ class EmbeddedLifeRuntime:
                 "memory.status_changed",
                 {"memory_id": memory_id, "status": status, "updated_at": updated_at},
                 actor=str(payload.get("actor") or "user"),
-                idempotency_key=f"memory.status:{memory_id}:{status}",
+                idempotency_key=(
+                    f"memory.status:{memory_id}:{status}:{previous.get('updated_at') or ''}"
+                ),
             )
             contract_memory_id, change_seq = self._contract_store_assert(
                 life_id,
@@ -5931,6 +5983,21 @@ class EmbeddedLifeRuntime:
         row = scope["memories"].get(memory_id)
         if not isinstance(row, dict):
             raise EmbeddedLifeError("life.memory.not_found", status=404)
+        prior_delete = self.system.journal.event_by_idempotency_key(
+            life_id, f"memory.delete:{memory_id}"
+        )
+        if prior_delete is not None and row.get("status") != "deleted":
+            # The journal already committed this deletion (a later projection
+            # step failed and rolled back the scope). Converge the projection
+            # instead of re-appending: the same key with a fresh timestamp
+            # would be rejected as journal_idempotency_conflict forever.
+            prior_payload = prior_delete.get("payload")
+            prior_updated_at = ""
+            if isinstance(prior_payload, Mapping):
+                prior_updated_at = str(prior_payload.get("updated_at") or "")
+            row["status"] = "deleted"
+            row["content"] = {"tombstone": True}
+            row["updated_at"] = prior_updated_at or str(row.get("updated_at") or "")
         if row.get("status") == "deleted":
             contract_memory_id, change_seq, tombstone_id = self._contract_store_delete(
                 life_id, memory_id, updated_at=str(row.get("updated_at") or "")

--- a/src/life_service/memory_coordinator.py
+++ b/src/life_service/memory_coordinator.py
@@ -43,6 +43,7 @@ from .legacy_layer_migration import (
     legacy_layer_for_assertion,
 )
 from .store import LifeShadowStore, LifeShadowStoreError
+from .complete_core import utc_now
 
 
 L1_POLICY_VERSION = "p15-l1-v1"
@@ -1359,7 +1360,9 @@ class MemoryCoordinator:
                 state,
                 evidence_refs=(derivation.derivation_id,),
                 trait_delta_micro=deltas,
-                updated_at=str(now_ms),
+                # temperament state stores ISO-8601 timestamps like every
+                # other writer here; a raw millisecond string breaks the format.
+                updated_at=utc_now(),
             )
             delta_sha256 = str(outcome.get("trait_delta_sha256") or "")
             self._store.put_temperament_receipt(

--- a/src/life_service/store.py
+++ b/src/life_service/store.py
@@ -629,12 +629,19 @@ class LifeShadowStore:
         try:
             connection.execute("BEGIN IMMEDIATE")
             existing = connection.execute(
-                "SELECT status FROM cognition_lane_leases WHERE life_id=? AND lane=?",
+                "SELECT status, expires_at_ms FROM cognition_lane_leases WHERE life_id=? AND lane=?",
                 (life_id, lane),
             ).fetchone()
             if existing is not None and str(existing["status"]) == "active":
-                connection.execute("COMMIT")
-                return None
+                if int(existing["expires_at_ms"]) > now_ms:
+                    connection.execute("COMMIT")
+                    return None
+                # An active lease past its deadline means the holder died
+                # without releasing: preempt it so the lane can never deadlock.
+                connection.execute(
+                    "DELETE FROM cognition_lane_leases WHERE life_id=? AND lane=? AND status='active'",
+                    (life_id, lane),
+                )
             if lane == "foreground":
                 connection.execute(
                     "DELETE FROM cognition_lane_leases WHERE life_id=? AND lane='background' AND status='active'",

--- a/src/life_service/transient_affect.py
+++ b/src/life_service/transient_affect.py
@@ -283,7 +283,7 @@ def _signal_scores(text: str) -> dict[str, int]:
         matches = sum(min(2, clean.count(term.casefold())) for term in terms)
         if matches:
             scores[emotion] = min(1000, 310 + matches * 145)
-    if "!" in text or "！" in text:
+    if "!" in clean or "！" in clean:
         scores["vigilance"] = min(1000, scores["vigilance"] + 100)
         if scores["frustration"]:
             scores["frustration"] = min(1000, scores["frustration"] + 100)
@@ -321,7 +321,7 @@ def appraise_user_turn(
         if score <= 0:
             continue
         retained = int(before[emotion] * 0.72)
-        state["emotions"][emotion] = max(retained, min(1000, retained + int(score * 0.85)))
+        state["emotions"][emotion] = min(1000, retained + int(score * 0.85))
     strongest_negative = max((scores[name] for name in _NEGATIVE), default=0)
     strongest_positive = max((scores[name] for name in _POSITIVE), default=0)
     if strongest_negative >= 450:

--- a/src/life_service/viability.py
+++ b/src/life_service/viability.py
@@ -230,7 +230,9 @@ def compute_viability_deficit(
         for name in normalized_weights
     ) // weight_total
     critical = max(by_name[name] for name in CRITICAL_DIMENSIONS)
-    total = weighted + (critical * critical_weight_milli // 1000)
+    # Keep the total inside the milli convention [0, 1000]: weighted and the
+    # critical contribution are each independently bounded by 1000.
+    total = min(1000, weighted + (critical * critical_weight_milli // 1000))
     policy_sha256 = canonical_sha256(
         {
             "critical_dimensions": sorted(CRITICAL_DIMENSIONS),

--- a/src/omni_body_skill/tools/delivery_kernel.py
+++ b/src/omni_body_skill/tools/delivery_kernel.py
@@ -830,7 +830,14 @@ def _qc_code(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str
             issues.append(_issue("miniapp_test_command_required","小程序工程必须提供可执行的离线测试命令。","critical","提供 node 测试脚本或项目自带测试命令。"))
             command=[]
         elif not command:
-            command=[sys.executable,"-m","pytest","-q"]
+            # Delayed import: omni_body_tool imports this module at load time.
+            # In frozen builds sys.executable is the backend exe, never reuse it.
+            try:
+                from .omni_body_tool import _resolve_python_interpreter
+                command=[_resolve_python_interpreter(),"-m","pytest","-q"]
+            except Exception as exc:
+                issues.append(_issue("tests_not_executable",f"测试无法执行：{exc}","critical","修复测试环境和命令。"))
+                command=[]
         if isinstance(command,str): command=command.split()
         if command:
             try:
@@ -1081,10 +1088,16 @@ def _deliverable_package(runtime: Any, target: str | None, args: Dict[str, Any])
             child_resolved = child.resolve(strict=True)
             if child_resolved == output_resolved:
                 raise ValueError("deliverable.package input and output must be different paths")
+            # Items may live in user-authorized roots outside the workspace;
+            # those are archived relative to their own source directory.
             archive_name = (
                 child.name
                 if source.is_file()
-                else child.relative_to(runtime.workspace).as_posix()
+                else (
+                    child.relative_to(runtime.workspace).as_posix()
+                    if child.is_relative_to(runtime.workspace)
+                    else f"{source.name}/{child.relative_to(source).as_posix()}"
+                )
             )
             folded = archive_name.casefold()
             if folded in seen_archives or folded == "delivery_manifest.json":

--- a/src/omni_body_skill/tools/omni_body_v3.py
+++ b/src/omni_body_skill/tools/omni_body_v3.py
@@ -297,7 +297,10 @@ def run_omni_body(args: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(result, dict):
         result = {"result": result, "success": True}
 
-    ok = bool(result.get("success", result.get("ok", False)))
+    if result.get("ok") is False:
+        ok = False
+    else:
+        ok = bool(result.get("success", result.get("ok", False)))
     evidence = _extract_evidence(result, target, workspace)
     response: dict[str, Any] = {
         "schema": TOOL_SCHEMA,

--- a/src/omni_body_skill/tools/pro_apps_v34.py
+++ b/src/omni_body_skill/tools/pro_apps_v34.py
@@ -718,7 +718,16 @@ def _office_native_action(runtime: Any, action: str, target: str | None, args: D
         tmp = _resolve(runtime, f".omni_temp/office_{int(time.time())}.py")
         tmp.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(script, encoding="utf-8")
-        res = subprocess.run([sys.executable, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
+        # Delayed import: omni_body_tool imports this module chain at load time.
+        # In frozen builds sys.executable is the backend exe, never reuse it.
+        try:
+            from .omni_body_tool import _resolve_python_interpreter
+            interpreter = _resolve_python_interpreter()
+        except Exception:
+            interpreter = None
+        if interpreter is None:
+            return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})
+        res = subprocess.run([interpreter, str(tmp)], cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 120)))
         return {"success": res.returncode == 0, "result": {"stdout": res.stdout, "stderr": res.stderr, "returncode": res.returncode}, "evidence": {"path": args.get("output") or "", "exists": bool(args.get("output") and _resolve(runtime, args.get("output")).exists())}}
     # Professional behavior: return executable bridge, not fake PDF/export.
     return _office_com_script(runtime, str(args.get("bridge_output") or f"bridges/{action.replace('.', '_')}.py"), {**args, "app": "powerpoint" if "powerpoint" in action else "excel" if "excel" in action else "word", "input": target or args.get("input")})

--- a/src/omni_body_skill/tools/sandbox_runtime.py
+++ b/src/omni_body_skill/tools/sandbox_runtime.py
@@ -472,24 +472,31 @@ class SandboxRunner:
                     ) from exc
         if run_root.exists():
             shutil.rmtree(run_root, ignore_errors=True)
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
-        before = _snapshot(sandbox_workspace)
-        real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
-        sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
-        sandbox_cwd.mkdir(parents=True, exist_ok=True)
-        rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
-        if os.name == "nt":
-            rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
-        limits = SandboxLimits(
-            timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
-            max_workspace_bytes=self.limits.max_workspace_bytes,
-            max_changed_bytes=self.limits.max_changed_bytes,
-            max_output_bytes=self.limits.max_output_bytes,
-            max_memory_bytes=self.limits.max_memory_bytes,
-            max_processes=self.limits.max_processes,
-        )
-        env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        # Preparation failures (workspace copy, snapshot, shell rewrite) must
+        # not leak run_root: the main try/finally below only covers execution.
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            _copy_workspace(self.workspace, sandbox_workspace, self.limits.max_workspace_bytes)
+            before = _snapshot(sandbox_workspace)
+            real_cwd = (cwd or self.workspace).expanduser().resolve(strict=False)
+            sandbox_cwd = sandbox_workspace / _safe_rel(self.workspace, real_cwd)
+            sandbox_cwd.mkdir(parents=True, exist_ok=True)
+            rewritten = _rewrite_workspace_paths(command, self.workspace, sandbox_workspace)
+            if os.name == "nt":
+                rewritten = _prepare_windows_utf8_shell_command(rewritten, cwd=sandbox_cwd)
+            limits = SandboxLimits(
+                timeout_seconds=max(1, int(timeout_seconds or self.limits.timeout_seconds)),
+                max_workspace_bytes=self.limits.max_workspace_bytes,
+                max_changed_bytes=self.limits.max_changed_bytes,
+                max_output_bytes=self.limits.max_output_bytes,
+                max_memory_bytes=self.limits.max_memory_bytes,
+                max_processes=self.limits.max_processes,
+            )
+            env = subprocess_environment(sanitized_environment(os.environ, temp_dir))
+        except BaseException:
+            if os.environ.get("TIANGONG_KEEP_SANDBOX", "0").strip().lower() not in {"1", "true", "yes", "on"}:
+                shutil.rmtree(run_root, ignore_errors=True)
+            raise
         started = time.monotonic()
         try:
             if os.name == "nt":

--- a/src/total_gateway/delivery_outbox.py
+++ b/src/total_gateway/delivery_outbox.py
@@ -240,6 +240,44 @@ class GatewayDeliveryOutboxWorker:
             created_at_ms=at_ms,
         ).reference
 
+    def _abandon_cancelled_outbox(
+        self, record: OutboxRecord, *, reason: str, now_ms: int
+    ) -> None:
+        """Settle an outbox intent whose generation was cancelled as AMBIGUOUS.
+
+        The payload failed validation only because its execution fact (the
+        ACTIVE generation) is gone; the payload JSON itself parsed fine, so
+        re-read it for the object-store scope binding and record a terminal
+        ambiguity result instead of retrying the claim forever.
+        """
+        raw = self._objects.read_bytes(record.intent.payload_object_id)
+        document = json.loads(raw.decode("utf-8"))
+        plan = document.get("plan") if isinstance(document, dict) else None
+        if not isinstance(plan, dict):
+            raise DeliveryOutboxError("delivery_outbox.payload.unreadable")
+        result_raw = canonical_json_bytes(
+            {
+                "kind": "error",
+                "outbox_id": record.intent.outbox_id,
+                "reason_code": "delivery_outbox.generation_cancelled",
+                "detail": reason[:200],
+            }
+        )
+        reference = self._objects.put_bytes(
+            result_raw,
+            kind="payload",
+            tenant_id=str(plan.get("tenant_id") or ""),
+            link_account_id=str(plan.get("link_account_id") or ""),
+            conversation_scope_hash=str(plan.get("conversation_scope_hash") or ""),
+            created_at_ms=now_ms,
+        ).reference
+        self._store.mark_expired_outbox_ambiguous(
+            record.intent.outbox_id,
+            observed_at_ms=now_ms,
+            result_object_id=reference.object_id,
+            result_sha256=reference.sha256,
+        )
+
     def _record_error_result(
         self,
         record: OutboxRecord,
@@ -309,7 +347,18 @@ class GatewayDeliveryOutboxWorker:
             now_ms=now_ms,
             lease_ms=120_000,
         )
-        payload = self._load_payload(claimed)
+        try:
+            payload = self._load_payload(claimed)
+        except DeliveryOutboxError as exc:
+            # A cancelled/fenced generation can never become ACTIVE again,
+            # so this intent is permanently undispatchable. Settle it as
+            # AMBIGUOUS here; raising instead would loop the orchestration
+            # worker on the same record every 120s lease expiry forever.
+            generation = self._store.get_generation(claimed.intent.request_id)
+            if generation is not None and generation.status == "ACTIVE":
+                raise
+            self._abandon_cancelled_outbox(claimed, reason=str(exc), now_ms=now_ms)
+            return True
         ticket = self._issue_ticket(payload.plan, issued_at_ms=now_ms)
         ticket_raw = canonical_json_bytes(ticket.model_dump(mode="json"))
         ticket_reference = self._objects.put_bytes(

--- a/src/total_gateway/desktop_api.py
+++ b/src/total_gateway/desktop_api.py
@@ -1181,8 +1181,6 @@ class DesktopApiRouter:
                 headers["X-Tiangong-Communication-Token"] = (
                     self._config.communication_internal_token
                 )
-            import sys
-            print(f"[GW_FORWARD] {route.method} {target} → upstream={route.upstream} host={host}:{port}", file=sys.stderr, flush=True)
             connection.request(
                 route.method,
                 target,
@@ -1208,7 +1206,6 @@ class DesktopApiRouter:
                     raise DesktopApiError(502, "desktop_api.upstream.response_too_large")
                 chunks.append(chunk)
             resp_body = b"".join(chunks)
-            print(f"[GW_FORWARD] response status={response.status} body={resp_body[:500]!r}", file=sys.stderr, flush=True)
             return DesktopProxyResponse(int(response.status), content_type, resp_body)
         except DesktopApiError:
             raise

--- a/src/total_gateway/runtime.py
+++ b/src/total_gateway/runtime.py
@@ -1527,7 +1527,12 @@ class GatewayRuntime:
                 )
                 runtime.cutover.start()
         except Exception:
-            runtime.close()
+            # close() must never mask the original startup failure: if closing
+            # also fails, keep the startup exception as the primary error.
+            try:
+                runtime.close()
+            except Exception:
+                pass
             raise
         return runtime
 

--- a/src/total_gateway/server.py
+++ b/src/total_gateway/server.py
@@ -825,9 +825,6 @@ class GatewayRequestHandler(BaseHTTPRequestHandler):
         return True
 
     def do_GET(self) -> None:
-        import sys, datetime
-        if self.path not in ("/health", "/ready"):
-            print(f"[REQ] {datetime.datetime.now().isoformat()} GET {self.path}", file=sys.stderr, flush=True)
         if self.path == "/health":
             payload = self.gateway.runtime.health_payload()
             self._send_json(200, payload)

--- a/src/world_understanding/cognition/store.py
+++ b/src/world_understanding/cognition/store.py
@@ -459,14 +459,15 @@ class WorldCognitionStore:
             rows = connection.execute(
                 "SELECT payload_json FROM evidence"
             ).fetchall()
+            # Parse each row once; corrupt rows still raise exactly as before.
+            evidence_rows = [
+                CognitionEvidence.model_validate_json(str(row[0])) for row in rows
+            ]
             return tuple(
-                CognitionEvidence.model_validate_json(str(row[0]))
-                for row in rows
+                evidence
+                for evidence in evidence_rows
                 if lineage_root_hash in {
-                    str(item)
-                    for item in CognitionEvidence.model_validate_json(
-                        str(row[0])
-                    ).lineage_root_hashes
+                    str(item) for item in evidence.lineage_root_hashes
                 }
             )
         finally:

--- a/src/world_understanding/semantic/pipeline.py
+++ b/src/world_understanding/semantic/pipeline.py
@@ -182,7 +182,7 @@ class SemanticPipeline:
         except Exception:
             trace = SemanticTrace("MODEL_ERROR", admission.attention_milli, admission.voi_milli, admission.disposition, admission.reason_code,
                                   None, None, SEMANTIC_PROMPT_VERSION, SEMANTIC_SCHEMA_VERSION, 0, 0, 0, refs, None, (), "MODEL_ERROR")
-            return SemanticRunResult("MODEL_ERROR", (), trace, _empty_cost(created_at_ms=created_at_ms, input_count=len(refs), success=Falsl , failure_type="MODEL_ERROR"))
+            return SemanticRunResult("MODEL_ERROR", (), trace, _empty_cost(created_at_ms=created_at_ms, input_count=len(refs), success=False, failure_type="MODEL_ERROR"))
 
         try:
             proposals = parse_semantic_output(response.output_text, refs=refs, prior_indices=bundle.prior_indices)


### PR DESCRIPTION
## Summary

Full-repo quality audit (7 dimensions, ~145k LOC) followed by 31 verified fixes, split by user-approved policy:

**Round 1 — 23 local-safe fixes** (no behavior change on healthy paths): fatal `Falsl` typo, stderr response-body leaks, frozen-build interpreter misuse, falsy-0 LLM budget bug, missing locks/timeouts, sandbox leak, atomic writes, misc dead code/math.

**Round 2 — 8 vitality fixes** (deadlock/liveness/idempotency only, no capability cuts per product policy): cognition lane lease expiry, decider-crash stimulus settlement, cognition backlog drain, memory delete/status retry convergence, feishu/wechat redelivery ACK reuse, priority scale mapping, cancelled-generation outbox settlement.

## Verification

- Clean pre-fix baseline: **3126 passed, 11 skipped** (full suite)
- Post-fix targeted suites: **358+ / 523 passed, 0 failures**
- Source ownership / mirror checks green (synced via `scripts/sync-generated-sources.py --write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)