### PR TITLE
fix: 五系统评价驱动 QC——F1-F6 缺陷修复（P8.1 反思链生产接线）

### DIFF
--- a/LIFE_CAUSAL_ARCHITECTURE_REFACTOR_PLAN.md
+++ b/LIFE_CAUSAL_ARCHITECTURE_REFACTOR_PLAN.md
@@ -1959,3 +1959,25 @@ event → episode → candidate → decision → policy → confirmation → ski
 - app、runtime314、contracts、bootstrap、release manifest 和运维 CLI 已同步；life 22 文件、contracts 26 文件源码/运行时逐文件一致。
 - 质检：P11 专项 12/12；生命门 202/202；完整仓库 unittest 673/673；40 个 JavaScript 文件语法、Python 语法和 `git diff --check` 全部通过。
 - source release manifest hash 为 `1ef133069e1fc40f59ea8c0d5dd3b29f0b3500fea1a23030eb1cb37a9faa3b33`，life-source 发布树 hash 为 `9c9b9ff850c97b8b959211266b7194869c9b151daae43039fc856adeea5422ee`；P0–P11 改造计划闭环。
+
+### 2026-08-21：P8.1 反思链生产接线（P8 收尾补课）
+
+评价驱动 QC 发现：P8 的因果反思与能力学习合约层完整但生产运行时零调用。
+P8.1 以六个独立可测的步骤补上完整链，架构决策如下（代码证据验证）：
+
+- 双体系共存：capability_health 管"当前哪个版本可用"（patch/降级，唯一写
+  pointer），capability_learning 管认知层熟练度（Hoeffding 下界、审查级
+  别），二者写路径零交集；verified+capability 失败 ≥3 且 A0-A2 才自动回滚
+  （熟练度归零），A3+ 只升审查，rollback 不改 pointer。
+- 确定性预测基线：预测 = 真实完成率的毫值映射（无历史回退 700），快照连
+  同依据哈希随 OPEN episode 先于执行落账，事后可审计防编造。
+- 诚实基线：生产无因果假设写入口 → 成功证据 correlation_only、
+  eligible_success=False，能力学习只在证据 eligible 时提交；成功晋升等
+  未来假设管线（认识论分层保持）。
+- 消费只读：面板 reflection_cards 独立键、overlay 双体系综合分排序
+  （max(health_score, proficiency_lcb)）、activity scope 注入最近反思摘要。
+- 并发与容错：链操作全在 runtime 锁内，失败 journal 不重试不外抛；
+  TIANGONG_LIFE_REFLECTION_CHAIN=0 熔断；新 journal 类型由权威重放静默跳过。
+- 三不碰：不进记忆晋升、不产生用户提问、不进 proactive。
+
+详见 `docs/repair-logs/2026-08-21_P8.1_reflection-lane-production-wiring.md`。

--- a/LIFE_REFACTOR_CHECKPOINT.md
+++ b/LIFE_REFACTOR_CHECKPOINT.md
@@ -266,6 +266,34 @@ P8 质检证据：
 - `scripts/check.ps1`：39 个 JavaScript 文件语法通过，Python 语法通过，unittest 650/650 通过。
 - `scripts/sync-life-source.ps1`：18 个文件一致；`git diff --check` 通过。
 
+### 补记：P8.1 反思链生产接线（2026-08-21，P8 收尾补课）
+
+P8 建成了完整的因果反思与能力学习合约层，但生产运行时零调用——反思链从未
+在真实任务/能力执行中运转。P8.1 补上完整链（评价驱动 QC，详见
+`docs/repair-logs/2026-08-21_P8.1_reflection-lane-production-wiring.md`）：
+
+1. store 增 5 个只读方法（零 schema 变更）；`episode_builder.py` 纯函数构建
+   预测快照/链形事件/OPEN episode/结果证据/影响面/九类失败映射。
+2. 任务源四挂点：worker 执行前以活动真实完成历史做确定性预测并 OPEN
+   episode 落账（先于执行、事后可审计）；完成/异常原子闭环反思；陈旧恢复
+   把孤儿 OPEN episode 以 ABORTED 收尾。
+3. 能力源两挂点：pointer.health 成功率做基线预测 + 影响面 + OPEN；执行后
+   闭环反思 → 能力证据 → 学习（仅 eligible 证据；correlation_only 成功按
+   诚实基线不进学习）→ verified 失败累积 ≥3 且 A0-A2 自动回滚（熟练度归
+   零，pointer 不动，双体系互斥）。
+4. 消费面：面板新键 `reflection_cards`；能力 overlay 按双体系综合分
+   `max(health_score_milli, proficiency_lower_bound_milli)` 排序；activity
+   scope 注入最近 5 条反思摘要供决策模型感知。
+5. 熔断 `TIANGONG_LIFE_REFLECTION_CHAIN=0`；所有链操作在 runtime 锁内，
+   失败 journal 不重试；新 journal 类型由权威重放静默跳过。
+6. 同批评价驱动修复：F1 proactive 忽略率门禁（消费 replied 信号）、F2
+   live 模式 UI 开关、F4 motivation_drift 接入自由行动排序、F5 能力正向
+   强化与闲置淘汰、F6 三调度器子预算记账。
+
+质检证据：`test_episode_builder.py` B1-B5、`test_life_reflection_chain_wiring.py`
+T1-T4/C1-C3/P1/P2/S1/S2 全绿；三不碰守卫（不进记忆晋升/不产生用户提问/
+不进 proactive）由测试锁死。
+
 ## 已完成：P9 Skill 双通道合一
 
 已完成内容：

--- a/app/backend/tiangong-backend/v3/hotfix_20260727.py
+++ b/app/backend/tiangong-backend/v3/hotfix_20260727.py
@@ -137,6 +137,15 @@ def _patch_life_autonomy_scheduler() -> None:
     if getattr(original, "_hotfix_20260727", False):
         _log("Bug B 补丁已生效，跳过重复打补丁")
         return
+    # 源码版本守卫：本补丁只为冻结 exe 里的旧版 life_service 服务。若当前
+    # 加载的模块已内置陈旧恢复逻辑且带有后续新增能力（如 _drift_affinity，
+    # 2026-08 引入），说明是更新的原生实现——用本补丁覆盖会把漂移排序、
+    # 反思链接线等新逻辑整体回退（全量测试下 test_foundation_closeout 导入
+    # v3.peizhi 即触发）。原生实现自 2026-07-27 起已包含 Bug B 语义，跳过。
+    if hasattr(cls, "_recover_stale_running_autonomy_tasks") and hasattr(cls, "_drift_affinity"):
+        APPLIED.append("bugB:skipped-native-source-newer")
+        _log("Bug B 跳过：当前 life_service 为更新的原生实现（内置恢复逻辑），猴子补丁不覆盖")
+        return
 
     # 以下别名来自冻结模块本身，保证与冻结版常量/函数完全一致。
     utc_now = er.utc_now

--- a/app/frontend-v2/renderer/plugins/life-panel.mjs
+++ b/app/frontend-v2/renderer/plugins/life-panel.mjs
@@ -518,6 +518,17 @@ const SETTING_FIELDS = [
   { key: "share_daily_limit", label: "每日分享上限", type: "number", min: 0, max: 1000, step: 1, help: "0 表示当天不主动分享。" },
   { key: "share_dnd_start", label: "免打扰开始", type: "time", help: "进入免打扰时段后不主动推送。" },
   { key: "share_dnd_end", label: "免打扰结束", type: "time", help: "离开免打扰时段后恢复正常策略。" },
+  { key: "proactive_enabled", label: "启用主动沟通", type: "checkbox", help: "允许生命在合适时机主动开口；影子模式只记录不发送。" },
+  {
+    key: "proactive_mode",
+    label: "主动沟通模式",
+    type: "select",
+    options: [
+      ["shadow", "影子（只记录不发送）"],
+      ["live", "正式发送"]
+    ],
+    help: "影子模式只把主动消息写入生命记录，不发送到对话；正式发送才会真正开口。"
+  },
   { key: "privacy.redact_llm", label: "模型调用脱敏", type: "checkbox", help: "发送给模型前隐藏受保护内容。" },
   { key: "privacy.redact_share", label: "分享内容脱敏", type: "checkbox", help: "生成对外分享内容前隐藏受保护内容。" }
 ];
@@ -540,6 +551,12 @@ const SETTING_GROUPS = [
     title: "主动分享",
     description: "控制生命信箱总结的发送条件、频率与免打扰时段。",
     fields: ["share_enabled", "share_quiet_if_user_active", "share_min_interval_seconds", "share_hourly_limit", "share_daily_limit", "share_dnd_start", "share_dnd_end"]
+  },
+  {
+    id: "proactive",
+    title: "主动沟通",
+    description: "控制生命主动发消息的总开关与模式；频率、预算与免打扰仍由后端权威设置约束。",
+    fields: ["proactive_enabled", "proactive_mode"]
   },
   {
     id: "privacy",
@@ -846,14 +863,15 @@ async function optionalGatewayPayload(path) {
 }
 
 async function fetchLifePanelPayload(settings = {}) {
-  const [panel, skills, tools] = await Promise.all([
+  const [panel, skills, tools, proactiveStatus] = await Promise.all([
     lifeApi.getPanel(),
     optionalGatewayPayload("/api/v1/v3/skills"),
-    optionalGatewayPayload("/api/v1/v3/tools")
+    optionalGatewayPayload("/api/v1/v3/tools"),
+    lifeApi.getProactiveStatus().catch(() => ({}))
   ]);
   const skillSummary = safeObject(skills.summary);
   const toolSummary = safeObject(tools.summary);
-  return buildLifeViewModel({
+  const view = buildLifeViewModel({
     ...safeObject(panel),
     system_capabilities: {
       skill_count: numberValue(skillSummary.skillCount ?? safeArray(skills.skills).length),
@@ -864,6 +882,8 @@ async function fetchLifePanelPayload(settings = {}) {
       validated: tools.ok !== false && skills.ok !== false
     }
   }, settings);
+  // view-model 是冻结的权威投影；主动沟通实时状态在投影之外，按只读附加。
+  return { ...view, proactive_status: safeObject(proactiveStatus) };
 }
 
 function shellCard({ icon = "sprout", label = "", value = "", hint = "", tone = "" }) {
@@ -1946,6 +1966,22 @@ function renderSettingField(field, settings) {
   `;
 }
 
+function renderProactiveStatus(payload) {
+  const status = safeObject(payload?.proactive_status);
+  if (!Object.keys(status).length) return "";
+  const statusSettings = safeObject(status.settings);
+  const scheduler = safeObject(status.scheduler);
+  const mode = statusSettings.proactive_mode === "live" ? "正式发送" : "影子（只记录不发送）";
+  const parts = [
+    `当前模式：${mode}`,
+    `待处理：${Number(status.pending || 0)} 条`,
+    `今日决策：${Number(scheduler.proactive_model_attempts || 0)} 次`
+  ];
+  const reason = String(scheduler.last_proactive_reason || "").trim();
+  if (reason) parts.push(`最近原因：${reason}`);
+  return `<small class="life-proactive-status">${esc(parts.join(" · "))}</small>`;
+}
+
 export function renderSettings(payload) {
   const settings = safeObject(payload.settings);
   const source = firstText(settings.source, "未挂载");
@@ -1975,6 +2011,7 @@ export function renderSettings(payload) {
                   <header>
                     <h4>${esc(group.title)}</h4>
                     <p>${esc(group.description)}</p>
+                    ${group.id === "proactive" ? renderProactiveStatus(payload) : ""}
                   </header>
                   <div class="life-settings-grid">
                     ${groupFields.map((field) => renderSettingField(field, settings)).join("")}

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "913e1796a6bfa77337e291614a99aa4bb61c9617533bb7b618251bf8a88d5c75",
+  "tree_sha256": "263c49765fdb13598ae11088fddccb44e40bdaa9b915768a5e2099ddf4d5cc13",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "7270c448a8e8141e42eb995b3782b2bd3ab252babd6f6aa70bf3d995d7cac99b",
+  "tree_sha256": "12828c24dc2811e1a1b10cdcbd168503aaaf73352b915c0b3f2e10a6073d3a55",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -1,8 +1,8 @@
 {
-  "file_count": 57,
+  "file_count": 58,
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "263c49765fdb13598ae11088fddccb44e40bdaa9b915768a5e2099ddf4d5cc13",
+  "tree_sha256": "ca2c60e7f9763c9df42326aebe9fc59f5d79772ab1015ea4e13608ca2ec62eed",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "12828c24dc2811e1a1b10cdcbd168503aaaf73352b915c0b3f2e10a6073d3a55",
+  "tree_sha256": "f5f692674e4cb703ebebd32072207d2c336ac4d8ede4dcaa201113e8be37a015",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "f5f692674e4cb703ebebd32072207d2c336ac4d8ede4dcaa201113e8be37a015",
+  "tree_sha256": "913e1796a6bfa77337e291614a99aa4bb61c9617533bb7b618251bf8a88d5c75",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/activity_scope.py
+++ b/app/life-service/runtime314/life_service/activity_scope.py
@@ -183,6 +183,7 @@ def build_activity_scope(
     soul: Mapping[str, Any] | None,
     scope: Mapping[str, Any],
     derivation_store: Any | None = None,
+    reflection_rows: Any | None = None,
 ) -> dict[str, Any]:
     """Build a bounded, canonical evidence projection for one learning turn."""
     memory_rows, memory_terms = _memory_refs(scope)
@@ -289,6 +290,19 @@ def build_activity_scope(
         "long_term_goals": goals,
         "preferences": preferences,
         "motivation_drift": motivation_drift,
+        # P8 反思链最近摘要（可选注入，默认缺省零影响）：让决策模型感知
+        # 上一次行动的预测偏差与教训，只读不改权重。
+        "recent_reflections": [
+            {
+                "reflection_id": str(row.get("reflection_id") or ""),
+                "observed_outcome": str(row.get("observed_outcome") or "")[:400],
+                "prediction_error_milli": int(row.get("prediction_error_milli") or 0),
+                "failure_dimensions": list(row.get("failure_dimensions") or [])[:4],
+                "next_minimal_experiment": str(row.get("next_minimal_experiment") or "")[:200] or None,
+            }
+            for row in (reflection_rows or [])[:5]
+            if isinstance(row, Mapping)
+        ],
         "boundaries": boundaries,
         "rejected_learning_fingerprints": sorted(set(item for item in rejected if item)),
         "repository_evidence": repository_evidence,

--- a/app/life-service/runtime314/life_service/activity_scope.py
+++ b/app/life-service/runtime314/life_service/activity_scope.py
@@ -16,6 +16,7 @@ from contracts import canonical_sha256
 from .panel_projection import (
     boundary_projection,
     long_term_goals,
+    motivation_drift_projection,
     preference_projection,
 )
 
@@ -238,6 +239,30 @@ def build_activity_scope(
     preferences = _canonical_safe(preference_projection(
         list(settings.get("autonomy_activity_types") or [])
     ))
+    # 动机漂移摘要（只读）：让模型在决策时感知"最近行为偏离长期偏好"，
+    # 与自由行动排序的 _drift_affinity 使用同一投影函数，口径一致。
+    completed_catalog = [
+        row for row in (autonomy.get("tasks") or {}).values()
+        if isinstance(row, Mapping)
+        and str(row.get("status") or "") == "completed"
+        and str(row.get("source") or "") == "life_activity_catalog"
+    ]
+    completed_catalog.sort(
+        key=lambda row: (int(row.get("updated_at_ms") or 0), int(row.get("sequence") or 0)),
+        reverse=True,
+    )
+    motivation_drift = [
+        {
+            "title": str(row.get("title") or ""),
+            "status": str(row.get("status") or ""),
+            "drift_detected": bool(row.get("drift_detected")),
+            # canonical 契约禁用 float，漂移分以毫值整数表示（0-1000）。
+            "drift_score_milli": int(round(float(row.get("drift_score") or 0) * 1000)),
+            "summary": str(row.get("summary") or ""),
+            "observed_actions": int(row.get("observed_actions") or 0),
+        }
+        for row in motivation_drift_projection(completed_catalog[:30], preferences)
+    ]
     declared_boundaries = [
         str(value)
         for value in soul_view.get("boundaries", [])
@@ -263,6 +288,7 @@ def build_activity_scope(
         "capabilities": capabilities,
         "long_term_goals": goals,
         "preferences": preferences,
+        "motivation_drift": motivation_drift,
         "boundaries": boundaries,
         "rejected_learning_fingerprints": sorted(set(item for item in rejected if item)),
         "repository_evidence": repository_evidence,

--- a/app/life-service/runtime314/life_service/capability_health.py
+++ b/app/life-service/runtime314/life_service/capability_health.py
@@ -31,6 +31,8 @@ DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
 DEFAULT_MAX_PATCH_ROUNDS = 2
 # 幂等 outcome_id 保留上限（FIFO），避免健康档案无限膨胀。
 SEEN_OUTCOME_CAP = 200
+# 健康分新鲜度半衰期：7 天未用衰减一半（与能力学习的 LEARNING_COOLDOWN_MS 对齐）。
+HEALTH_FRESHNESS_HALF_LIFE_MS = 7 * 86_400_000
 
 
 def canonical_sha256(value: Mapping[str, Any]) -> str:
@@ -62,6 +64,8 @@ def initial_health(artifact_id: str, *, now_ms: int) -> dict[str, Any]:
         "successes": 0,
         "failures": 0,
         "consecutive_failures": 0,
+        "success_streak": 0,
+        "last_success_at_ms": 0,
         "patch_rounds": 0,
         "patch_pending": None,
         "patch_history": [],
@@ -137,9 +141,13 @@ def ingest_outcome(
     if result == "success":
         health["successes"] = int(health.get("successes") or 0) + 1
         health["consecutive_failures"] = 0
+        # 正向强化：连胜与最近成功时间是健康分的组成部分。
+        health["success_streak"] = int(health.get("success_streak") or 0) + 1
+        health["last_success_at_ms"] = occurred_ms
     else:
         health["failures"] = int(health.get("failures") or 0) + 1
         health["consecutive_failures"] = int(health.get("consecutive_failures") or 0) + 1
+        health["success_streak"] = 0
     health["seen_outcome_ids"] = seen
     health["last_outcome_at_ms"] = occurred_ms
     value["health"] = health
@@ -152,6 +160,36 @@ def ingest_outcome(
     ):
         return value, "request_patch", "consecutive_failures"
     return value, "none", "recorded"
+
+
+def health_score_milli(health: Mapping[str, Any], now_ms: int) -> int:
+    """综合健康分（0-1000 毫值），用于能力排序：成功者靠前、闲置者自然沉底。
+
+    组成：保守成功率（Hoeffding 风格下界，样本少时向中性 500 收缩）
+    × 新鲜度（7 天半衰，越久未用越向 500 衰减） + 连胜加成（封顶 100）。
+    """
+    _int(now_ms, "now_ms")
+    uses = int(health.get("uses") or 0)
+    successes = int(health.get("successes") or 0)
+    if uses <= 0:
+        rate = 0.5
+    else:
+        raw = successes / uses
+        # Hoeffding 风格保守下界（α=0.05，ln(1/α)≈3）：样本少时显著低于观测率。
+        penalty = (3.0 / (2.0 * uses)) ** 0.5
+        conservative = max(0.0, raw - penalty)
+        # 向中性 0.5 收缩：样本越少越接近"不知道"，而不是"差"。
+        weight = uses / (uses + 10)
+        rate = 0.5 + weight * (conservative - 0.5)
+    last_ms = int(health.get("last_outcome_at_ms") or 0)
+    if last_ms <= 0:
+        decay = 1.0
+    else:
+        half_lives = max(0, int(now_ms) - last_ms) / HEALTH_FRESHNESS_HALF_LIFE_MS
+        decay = 1.0 - 0.5 ** half_lives
+    rate_milli = 500.0 + (rate - 0.5) * 1000.0 * (1.0 - decay)
+    streak_bonus = min(100, int(health.get("success_streak") or 0) * 10)
+    return max(0, min(1000, int(round(rate_milli)) + streak_bonus))
 
 
 def propose_patch(
@@ -310,6 +348,8 @@ def reactivate_pointer(
     health["consecutive_failures"] = 0
     health["patch_rounds"] = 0
     health["patch_pending"] = None
+    # 重新激活等于重新赢得信任：连胜清零，从头积累。
+    health["success_streak"] = 0
     health["reactivated_at_ms"] = _int(now_ms, "now_ms")
     value["health"] = health
     value["status"] = "active"
@@ -344,6 +384,7 @@ __all__ = [
     "initial_health",
     "attach_health",
     "ingest_outcome",
+    "health_score_milli",
     "propose_patch",
     "settle_patch",
     "degrade_pointer",

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -87,8 +87,10 @@ from .learning_executor import execute_learning_preview
 from .capability_health import (
     DEFAULT_MAX_CONSECUTIVE_FAILURES,
     DEFAULT_MAX_PATCH_ROUNDS,
+    HEALTH_FRESHNESS_HALF_LIFE_MS,
     attach_health,
     degrade_pointer,
+    health_score_milli,
     ingest_outcome,
     propose_patch,
     reactivate_pointer,
@@ -6514,6 +6516,7 @@ class EmbeddedLifeRuntime:
             raise EmbeddedLifeError("life.identity.id_invalid", status=409)
         scope = self._scope_state(life_id)
         pointers = scope.get("capability_pointers") if isinstance(scope.get("capability_pointers"), Mapping) else {}
+        now_ms = time.time_ns() // 1_000_000
         rows = []
         for raw in scope["capabilities"].values():
             if not isinstance(raw, Mapping) or raw.get("status") != "published" or raw.get("kind") not in {"skill", "tool"}:
@@ -6526,8 +6529,29 @@ class EmbeddedLifeRuntime:
             activation_status = str(pointer.get("status") or "pending")
             row["activation_status"] = activation_status
             row["runtime_usable"] = activation_status == "active"
+            health = pointer.get("health") if isinstance(pointer.get("health"), Mapping) else {}
+            row["health_score_milli"] = health_score_milli(health, now_ms)
+            row["last_outcome_at_ms"] = int(health.get("last_outcome_at_ms") or 0)
+            # 闲置标记（派生，不持久化）：>7 天无真实执行结果的 active 能力。
+            # 只影响排序自然沉底与 32 条截断淘汰，不降级、不禁用；补丁验证中的不算闲置。
+            last_outcome_ms = row["last_outcome_at_ms"]
+            row["idle"] = bool(
+                activation_status == "active"
+                and last_outcome_ms > 0
+                and now_ms - last_outcome_ms > HEALTH_FRESHNESS_HALF_LIFE_MS
+                and not health.get("patch_pending")
+            )
             rows.append(row)
-        rows.sort(key=lambda item: (str(item.get("kind")), str(item.get("title")), int(item.get("version") or 0)))
+        # 健康分排序：成功且常用的能力靠前，闲置者自然沉底（32 条截断即淘汰）。
+        rows.sort(
+            key=lambda item: (
+                -int(item.get("health_score_milli") or 0),
+                -int(item.get("last_outcome_at_ms") or 0),
+                str(item.get("kind")),
+                str(item.get("title")),
+                int(item.get("version") or 0),
+            )
+        )
         model_context = []
         active_rows = [row for row in rows if row.get("activation_status") == "active"]
         for row in active_rows[:32]:
@@ -6539,6 +6563,7 @@ class EmbeddedLifeRuntime:
                 "title": row.get("title"),
                 "summary": row.get("summary"),
                 "risk_level": row.get("risk_level"),
+                "health_score_milli": row.get("health_score_milli"),
                 "task_intents": list(spec.get("task_intents") or [])[:24],
                 "required_actions": list(row.get("required_actions") or [])[:16],
                 "steps": list(spec.get("steps") or [])[:16],
@@ -6839,6 +6864,7 @@ class EmbeddedLifeRuntime:
                 key: health.get(key)
                 for key in (
                     "uses", "successes", "failures", "consecutive_failures",
+                    "success_streak", "last_success_at_ms", "last_outcome_at_ms",
                     "patch_rounds", "patch_history",
                 )
             },

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -748,6 +748,9 @@ class EmbeddedLifeRuntime:
                 "proactive_min_utility_lcb_milli": 120,
                 "proactive_min_margin_milli": 80,
                 "proactive_reply_link_window_seconds": 21600,
+                # F1 忽略率门禁：用户持续不回复时抬高开口门槛（0 = 禁用门禁）。
+                "proactive_engagement_window_size": 8,
+                "proactive_min_reply_rate_milli": 200,
                 "learned_boundary_rules": [],
             },
             "inbox": [],
@@ -3301,6 +3304,25 @@ class EmbeddedLifeRuntime:
             and str(row.get("reason") or "") == "life.proactive.native"
             and int(row.get("created_at_ms") or 0) > 0
         ]
+        context_settings = scope.get("settings") if isinstance(scope.get("settings"), Mapping) else {}
+        # F1：投递结果投影（replied/acked）供忽略率门禁消费。仍在回复链接
+        # 窗口内的投递不算数——用户还来得及回，不能提前记为忽略。
+        reply_window_ms = max(
+            60, int(context_settings.get("proactive_reply_link_window_seconds") or 21600)
+        ) * 1000
+        delivery_outcomes = [
+            {
+                "created_at_ms": int(row.get("created_at_ms") or 0),
+                "candidate_kind": str(row.get("candidate_kind") or ""),
+                "replied": bool(row.get("replied")),
+                "acked": bool(row.get("acked")),
+            }
+            for row in scope.get("proactive_chats", [])
+            if isinstance(row, Mapping)
+            and str(row.get("reason") or "") == "life.proactive.native"
+            and int(row.get("created_at_ms") or 0) > 0
+            and now_ms - int(row.get("created_at_ms") or 0) > reply_window_ms
+        ]
         affect = scope.get("affect") if isinstance(scope.get("affect"), Mapping) else {}
         return {
             "schema": "tiangong.life.initiative-context.v1",
@@ -3311,6 +3333,7 @@ class EmbeddedLifeRuntime:
             "last_user_activity_at_ms": int(scheduler.get("last_user_activity_at_ms") or 0),
             "last_user_run_id": str(scheduler.get("last_user_run_id") or ""),
             "recent_delivery_times_ms": deliveries[-64:],
+            "recent_delivery_outcomes": delivery_outcomes[-64:],
             "observations": observations[:40],
             "recent_tasks": task_projection,
             "relationships": self._project_proactive_relationships(life_id=life_id),
@@ -8722,6 +8745,8 @@ class EmbeddedLifeRuntime:
                         "proactive_min_utility_lcb_milli",
                         "proactive_min_margin_milli",
                         "proactive_reply_link_window_seconds",
+                        "proactive_engagement_window_size",
+                        "proactive_min_reply_rate_milli",
                     }
                     # Preserve namespaced/extension settings used by plugins and
                     # tests.  Known safety-sensitive keys are strongly typed;
@@ -8787,6 +8812,8 @@ class EmbeddedLifeRuntime:
                         "proactive_min_utility_lcb_milli": (0, 4000),
                         "proactive_min_margin_milli": (0, 4000),
                         "proactive_reply_link_window_seconds": (60, 604800),
+                        "proactive_engagement_window_size": (0, 64),
+                        "proactive_min_reply_rate_milli": (0, 1000),
                     }
                     for key, (minimum, maximum) in limits.items():
                         if key not in updates:

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -707,6 +707,14 @@ class EmbeddedLifeRuntime:
                 "heartbeat_enabled": True,
                 "llm_daily_budget": 20,
                 "llm_daily_attempt_budget": 30,
+                # 学习/自我迭代/能力补丁三个调度器各自的子预算：与 proactive
+                # 同样隔离于全局生命模型预算，防止单一子系统吃满整天的量。
+                "learning_llm_daily_budget": 6,
+                "learning_llm_daily_attempt_budget": 8,
+                "self_iteration_llm_daily_budget": 4,
+                "self_iteration_llm_daily_attempt_budget": 6,
+                "capability_patch_llm_daily_budget": 6,
+                "capability_patch_llm_daily_attempt_budget": 8,
                 "share_enabled": True,
                 "share_quiet_if_user_active": True,
                 "share_min_interval_seconds": 2700,
@@ -785,6 +793,24 @@ class EmbeddedLifeRuntime:
                 "proactive_model_failures": 0,
                 "proactive_model_timeouts": 0,
                 "proactive_model_skipped": 0,
+                "learning_model_budget_date": "",
+                "learning_model_attempts": 0,
+                "learning_model_successes": 0,
+                "learning_model_failures": 0,
+                "learning_model_timeouts": 0,
+                "learning_model_skipped": 0,
+                "self_iteration_model_budget_date": "",
+                "self_iteration_model_attempts": 0,
+                "self_iteration_model_successes": 0,
+                "self_iteration_model_failures": 0,
+                "self_iteration_model_timeouts": 0,
+                "self_iteration_model_skipped": 0,
+                "capability_patch_model_budget_date": "",
+                "capability_patch_model_attempts": 0,
+                "capability_patch_model_successes": 0,
+                "capability_patch_model_failures": 0,
+                "capability_patch_model_timeouts": 0,
+                "capability_patch_model_skipped": 0,
                 "last_user_run_id": "",
             },
             "updated_at": utc_now(),
@@ -2923,6 +2949,11 @@ class EmbeddedLifeRuntime:
         if not callable(getattr(self, "_learning_decider", None)):
             scheduler["last_learning_decision_error"] = "life.learning.model_bridge_unavailable"
             return
+        if not self._reserve_sub_model_call_locked(scheduler=scheduler, settings=settings, pool="learning"):
+            scheduler["last_learning_decision_at_ms"] = now_ms
+            scheduler["last_learning_decision_error"] = "life.learning.model_budget_exhausted"
+            self._persist(life_id)
+            return
         scheduler["learning_decision_inflight"] = True
         scheduler["last_learning_decision_at_ms"] = now_ms
         scheduler["last_learning_decision_error"] = ""
@@ -2934,6 +2965,11 @@ class EmbeddedLifeRuntime:
                 decision = self._learning_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("learning model decision is invalid")
+                with self._lock:
+                    self._account_sub_model_success_locked(
+                        self._scope_state(life_id).setdefault("scheduler", {}),
+                        pool="learning",
+                    )
                 target = str(decision.get("target") or decision.get("artifact_kind") or "").strip().casefold()
                 with self._lock:
                     if target in {"", "none", "no_learning", "no-learning"}:
@@ -2971,7 +3007,13 @@ class EmbeddedLifeRuntime:
                 # instead of recording only the exception type.
                 detail = re.sub(r"\s+", " ", str(exc)).strip()[:160]
                 with self._lock:
-                    self._scope_state(life_id).setdefault("scheduler", {})[
+                    scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
+                    self._account_sub_model_failure_locked(
+                        scheduler_state,
+                        pool="learning",
+                        timeout=isinstance(exc, TimeoutError),
+                    )
+                    scheduler_state[
                         "last_learning_decision_error"
                     ] = f"life.learning.decision_failed:{type(exc).__name__}:{detail}"
             finally:
@@ -3005,6 +3047,11 @@ class EmbeddedLifeRuntime:
         if not callable(getattr(self, "_self_iteration_decider", None)):
             scheduler["last_self_iteration_decision_error"] = "life.self_iteration.model_bridge_unavailable"
             return
+        if not self._reserve_sub_model_call_locked(scheduler=scheduler, settings=settings, pool="self_iteration"):
+            scheduler["last_self_iteration_decision_at_ms"] = now_ms
+            scheduler["last_self_iteration_decision_error"] = "life.self_iteration.model_budget_exhausted"
+            self._persist(life_id)
+            return
         scheduler["self_iteration_decision_inflight"] = True
         scheduler["last_self_iteration_decision_at_ms"] = now_ms
         scheduler["last_self_iteration_decision_error"] = ""
@@ -3016,6 +3063,11 @@ class EmbeddedLifeRuntime:
                 decision = self._self_iteration_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("self-iteration model decision is invalid")
+                with self._lock:
+                    self._account_sub_model_success_locked(
+                        self._scope_state(life_id).setdefault("scheduler", {}),
+                        pool="self_iteration",
+                    )
                 target = str(decision.get("target") or "").strip().casefold()
                 with self._lock:
                     if target in {"", "none", "no_upgrade", "no-upgrade"}:
@@ -3028,7 +3080,13 @@ class EmbeddedLifeRuntime:
             except Exception as exc:
                 detail = re.sub(r"\s+", " ", str(exc)).strip()[:160]
                 with self._lock:
-                    self._scope_state(life_id).setdefault("scheduler", {})[
+                    scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
+                    self._account_sub_model_failure_locked(
+                        scheduler_state,
+                        pool="self_iteration",
+                        timeout=isinstance(exc, TimeoutError),
+                    )
+                    scheduler_state[
                         "last_self_iteration_decision_error"
                     ] = f"life.self_iteration.decision_failed:{type(exc).__name__}:{detail}"
             finally:
@@ -3319,6 +3377,117 @@ class EmbeddedLifeRuntime:
         scheduler["model_attempts"] = int(scheduler.get("model_attempts") or 0) + 1
         scheduler["proactive_model_attempts"] = int(scheduler.get("proactive_model_attempts") or 0) + 1
         return True
+
+    # 学习/自我迭代/能力补丁三个调度器的子预算隔离：与 proactive 同模式，
+    # 全局池 + 子池双检查双累加，防止任何一个子系统占满全局生命模型预算。
+    _MODEL_SUB_BUDGET_POOLS = {
+        "learning": {
+            "prefix": "learning_model_",
+            "success_key": "learning_llm_daily_budget",
+            "success_default": 6,
+            "attempt_key": "learning_llm_daily_attempt_budget",
+            "attempt_default": 8,
+        },
+        "self_iteration": {
+            "prefix": "self_iteration_model_",
+            "success_key": "self_iteration_llm_daily_budget",
+            "success_default": 4,
+            "attempt_key": "self_iteration_llm_daily_attempt_budget",
+            "attempt_default": 6,
+        },
+        "capability_patch": {
+            "prefix": "capability_patch_model_",
+            "success_key": "capability_patch_llm_daily_budget",
+            "success_default": 6,
+            "attempt_key": "capability_patch_llm_daily_attempt_budget",
+            "attempt_default": 8,
+        },
+    }
+
+    def _reset_sub_model_budget_if_needed(self, scheduler: dict[str, Any], *, pool: str) -> None:
+        config = self._MODEL_SUB_BUDGET_POOLS[pool]
+        prefix = str(config["prefix"])
+        budget_day = utc_now()[:10]
+        # Preserve the existing global Life-model hard cap.
+        if str(scheduler.get("model_budget_date") or "") != budget_day:
+            scheduler.update({
+                "model_budget_date": budget_day,
+                "model_attempts": 0,
+                "model_successes": 0,
+                "model_failures": 0,
+                "model_timeouts": 0,
+                "model_skipped": 0,
+            })
+        if str(scheduler.get(f"{prefix}budget_date") or "") != budget_day:
+            scheduler.update({
+                f"{prefix}budget_date": budget_day,
+                f"{prefix}attempts": 0,
+                f"{prefix}successes": 0,
+                f"{prefix}failures": 0,
+                f"{prefix}timeouts": 0,
+                f"{prefix}skipped": 0,
+            })
+
+    def _sub_model_budget_exhausted(
+        self,
+        scheduler: dict[str, Any],
+        *,
+        settings: Mapping[str, Any],
+        pool: str,
+    ) -> bool:
+        """Check-only peek (no counter changes); performs the daily reset."""
+        config = self._MODEL_SUB_BUDGET_POOLS[pool]
+        prefix = str(config["prefix"])
+        self._reset_sub_model_budget_if_needed(scheduler, pool=pool)
+        global_success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
+        global_attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
+        sub_success_limit = self._daily_limit_setting(settings, str(config["success_key"]), int(config["success_default"]))
+        sub_attempt_limit = self._daily_limit_setting(settings, str(config["attempt_key"]), int(config["attempt_default"]))
+        return (
+            (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
+            or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
+            or (sub_success_limit and int(scheduler.get(f"{prefix}successes") or 0) >= sub_success_limit)
+            or (sub_attempt_limit and int(scheduler.get(f"{prefix}attempts") or 0) >= sub_attempt_limit)
+        )
+
+    def _reserve_sub_model_call_locked(
+        self,
+        *,
+        scheduler: dict[str, Any],
+        settings: Mapping[str, Any],
+        pool: str,
+    ) -> bool:
+        """Reserve one real LLM call against both the global and the sub pool."""
+        config = self._MODEL_SUB_BUDGET_POOLS[pool]
+        prefix = str(config["prefix"])
+        if self._sub_model_budget_exhausted(scheduler, settings=settings, pool=pool):
+            scheduler["model_skipped"] = int(scheduler.get("model_skipped") or 0) + 1
+            scheduler[f"{prefix}skipped"] = int(scheduler.get(f"{prefix}skipped") or 0) + 1
+            return False
+        scheduler["model_attempts"] = int(scheduler.get("model_attempts") or 0) + 1
+        scheduler[f"{prefix}attempts"] = int(scheduler.get(f"{prefix}attempts") or 0) + 1
+        return True
+
+    def _account_sub_model_success_locked(self, scheduler: dict[str, Any], *, pool: str) -> None:
+        prefix = str(self._MODEL_SUB_BUDGET_POOLS[pool]["prefix"])
+        self._reset_sub_model_budget_if_needed(scheduler, pool=pool)
+        scheduler["model_successes"] = int(scheduler.get("model_successes") or 0) + 1
+        scheduler[f"{prefix}successes"] = int(scheduler.get(f"{prefix}successes") or 0) + 1
+
+    def _account_sub_model_failure_locked(
+        self,
+        scheduler: dict[str, Any],
+        *,
+        pool: str,
+        timeout: bool = False,
+    ) -> None:
+        prefix = str(self._MODEL_SUB_BUDGET_POOLS[pool]["prefix"])
+        self._reset_sub_model_budget_if_needed(scheduler, pool=pool)
+        scheduler["model_failures"] = int(scheduler.get("model_failures") or 0) + 1
+        scheduler[f"{prefix}failures"] = int(scheduler.get(f"{prefix}failures") or 0) + 1
+        if timeout:
+            scheduler["model_timeouts"] = int(scheduler.get("model_timeouts") or 0) + 1
+            scheduler[f"{prefix}timeouts"] = int(scheduler.get(f"{prefix}timeouts") or 0) + 1
 
     def _schedule_native_proactive(self, *, life_id: str) -> None:
         """Schedule the sole post-P15 proactive producer without blocking heartbeat."""
@@ -7146,6 +7315,12 @@ class EmbeddedLifeRuntime:
             return
         if not callable(getattr(self, "_capability_patch_decider", None)):
             return
+        # 子池已耗尽时不再起线程；真正的按次记账在 worker 内每个补丁目标前完成。
+        if self._sub_model_budget_exhausted(scheduler, settings=scope_state["settings"], pool="capability_patch"):
+            scheduler["last_capability_health_at_ms"] = now_ms
+            scheduler["last_capability_health_error"] = "life.capability_patch.model_budget_exhausted"
+            self._persist(life_id)
+            return
         scheduler["capability_health_inflight"] = True
         scheduler["last_capability_health_at_ms"] = now_ms
         self._persist(life_id)
@@ -7179,10 +7354,39 @@ class EmbeddedLifeRuntime:
                         pointer=target["pointer"],
                         scope=self._scope_state(life_id),
                     )
-                    decision = self._capability_patch_decider(material)
-                    if not isinstance(decision, Mapping):
+                    # 每个补丁目标一次真实的模型调用，逐一记账。
+                    with self._lock:
+                        scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
+                        if not self._reserve_sub_model_call_locked(
+                            scheduler=scheduler_state,
+                            settings=self._scope_state(life_id)["settings"],
+                            pool="capability_patch",
+                        ):
+                            scheduler_state["last_capability_health_error"] = "life.capability_patch.model_budget_exhausted"
+                            self._persist(life_id)
+                            return
+                    try:
+                        decision = self._capability_patch_decider(material)
+                        valid_decision = isinstance(decision, Mapping)
+                    except Exception:
+                        with self._lock:
+                            self._account_sub_model_failure_locked(
+                                self._scope_state(life_id).setdefault("scheduler", {}),
+                                pool="capability_patch",
+                            )
+                        continue
+                    if not valid_decision:
+                        with self._lock:
+                            self._account_sub_model_failure_locked(
+                                self._scope_state(life_id).setdefault("scheduler", {}),
+                                pool="capability_patch",
+                            )
                         continue
                     with self._lock:
+                        self._account_sub_model_success_locked(
+                            self._scope_state(life_id).setdefault("scheduler", {}),
+                            pool="capability_patch",
+                        )
                         proposed = self._capability_patch_propose(
                             {"life_id": life_id, "artifact_id": artifact["artifact_id"], "actor": "life_health"},
                             decision=decision,
@@ -8459,6 +8663,12 @@ class EmbeddedLifeRuntime:
                         "heartbeat_enabled",
                         "llm_daily_budget",
                         "llm_daily_attempt_budget",
+                        "learning_llm_daily_budget",
+                        "learning_llm_daily_attempt_budget",
+                        "self_iteration_llm_daily_budget",
+                        "self_iteration_llm_daily_attempt_budget",
+                        "capability_patch_llm_daily_budget",
+                        "capability_patch_llm_daily_attempt_budget",
                         "share_enabled",
                         "share_quiet_if_user_active",
                         "share_min_interval_seconds",

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -2469,6 +2469,58 @@ class EmbeddedLifeRuntime:
                     affinity[activity_id] = weighted
         return affinity
 
+    # 动机漂移：最近行动分布偏离长期偏好时，给欠采样活动加分，把自由行动
+    # 拉回用户配置的方向。只读（不写回 kind_weights 等用户可见配置）。
+    _DRIFT_AFFINITY_COEFFICIENT = 150
+    _DRIFT_AFFINITY_MIN_SAMPLE = 10
+
+    def _drift_affinity(self, scope: Mapping[str, Any]) -> dict[str, int]:
+        """Boost under-sampled activities when recent actions drift from preferences."""
+        autonomy = scope.get("autonomy") if isinstance(scope.get("autonomy"), Mapping) else {}
+        completed = [
+            row for row in (autonomy.get("tasks") or {}).values()
+            if isinstance(row, Mapping)
+            and str(row.get("status") or "") == "completed"
+            and str(row.get("source") or "") == "life_activity_catalog"
+        ]
+        completed.sort(
+            key=lambda row: (int(row.get("updated_at_ms") or 0), int(row.get("sequence") or 0)),
+            reverse=True,
+        )
+        settings = scope.get("settings") if isinstance(scope.get("settings"), Mapping) else {}
+        preferences = preference_projection(sorted({
+            str(value)
+            for value in settings.get("autonomy_activity_types") or []
+            if str(value)
+        }))
+        rows = motivation_drift_projection(completed[:30], preferences)
+        if not rows:
+            return {}
+        row = rows[0]
+        # 样本不足时漂移抖动大（insufficient_evidence 或低于最小样本），不加分。
+        if int(row.get("observed_actions") or 0) < self._DRIFT_AFFINITY_MIN_SAMPLE:
+            return {}
+        if not row.get("drift_detected"):
+            return {}
+        observed = row.get("observed_distribution")
+        observed = observed if isinstance(observed, Mapping) else {}
+        expected = preferences.get("kind_weights")
+        expected = expected if isinstance(expected, Mapping) else {}
+        observed_total = sum(int(value or 0) for value in observed.values()) or 1
+        expected_total = sum(max(0.0, float(value or 0)) for value in expected.values()) or 1.0
+        score = min(1.0, max(0.0, float(row.get("drift_score") or 0)))
+        affinity: dict[str, int] = {}
+        for activity_id, weight in expected.items():
+            gap = max(
+                0.0,
+                max(0.0, float(weight or 0)) / expected_total
+                - int(observed.get(activity_id) or 0) / observed_total,
+            )
+            bonus = int(score * gap * self._DRIFT_AFFINITY_COEFFICIENT)
+            if bonus > 0:
+                affinity[str(activity_id)] = bonus
+        return affinity
+
     def _schedule_autonomous_activity_decision(self, *, life_id: str) -> None:
         """Execute one catalog activity through the gateway model bridge.
 
@@ -2548,11 +2600,15 @@ class EmbeddedLifeRuntime:
         ]
         pool = due if due else eligible
         desire = self._desire_affinity(scope)
+        # 漂移加分只在自由行动分支生效：到点计划保持"高优先级先做"的确定性，
+        # 不被欠采样补偿改写次序。
+        drift = {} if due else self._drift_affinity(scope)
         pool.sort(
             key=lambda task: (
                 -(
                     int(task.get("priority") or 0)
                     + desire.get(str(task.get("activity_id") or ""), 0)
+                    + drift.get(str(task.get("activity_id") or ""), 0)
                 ),
                 int(task.get("sequence") or 0),
                 str(task.get("task_id") or ""),

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -27,12 +27,14 @@ from contracts import (
     CausalContextItem,
     CausalEpisodeVNext,
     LifeAuthorityHead,
+    LifeEventEnvelope,
     LifeRevisionVector,
     RootExperienceHead,
     RunLifeBinding,
     canonical_json_bytes,
     canonical_sha256,
 )
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from .autonomous_tasks import (
     ACTIVE_TASK_STATES,
@@ -62,6 +64,7 @@ from .legacy_fusion import default_body, default_schedule, normalize_body, norma
 from .panel_projection import (
     action_value_projection,
     boundary_projection,
+    capability_profile_projection,
     catalog_tasks_for_day,
     fallback_context_projection,
     long_term_goals,
@@ -70,6 +73,7 @@ from .panel_projection import (
     preference_projection,
     record_day,
     records_for_day,
+    reflection_card_projection,
     reflection_projection,
 )
 from .artifact_executor import (
@@ -96,6 +100,19 @@ from .capability_health import (
     reactivate_pointer,
     runtime_usable,
     settle_patch,
+)
+from .capability_learning import build_capability_evidence
+from .episode_builder import (
+    build_action_impact,
+    build_life_event,
+    build_open_episode,
+    build_outcome_evidence,
+    build_prediction,
+    failure_category_from_error,
+    failure_category_from_step_error,
+    fingerprint,
+    observed_quality_from_steps,
+    prediction_from_snapshot,
 )
 from .memory_classification import classify_memory, normalize_relations
 from .memory_lifecycle import advance_lifecycle, initial_lifecycle, normalize_lifecycle, recall_lifecycle
@@ -2441,12 +2458,528 @@ class EmbeddedLifeRuntime:
                         f"{recovered.get('attempt_count', 0)}"
                     ),
                 )
+                # F3 挂点4：陈旧恢复 → 仍 OPEN 的 episode 以 ABORTED 收尾，消孤儿。
+                with self._lock:
+                    self._abort_runtime_episode_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=task_id,
+                        reason="life.autonomy.stale_running_recovered",
+                    )
                 self._persist(life_id)
             except Exception:
                 scope["autonomy"] = before
                 raise
             recovered_count += 1
         return recovered_count
+
+    # ---------- P8 反思链生产接线（F3：任务/能力双源，事前预测先落账） ----------
+    # 决策 E：所有 life_events 链操作（读 head→构造→append）在 self._lock 内；
+    # 任一环节失败即放弃该次反思并 journal（life.episode.failed），绝不向上抛。
+
+    _REFLECTION_EPISODE_REGISTRY_CAP = 32
+
+    def _reflection_chain_enabled(self) -> bool:
+        """熔断开关：TIANGONG_LIFE_REFLECTION_CHAIN=0 时整条反思链停摆。"""
+        return str(os.environ.get("TIANGONG_LIFE_REFLECTION_CHAIN") or "1").strip() != "0"
+
+    def _recent_reflection_rows(self, life_id: str) -> list[Any] | None:
+        """最近反思卡（供 activity scope 注入；store 不可用时返回 None 零影响）。"""
+        try:
+            return list(self._contract_store().list_reflection_cards(life_id, limit=5))
+        except Exception:
+            return None
+
+    def _reflection_signer(self) -> tuple[str, Any]:
+        """进程内 Ed25519 写者。链只校验哈希连续性不验签；密钥随进程。"""
+        key = getattr(self, "_reflection_signer_key", None)
+        if key is None:
+            key = Ed25519PrivateKey.generate()
+            self._reflection_signer_key = key
+        return "life_reflection_chain", lambda digest: key.sign(digest).hex()
+
+    def _reflection_journal_failure(
+        self, life_id: str, phase: str, exc: BaseException | None
+    ) -> None:
+        try:
+            self.system.journal.append(
+                life_id,
+                "life.episode.failed",
+                {
+                    "phase": str(phase),
+                    "error_type": type(exc).__name__ if exc else "",
+                    "detail": re.sub(r"\s+", " ", str(exc or ""))[:160],
+                },
+                actor="life_reflection",
+                idempotency_key=(
+                    f"life.reflection.failed:{phase}:{time.time_ns() // 1_000_000}"
+                ),
+            )
+        except Exception:
+            pass  # 观测性日志失败不得影响主流程
+
+    def _runtime_life_event_locked(
+        self,
+        *,
+        life_id: str,
+        event_kind: str,
+        content: Mapping[str, Any],
+        correlation_id: str,
+        causation_id: str | None = None,
+    ) -> LifeEventEnvelope | None:
+        """向权威链追加一个反思链事件；不可用/失败时返回 None。"""
+        try:
+            store = self._contract_store()
+            head = store.life_event_head(life_id)
+            now_ms = time.time_ns() // 1_000_000
+            key_id, sign = self._reflection_signer()
+            event = build_life_event(
+                life_id=life_id,
+                sequence=1 if head is None else head.sequence + 1,
+                writer_epoch=1 if head is None else head.writer_epoch,
+                previous_event_hash=None if head is None else head.event_hash,
+                event_kind=event_kind,
+                content=content,
+                occurred_at_ms=now_ms,
+                observed_at_ms=now_ms,
+                correlation_id=correlation_id,
+                causation_id=causation_id,
+                signer_key_id=key_id,
+                sign=sign,
+            )
+            store.append_event(event)
+            return event
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, f"event:{event_kind}", exc)
+            return None
+
+    def _open_runtime_episode_locked(
+        self,
+        *,
+        life_id: str,
+        source: str,
+        ref_id: str,
+        event_kind: str,
+        intention: str,
+        context_sha256: str,
+        prediction: Any,
+        action_risk: str,
+        candidate_action_ids: tuple[str, ...] = (),
+        selected_action_id: str | None = None,
+        started_event: LifeEventEnvelope | None = None,
+        registry_extra: Mapping[str, Any] | None = None,
+    ) -> str | None:
+        """事前落账：started 事件 → OPEN episode → 注册表登记（FIFO 32）。"""
+        if not self._reflection_chain_enabled():
+            return None
+        try:
+            started = started_event or self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind=event_kind,
+                content={
+                    "ref": ref_id,
+                    "source": source,
+                    "intention": intention[:800],
+                    "predicted_success_milli": prediction.predicted_success_milli,
+                    "prediction_snapshot_sha256": prediction.snapshot_sha256,
+                    "action_risk": action_risk,
+                },
+                correlation_id=f"{source}:{ref_id}",
+            )
+            if started is None:
+                return None
+            episode = build_open_episode(
+                life_id=life_id,
+                trigger_event_ids=[started.event_id],
+                context_state_hashes=[context_sha256 or started.event_hash],
+                intention=intention[:20_000],
+                prediction=prediction,
+                candidate_action_ids=candidate_action_ids,
+                selected_action_id=selected_action_id,
+                created_at_ms=time.time_ns() // 1_000_000,
+            )
+            self._contract_store().put_causal_episode(episode)
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "open", exc)
+            return None
+        scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+        registry = [
+            row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+        ]
+        registry.append({
+            "source": source,
+            "ref": ref_id,
+            "episode_id": episode.episode_id,
+            "correlation_id": f"{source}:{ref_id}",
+            "predicted_success_milli": prediction.predicted_success_milli,
+            "prediction_snapshot": prediction.snapshot,
+            "context_sha256": context_sha256,
+            "action_risk": action_risk,
+            "opened_at_ms": time.time_ns() // 1_000_000,
+            **(dict(registry_extra) if registry_extra else {}),
+        })
+        scheduler["open_episodes"] = registry[-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+        try:
+            self.system.journal.append(
+                life_id,
+                "life.episode.opened",
+                {"episode_id": episode.episode_id, "source": source, "ref": ref_id},
+                actor="life_reflection",
+                idempotency_key=f"life.reflection.open:{episode.episode_id}",
+            )
+        except Exception:
+            pass
+        self._persist(life_id)
+        return episode.episode_id
+
+    def _commit_runtime_reflection_locked(
+        self,
+        *,
+        life_id: str,
+        source: str,
+        ref_id: str,
+        outcome_status: str,
+        observed_outcome: str,
+        observed_quality_milli: int,
+        completion_decision: Mapping[str, Any],
+        terminal_fact_parts: Mapping[str, Any],
+        event_kind: str,
+        failure_category: str | None = None,
+        journal_event: str = "life.episode.committed",
+    ) -> None:
+        """事后收尾：outcome 事件 → 结果证据 → 原子闭环反思 → 注册表移除。"""
+        if not self._reflection_chain_enabled():
+            return
+        try:
+            scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+            registry = [
+                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+            ]
+            entry = next(
+                (
+                    row for row in registry
+                    if str(row.get("source") or "") == source
+                    and str(row.get("ref") or "") == ref_id
+                ),
+                None,
+            )
+            if entry is None:
+                return  # 没有事前落账（链路关闭或 opening 失败），无从收尾
+            outcome_event = self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind=event_kind,
+                content={
+                    "ref": ref_id,
+                    "source": source,
+                    "outcome_status": outcome_status,
+                    "quality_milli": observed_quality_milli,
+                    **{str(key): value for key, value in terminal_fact_parts.items()},
+                },
+                correlation_id=str(entry.get("correlation_id") or f"{source}:{ref_id}"),
+            )
+            if outcome_event is None:
+                return
+            prediction = prediction_from_snapshot(entry.get("prediction_snapshot") or {})
+            outcome = build_outcome_evidence(
+                life_id=life_id,
+                episode_id=str(entry.get("episode_id") or ""),
+                outcome_status=outcome_status,
+                observed_outcome=observed_outcome[:50_000],
+                observed_quality_milli=observed_quality_milli,
+                prediction=prediction,
+                completion_decision_sha256=fingerprint(dict(completion_decision)),
+                terminal_fact_hashes=[outcome_event.event_hash],
+                outcome_event_ids=[outcome_event.event_id],
+                context_fingerprint_sha256=str(entry.get("context_sha256") or ""),
+                action_risk=str(entry.get("action_risk") or "A1"),
+                failure_category=failure_category,
+                occurred_at_ms=time.time_ns() // 1_000_000,
+            )
+            result = self._contract_store().commit_episode_reflection(
+                outcome, now_ms=time.time_ns() // 1_000_000
+            )
+            scheduler["open_episodes"] = [
+                row for row in registry if row is not entry
+            ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+            try:
+                self.system.journal.append(
+                    life_id,
+                    journal_event,
+                    {
+                        "episode_id": entry.get("episode_id"),
+                        "source": source,
+                        "ref": ref_id,
+                        "outcome_status": outcome_status,
+                        "reflection_id": result.reflection.reflection_id,
+                    },
+                    actor="life_reflection",
+                    idempotency_key=f"life.reflection.commit:{entry.get('episode_id')}",
+                )
+            except Exception:
+                pass
+            self._persist(life_id)
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "commit", exc)
+
+    def _abort_runtime_episode_locked(
+        self, *, life_id: str, source: str, ref_id: str, reason: str
+    ) -> None:
+        """陈旧恢复：仍 OPEN 的 episode 以 ABORTED 收尾，消除孤儿。"""
+        if not self._reflection_chain_enabled():
+            return
+        self._commit_runtime_reflection_locked(
+            life_id=life_id,
+            source=source,
+            ref_id=ref_id,
+            outcome_status="aborted",
+            observed_outcome=f"运行中断，任务未收尾：{reason}"[:50_000],
+            observed_quality_milli=0,
+            completion_decision={"ref": ref_id, "status": "aborted", "reason": reason},
+            terminal_fact_parts={"abort_reason": reason[:200]},
+            event_kind=f"{source}.attempt.aborted",
+        )
+
+    def _open_capability_episode_locked(
+        self,
+        *,
+        life_id: str,
+        artifact: Mapping[str, Any],
+        pointer: Mapping[str, Any],
+        execution_id: str,
+    ) -> None:
+        """F3 挂点5：能力执行前 → health 基线预测 + started 事件 + 影响面 + OPEN episode。"""
+        if not self._reflection_chain_enabled():
+            return
+        try:
+            health = pointer.get("health") if isinstance(pointer.get("health"), Mapping) else {}
+            prediction = build_prediction(
+                basis_inputs={
+                    "source": "capability",
+                    "artifact_id": str(artifact.get("artifact_id") or ""),
+                    "version": str(artifact.get("version") or ""),
+                },
+                successes=int(health.get("successes") or 0),
+                uses=int(health.get("uses") or 0),
+            )
+            started = self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind="capability.invoke.started",
+                content={
+                    "execution_id": execution_id,
+                    "artifact_id": str(artifact.get("artifact_id") or ""),
+                    "predicted_success_milli": prediction.predicted_success_milli,
+                    "prediction_snapshot_sha256": prediction.snapshot_sha256,
+                    "action_risk": str(artifact.get("risk_level") or "A3"),
+                },
+                correlation_id=f"capability:{execution_id}",
+            )
+            if started is None:
+                return
+            impact = build_action_impact(
+                life_id=life_id,
+                action_id=str(artifact.get("artifact_id") or ""),
+                risk_class=str(artifact.get("risk_level") or "A3"),
+                source_event_ids=[started.event_id],
+                created_at_ms=time.time_ns() // 1_000_000,
+            )
+            self._contract_store().put_action_impact(impact)
+            self._open_runtime_episode_locked(
+                life_id=life_id,
+                source="capability",
+                ref_id=execution_id,
+                event_kind="capability.invoke.started",
+                intention=str(artifact.get("summary") or artifact.get("title") or "能力执行")[:20_000],
+                context_sha256=str(artifact.get("artifact_sha256") or ""),
+                prediction=prediction,
+                action_risk=str(artifact.get("risk_level") or "A3"),
+                candidate_action_ids=(str(artifact.get("artifact_id") or ""),),
+                selected_action_id=str(artifact.get("artifact_id") or ""),
+                started_event=started,
+                registry_extra={
+                    "capability_id": str(artifact.get("artifact_id") or ""),
+                    "capability_version": str(artifact.get("version") or ""),
+                    "capability_scope": str(artifact.get("title") or ""),
+                    "action_impact": impact.model_dump(mode="json"),
+                },
+            )
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "capability_open", exc)
+
+    # 决策 A：verified + capability 归因的失败证据累积到该阈值且影响面
+    # A0-A2 时才自动回滚（熟练度归零）；A3+ 只升 HUMAN_REVIEW/CORE_REVIEW。
+    CAPABILITY_AUTO_ROLLBACK_FAILURES = 3
+
+    def _commit_capability_reflection_locked(
+        self,
+        *,
+        life_id: str,
+        artifact: Mapping[str, Any],
+        execution: Mapping[str, Any],
+        records: list[dict[str, Any]],
+        execution_id: str,
+        completed: bool,
+    ) -> dict[str, Any] | None:
+        """F3 挂点6：能力执行后 → 闭环反思 → 能力证据 → 学习 → 回滚规则。"""
+        if not self._reflection_chain_enabled():
+            return None
+        try:
+            store = self._contract_store()
+            scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+            registry = [
+                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+            ]
+            entry = next(
+                (
+                    row for row in registry
+                    if str(row.get("source") or "") == "capability"
+                    and str(row.get("ref") or "") == execution_id
+                ),
+                None,
+            )
+            if entry is None:
+                return None
+            from contracts import ActionImpact
+
+            impact = ActionImpact.model_validate_json(
+                canonical_json_bytes(entry.get("action_impact") or {})
+            )
+            failed_steps = [row for row in records if row.get("ok") is not True]
+            quality = observed_quality_from_steps(records)
+            summary = {
+                "execution_id": execution_id,
+                "artifact_id": entry.get("capability_id"),
+                "status": str(execution.get("status") or ""),
+                "quality_milli": quality,
+                "failed_steps": len(failed_steps),
+            }
+            outcome_event = self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind="capability.outcome.recorded",
+                content=summary,
+                correlation_id=str(entry.get("correlation_id") or f"capability:{execution_id}"),
+            )
+            if outcome_event is None:
+                return None
+            prediction = prediction_from_snapshot(entry.get("prediction_snapshot") or {})
+            # 步骤错误码在执行记录的 result 里，合并后做九类映射。
+            category = (
+                failure_category_from_step_error(
+                    {**(failed_steps[0].get("result") or {}), **failed_steps[0]}
+                )
+                if failed_steps
+                else None
+            )
+            outcome = build_outcome_evidence(
+                life_id=life_id,
+                episode_id=str(entry.get("episode_id") or ""),
+                outcome_status="success" if completed else "failure",
+                observed_outcome=(
+                    f"能力执行{'成功' if completed else '失败'}：{entry.get('capability_scope') or ''}"
+                )[:50_000],
+                observed_quality_milli=quality,
+                prediction=prediction,
+                completion_decision_sha256=fingerprint(dict(summary)),
+                terminal_fact_hashes=[outcome_event.event_hash],
+                outcome_event_ids=[outcome_event.event_id],
+                context_fingerprint_sha256=str(entry.get("context_sha256") or ""),
+                action_risk=str(entry.get("action_risk") or "A3"),
+                failure_category=category,
+                occurred_at_ms=time.time_ns() // 1_000_000,
+            )
+            reflected = store.commit_episode_reflection(
+                outcome, now_ms=time.time_ns() // 1_000_000
+            )
+            evidence = build_capability_evidence(
+                outcome,
+                reflected.reflection,
+                impact,
+                capability_id=str(entry.get("capability_id") or ""),
+                capability_version=str(entry.get("capability_version") or ""),
+                now_ms=time.time_ns() // 1_000_000,
+            )
+            # 决策 C 诚实基线：生产路径成功证据 correlation_only，两个
+            # eligible 位均为 False。profile 契约要求证据集至少含一条
+            # eligible 证据，因此只在 eligible（失败或未来假设支持的成败）
+            # 时提交学习；成功反思照常闭环，熟练度晋升等未来假设管线。
+            learned = None
+            if evidence.eligible_success or evidence.eligible_failure:
+                learned = store.commit_capability_learning(
+                    (evidence,),
+                    scope=str(entry.get("capability_scope") or "能力学习"),
+                    now_ms=time.time_ns() // 1_000_000,
+                )
+            rollback_applied = False
+            version = str(entry.get("capability_version") or "")
+            historical = [
+                row for row in store.list_capability_evidence(
+                    life_id, capability_id=str(entry.get("capability_id") or ""), limit=200
+                )
+                if row.capability_version == version
+                and row.eligible_failure
+                and row.impact_floor in {"A0", "A1", "A2"}
+            ]
+            if len(historical) >= self.CAPABILITY_AUTO_ROLLBACK_FAILURES:
+                store.apply_capability_rollback(
+                    capability_id=str(entry.get("capability_id") or ""),
+                    capability_version=version,
+                    life_id=life_id,
+                    trigger_evidence_ids=tuple(
+                        sorted(row.evidence_id for row in historical)
+                    ),
+                    now_ms=time.time_ns() // 1_000_000,
+                )
+                rollback_applied = True
+            scheduler["open_episodes"] = [
+                row for row in registry if row is not entry
+            ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+            if learned is not None:
+                try:
+                    self.system.journal.append(
+                        life_id,
+                        "life.capability.learning.committed",
+                        {
+                            "episode_id": entry.get("episode_id"),
+                            "capability_id": entry.get("capability_id"),
+                            "outcome": learned.decision.outcome,
+                            "review_level": learned.decision.review_level,
+                            "rollback_applied": rollback_applied,
+                        },
+                        actor="life_reflection",
+                        idempotency_key=f"life.capability.learning:{entry.get('episode_id')}",
+                    )
+                except Exception:
+                    pass
+            self._persist(life_id)
+            learning_summary = (
+                {
+                    "profile_sha256": learned.profile.profile_sha256,
+                    "decision_id": learned.decision.learning_decision_id,
+                    "outcome": learned.decision.outcome,
+                    "review_level": learned.decision.review_level,
+                    "proficiency_lower_bound_milli": learned.profile.proficiency_lower_bound_milli,
+                }
+                if learned is not None
+                else {
+                    # 诚实基线：证据未达 eligible（如 correlation_only 的成功），
+                    # 本次不进入能力学习，反思照常闭环。
+                    "outcome": "not_committed",
+                    "reason": "capability.evidence_not_eligible",
+                }
+            )
+            learning_summary["rollback_applied"] = rollback_applied
+            return {
+                "reflection": {
+                    "reflection_id": reflected.reflection.reflection_id,
+                    "episode_id": reflected.reflection.episode_id,
+                    "source": "causal_reflection_chain",
+                    "observed_outcome": reflected.reflection.observed_outcome,
+                    "prediction_error_milli": reflected.reflection.prediction_error_milli,
+                },
+                "capability_learning": learning_summary,
+            }
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "capability_commit", exc)
+            return None
 
     _ACTIVITY_WINDOW_HOURS = {
         "上午": (6, 11),
@@ -2672,8 +3205,40 @@ class EmbeddedLifeRuntime:
                         life_id=life_id,
                         soul=self._soul(),
                         scope=self._scope_state(life_id),
+                        reflection_rows=self._recent_reflection_rows(life_id),
                     )
                     task = deepcopy(self._autonomy_state(life_id)["tasks"][task_id])
+                    # F3 挂点1：事前预测先落账（OPEN episode），事后不可编造；
+                    # 预测依据 = 该活动的真实完成历史。
+                    activity_id = str(task.get("activity_id") or "")
+                    history = [
+                        row for row in self._autonomy_state(life_id)["tasks"].values()
+                        if isinstance(row, Mapping)
+                        and str(row.get("activity_id") or "") == activity_id
+                        and str(row.get("status") or "") in {"completed", "failed"}
+                    ]
+                    self._open_runtime_episode_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=task_id,
+                        event_kind="autonomy.task.attempt.started",
+                        intention=str(task.get("objective") or task.get("title") or "自主行动"),
+                        context_sha256=str(activity_scope.get("scope_sha256") or ""),
+                        prediction=build_prediction(
+                            basis_inputs={
+                                "source": "autonomy",
+                                "task_id": task_id,
+                                "activity_id": activity_id,
+                            },
+                            successes=sum(
+                                1 for row in history if str(row.get("status") or "") == "completed"
+                            ),
+                            uses=len(history),
+                        ),
+                        action_risk=str(task.get("risk_class") or "A0"),
+                        candidate_action_ids=(task_id,),
+                        selected_action_id=task_id,
+                    )
                 decision = self._autonomy_decider(activity_scope, task)
                 if not isinstance(decision, Mapping):
                     raise ValueError("autonomy model result is invalid")
@@ -2710,6 +3275,24 @@ class EmbeddedLifeRuntime:
                         actor="life_autonomy",
                         idempotency_key=f"autonomy.task.model-complete:{task_id}:{completed.get('attempt_count', 0)}",
                     )
+                    # F3 挂点2：任务完成 → 闭环反思（质量 900，终态事实=结果哈希）。
+                    self._commit_runtime_reflection_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=task_id,
+                        outcome_status="success",
+                        observed_outcome=str(result.get("summary") or "任务完成。"),
+                        observed_quality_milli=900,
+                        completion_decision={
+                            "task_id": task_id,
+                            "status": "completed",
+                            "attempt_count": completed.get("attempt_count"),
+                        },
+                        terminal_fact_parts={
+                            "summary": str(result.get("summary") or "")[:800],
+                        },
+                        event_kind="autonomy.task.attempt.finished",
+                    )
                     self._sync_daily_summary(life_id)
                     self._persist(life_id)
             except Exception as exc:
@@ -2733,6 +3316,23 @@ class EmbeddedLifeRuntime:
                             {"task_id": task_id, "task": blocked},
                             actor="life_autonomy",
                             idempotency_key=f"autonomy.task.model-blocked:{task_id}:{blocked.get('attempt_count', 0)}",
+                        )
+                        # F3 挂点3：任务异常 → 失败闭环（九类映射 + 反事实模板）。
+                        self._commit_runtime_reflection_locked(
+                            life_id=life_id,
+                            source="autonomy",
+                            ref_id=task_id,
+                            outcome_status="failure",
+                            observed_outcome=f"任务失败：{type(exc).__name__}",
+                            observed_quality_milli=100,
+                            completion_decision={
+                                "task_id": task_id,
+                                "status": "failed",
+                                "attempt_count": blocked.get("attempt_count"),
+                            },
+                            terminal_fact_parts={"error_type": type(exc).__name__},
+                            event_kind="autonomy.task.attempt.failed",
+                            failure_category=failure_category_from_error(exc),
                         )
                     scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
                     activity_detail = re.sub(r"\s+", " ", str(exc)).strip()[:160]
@@ -2966,7 +3566,7 @@ class EmbeddedLifeRuntime:
 
         def worker() -> None:
             try:
-                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id))
+                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id), reflection_rows=self._recent_reflection_rows(life_id))
                 decision = self._learning_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("learning model decision is invalid")
@@ -3064,7 +3664,7 @@ class EmbeddedLifeRuntime:
 
         def worker() -> None:
             try:
-                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id))
+                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id), reflection_rows=self._recent_reflection_rows(life_id))
                 decision = self._self_iteration_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("self-iteration model decision is invalid")
@@ -4510,6 +5110,17 @@ class EmbeddedLifeRuntime:
             completed_autonomous_tasks,
             preferences,
         )
+        # P8 反思链卡片（只读独立键，不动现有 reflections/action_values）。
+        reflection_cards: list[dict[str, Any]] = []
+        try:
+            reflection_cards = [
+                reflection_card_projection(card)
+                for card in self._contract_store().list_reflection_cards(
+                    str(self._active().get("life_id") or ""), limit=20
+                )
+            ]
+        except Exception:
+            reflection_cards = []
         affect_state = deepcopy(scope["affect"])
         affect_state.setdefault(
             "drives",
@@ -4645,6 +5256,7 @@ class EmbeddedLifeRuntime:
             },
             "drift": drift_rows,
             "reflections": reflection_rows,
+            "reflection_cards": reflection_cards,
             "action_values": action_value_rows,
             "learning": {
                 "candidate_count": len(learning_pending),
@@ -6540,6 +7152,15 @@ class EmbeddedLifeRuntime:
         scope = self._scope_state(life_id)
         pointers = scope.get("capability_pointers") if isinstance(scope.get("capability_pointers"), Mapping) else {}
         now_ms = time.time_ns() // 1_000_000
+        # 认知层 profile（capability_learning 双体系之认知侧，只读输入）。
+        profiles_by_capability: dict[str, Any] = {}
+        try:
+            profiles_by_capability = {
+                str(profile.capability_id): profile
+                for profile in self._contract_store().latest_capability_profiles(life_id)
+            }
+        except Exception:
+            profiles_by_capability = {}
         rows = []
         for raw in scope["capabilities"].values():
             if not isinstance(raw, Mapping) or raw.get("status") != "published" or raw.get("kind") not in {"skill", "tool"}:
@@ -6555,6 +7176,12 @@ class EmbeddedLifeRuntime:
             health = pointer.get("health") if isinstance(pointer.get("health"), Mapping) else {}
             row["health_score_milli"] = health_score_milli(health, now_ms)
             row["last_outcome_at_ms"] = int(health.get("last_outcome_at_ms") or 0)
+            profile = profiles_by_capability.get(str(row.get("artifact_id") or ""))
+            proficiency = int(getattr(profile, "proficiency_lower_bound_milli", 0) or 0) if profile else 0
+            row["profile"] = capability_profile_projection(profile) if profile else None
+            row["proficiency_lower_bound_milli"] = proficiency
+            # 决策 D：双体系综合分——运行时健康与认知熟练度任一看好即靠前。
+            row["composite_score_milli"] = max(int(row["health_score_milli"]), proficiency)
             # 闲置标记（派生，不持久化）：>7 天无真实执行结果的 active 能力。
             # 只影响排序自然沉底与 32 条截断淘汰，不降级、不禁用；补丁验证中的不算闲置。
             last_outcome_ms = row["last_outcome_at_ms"]
@@ -6565,10 +7192,11 @@ class EmbeddedLifeRuntime:
                 and not health.get("patch_pending")
             )
             rows.append(row)
-        # 健康分排序：成功且常用的能力靠前，闲置者自然沉底（32 条截断即淘汰）。
+        # 综合分排序：成功、常用、有认知熟练度的能力靠前，闲置者自然沉底
+        # （32 条截断即淘汰）。
         rows.sort(
             key=lambda item: (
-                -int(item.get("health_score_milli") or 0),
+                -int(item.get("composite_score_milli") or 0),
                 -int(item.get("last_outcome_at_ms") or 0),
                 str(item.get("kind")),
                 str(item.get("title")),
@@ -6587,6 +7215,7 @@ class EmbeddedLifeRuntime:
                 "summary": row.get("summary"),
                 "risk_level": row.get("risk_level"),
                 "health_score_milli": row.get("health_score_milli"),
+                "proficiency_lower_bound_milli": row.get("proficiency_lower_bound_milli"),
                 "task_intents": list(spec.get("task_intents") or [])[:24],
                 "required_actions": list(row.get("required_actions") or [])[:16],
                 "steps": list(spec.get("steps") or [])[:16],
@@ -7985,6 +8614,15 @@ class EmbeddedLifeRuntime:
         existing = scope["executions"].get(execution_id)
         if isinstance(existing, Mapping):
             return {"ok": True, "replayed": True, "execution": deepcopy(existing)}
+        # F3 挂点5：能力执行前 → health 基线预测 + started 事件 + 影响面 + OPEN
+        # episode（事前落账；失败不影响能力执行本身）。
+        with self._lock:
+            self._open_capability_episode_locked(
+                life_id=life_id,
+                artifact=artifact,
+                pointer=pointer,
+                execution_id=execution_id,
+            )
         records: list[dict[str, Any]] = []
         completed = True
         for position, raw_step in enumerate(steps):
@@ -8079,11 +8717,23 @@ class EmbeddedLifeRuntime:
             scope["executions"] = before
             scope["capability_pointers"][lineage_id] = pointer_before
             raise
+        # F3 挂点6：能力执行后 → 闭环反思 + 能力证据 + 学习 + 回滚规则；
+        # 返回体追加只读观测键，不改变调用契约。
+        with self._lock:
+            reflection_summary = self._commit_capability_reflection_locked(
+                life_id=life_id,
+                artifact=artifact,
+                execution=execution,
+                records=records,
+                execution_id=execution_id,
+                completed=completed,
+            )
         return {
             "ok": completed,
             "execution": deepcopy(execution),
             "pointer": deepcopy(updated_pointer),
             "event": event,
+            **(reflection_summary or {}),
         }
 
     def _execution_recover(self, payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/app/life-service/runtime314/life_service/episode_builder.py
+++ b/app/life-service/runtime314/life_service/episode_builder.py
@@ -1,0 +1,420 @@
+"""P8 反思链生产构建器：纯函数，无 I/O，不 import runtime。
+
+任务/能力执行 →（事前）预测快照 + OPEN episode →（事后）结果证据 →
+store.commit_episode_reflection 原子闭环反思。所有写入由 embedded_runtime
+在 ``self._lock`` 内完成；本模块只负责构造合法契约对象。
+
+诚实基线（决策 C）：生产路径没有因果假设写入口，所以成功证据
+``supported_cause_ids=()`` → ``causal_support="correlation_only"``、
+``eligible_success=False``——成功晋升留给未来假设管线，这是 P8 出口
+条件的认识论分层，不是缺陷。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from contracts import (
+    ActionImpact,
+    CausalEpisode,
+    EpisodeOutcomeEvidence,
+    LifeEventEnvelope,
+    canonical_sha256,
+    derive_life_event_id,
+)
+
+from .capability_learning import _impact_floor
+
+
+ZERO_SHA256 = "0" * 64
+ZERO_SIGNATURE = "0" * 128
+# 无历史时的确定性预测基线（决策 C：不做随机猜测）。
+DEFAULT_PREDICTED_SUCCESS_MILLI = 700
+
+# 风险档位 → 影响面毫值（保证 _impact_floor(impact) == risk_class）。
+_RISK_SCOPE_MILLI = {
+    "A0": 0,
+    "A1": 100,
+    "A2": 300,
+    "A3": 500,
+    "A4": 700,
+    "A5": 900,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PredictionSnapshot:
+    """事前预测快照：先于执行落账，事后可审计防编造。"""
+
+    predicted_success_milli: int
+    basis: str  # "history" | "default"
+    snapshot: dict[str, Any]
+    snapshot_sha256: str
+    prior_prediction: str  # 嵌入 OPEN episode 的可读 JSON 文本
+
+
+def fingerprint(parts: Mapping[str, Any]) -> str:
+    """上下文指纹：canonical 哈希（输入必须 canonical 安全，禁 float）。"""
+    return canonical_sha256(dict(parts))
+
+
+def build_prediction(
+    *,
+    basis_inputs: Mapping[str, Any],
+    successes: int = 0,
+    uses: int = 0,
+    fallback_milli: int = DEFAULT_PREDICTED_SUCCESS_MILLI,
+) -> PredictionSnapshot:
+    """确定性预测：有历史用完成率（毫值整数），无历史回退基线。
+
+    ``basis_inputs`` 记录预测依据（如 activity_id、历史样本数、健康档案
+    摘要），进入快照哈希，事后不可伪造。
+    """
+    if uses > 0:
+        predicted = max(0, min(1000, successes * 1000 // uses))
+        basis = "history"
+    else:
+        predicted = max(0, min(1000, fallback_milli))
+        basis = "default"
+    snapshot = {
+        "domain": "tiangong.life.prediction-snapshot.v1",
+        "basis": basis,
+        "predicted_success_milli": predicted,
+        "sample_successes": int(successes),
+        "sample_uses": int(uses),
+        **{str(key): value for key, value in basis_inputs.items()},
+    }
+    snapshot_sha256 = canonical_sha256(snapshot)
+    from contracts import canonical_json_bytes
+
+    prior_prediction = canonical_json_bytes(snapshot).decode("utf-8")
+    return PredictionSnapshot(
+        predicted_success_milli=predicted,
+        basis=basis,
+        snapshot=snapshot,
+        snapshot_sha256=snapshot_sha256,
+        prior_prediction=prior_prediction,
+    )
+
+
+def build_life_event(
+    *,
+    life_id: str,
+    sequence: int,
+    writer_epoch: int,
+    previous_event_hash: str | None,
+    event_kind: str,
+    content: Mapping[str, Any],
+    occurred_at_ms: int,
+    observed_at_ms: int,
+    correlation_id: str,
+    causation_id: str | None = None,
+    signer_key_id: str,
+    sign: Callable[[str], str],
+    source_kind: str = "reflection",
+    evidence_class: str = "reflection",
+) -> LifeEventEnvelope:
+    """构造链形生命事件：确定性 identity + 哈希链 + 外部签名回调。"""
+    content_sha256 = canonical_sha256({"domain": "life.reflection.content.v1", "content": dict(content)})
+    ingress_id = f"internal:{event_kind}:{sequence}"
+    dedupe_key = canonical_sha256(
+        {"dedupe": event_kind, "correlation_id": correlation_id, "life_id": life_id, "sequence": sequence}
+    )
+    unsigned = LifeEventEnvelope(
+        event_id=derive_life_event_id(
+            life_id=life_id,
+            writer_epoch=writer_epoch,
+            sequence=sequence,
+            ingress_id=ingress_id,
+        ),
+        life_id=life_id,
+        sequence=sequence,
+        writer_epoch=writer_epoch,
+        source_service="life_reflection_chain",
+        source_kind=source_kind,
+        event_kind=event_kind,
+        occurred_at_ms=occurred_at_ms,
+        observed_at_ms=max(occurred_at_ms, observed_at_ms),
+        principal_ref=life_id,
+        subject_refs=(life_id,),
+        evidence_class=evidence_class,
+        source_credibility_milli=1000,
+        privacy_scope="system",
+        content_object_id=f"obj:{content_sha256[:40]}",
+        content_sha256=content_sha256,
+        dedupe_key=dedupe_key,
+        causation_id=causation_id,
+        correlation_id=correlation_id,
+        previous_event_hash=previous_event_hash,
+        event_hash=ZERO_SHA256,
+        signer_key_id=signer_key_id,
+        signature=ZERO_SIGNATURE,
+    ).with_computed_event_hash()
+    return unsigned.model_copy(update={"signature": sign(unsigned.event_hash.encode("ascii"))})
+
+
+def build_open_episode(
+    *,
+    life_id: str,
+    trigger_event_ids: Sequence[str],
+    context_state_hashes: Sequence[str],
+    intention: str,
+    prediction: PredictionSnapshot,
+    candidate_action_ids: Sequence[str] = (),
+    selected_action_id: str | None = None,
+    created_at_ms: int,
+) -> CausalEpisode:
+    """构造 OPEN 事前 episode；identity 由触发事件+预测快照确定性推导。"""
+    triggers = tuple(sorted(set(str(value) for value in trigger_event_ids)))
+    contexts = tuple(sorted(set(str(value) for value in context_state_hashes)))
+    if not triggers or not contexts:
+        raise ValueError("open episode requires trigger events and context hashes")
+    episode_id = "cep_" + canonical_sha256(
+        {
+            "domain": "tiangong.life.reflection-episode-id.v1",
+            "life_id": life_id,
+            "trigger_event_ids": triggers,
+            "prediction_snapshot_sha256": prediction.snapshot_sha256,
+            "intention": intention,
+        }
+    )
+    return CausalEpisode(
+        episode_id=episode_id,
+        life_id=life_id,
+        revision=1,
+        supersedes_episode_sha256=None,
+        trigger_event_ids=triggers,
+        context_state_hashes=contexts,
+        intention=intention,
+        prior_prediction=prediction.prior_prediction,
+        candidate_action_ids=tuple(sorted(set(str(value) for value in candidate_action_ids))),
+        selected_action_id=selected_action_id,
+        authorization_ref=None,
+        mediator_event_ids=(),
+        outcome_event_ids=(),
+        outcome_evaluation=None,
+        prediction_error_milli=None,
+        terminal_status="OPEN",
+        created_at_ms=created_at_ms,
+        closed_at_ms=None,
+        episode_sha256=ZERO_SHA256,
+    ).with_computed_episode_sha256()
+
+
+def build_outcome_evidence(
+    *,
+    life_id: str,
+    episode_id: str,
+    outcome_status: str,
+    observed_outcome: str,
+    observed_quality_milli: int,
+    prediction: PredictionSnapshot,
+    completion_decision_sha256: str,
+    terminal_fact_hashes: Sequence[str],
+    outcome_event_ids: Sequence[str],
+    context_fingerprint_sha256: str,
+    action_risk: str,
+    failure_category: str | None = None,
+    method_attribution: str = "capability",
+    counterfactual_actions: Sequence[str] = (),
+    next_minimal_experiment: str | None = None,
+    occurred_at_ms: int,
+) -> EpisodeOutcomeEvidence:
+    """构造结果证据；失败时补反事实与最小实验模板（若未提供）。"""
+    if outcome_status == "success":
+        if failure_category is not None:
+            raise ValueError("success outcome cannot carry a failure category")
+    elif failure_category is None:
+        failure_category = "stale_context" if outcome_status == "aborted" else "unknown"
+    if outcome_status == "failure" and not counterfactual_actions:
+        counterfactual_actions = ("复跑同一任务，先执行只读探针再决定是否继续。",)
+        next_minimal_experiment = next_minimal_experiment or (
+            "先执行只读探针确认环境与输入，再重试原任务。"
+        )
+    facts = tuple(sorted(set(str(value) for value in terminal_fact_hashes)))
+    events = tuple(sorted(set(str(value) for value in outcome_event_ids)))
+    if not facts or not events:
+        raise ValueError("episode outcome requires terminal facts and outcome events")
+    outcome_evidence_id = "oev_" + canonical_sha256(
+        {
+            "domain": "tiangong.life.outcome-evidence-id.v1",
+            "life_id": life_id,
+            "episode_id": episode_id,
+            "outcome_status": outcome_status,
+            "prediction_snapshot_sha256": prediction.snapshot_sha256,
+            "occurred_at_ms": occurred_at_ms,
+        }
+    )
+    return EpisodeOutcomeEvidence(
+        outcome_evidence_id=outcome_evidence_id,
+        life_id=life_id,
+        episode_id=episode_id,
+        outcome_status=outcome_status,
+        observed_outcome=observed_outcome,
+        observed_quality_milli=max(0, min(1000, observed_quality_milli)),
+        predicted_success_milli=prediction.predicted_success_milli,
+        prediction_snapshot_hash=prediction.snapshot_sha256,
+        completion_decision_sha256=completion_decision_sha256,
+        terminal_fact_hashes=facts,
+        outcome_event_ids=events,
+        failure_category=failure_category,
+        method_attribution=method_attribution,
+        supported_cause_ids=(),
+        counterevidence_refs=(),
+        alternative_explanation_refs=(),
+        context_fingerprint_sha256=context_fingerprint_sha256,
+        preference_domain=None,
+        user_preference_uncertainty_milli=0,
+        action_risk=action_risk,
+        counterfactual_actions=tuple(counterfactual_actions),
+        next_minimal_experiment=next_minimal_experiment,
+        candidate_user_question=None,
+        occurred_at_ms=occurred_at_ms,
+        evidence_sha256=ZERO_SHA256,
+    ).with_computed_evidence_sha256()
+
+
+def build_action_impact(
+    *,
+    life_id: str,
+    action_id: str,
+    risk_class: str,
+    source_event_ids: Sequence[str],
+    created_at_ms: int,
+) -> ActionImpact:
+    """按风险档位构造影响面；保证 _impact_floor(impact) == risk_class。"""
+    scope_milli = _RISK_SCOPE_MILLI.get(str(risk_class).upper())
+    if scope_milli is None:
+        raise ValueError(f"action impact risk class is invalid: {risk_class}")
+    events = tuple(sorted(set(str(value) for value in source_event_ids)))
+    if not events:
+        raise ValueError("action impact requires source events")
+    impact_id = "imp_" + canonical_sha256(
+        {
+            "domain": "tiangong.life.reflection-impact-id.v1",
+            "life_id": life_id,
+            "action_id": action_id,
+            "risk_class": str(risk_class).upper(),
+            "created_at_ms": created_at_ms,
+        }
+    )
+    impact = ActionImpact(
+        impact_id=impact_id,
+        life_id=life_id,
+        action_id=action_id,
+        dynamic_risk=str(risk_class).upper(),
+        affected_internal_nodes=(),
+        touches_identity=False,
+        touches_soul=False,
+        touches_memory_keys=False,
+        touches_policy=False,
+        touches_core_code=False,
+        workspace_scope_milli=scope_milli,
+        external_recipient_count=0,
+        credential_scope_milli=0,
+        privacy_scope_milli=scope_milli,
+        blast_radius_milli=scope_milli,
+        irreversibility_milli=scope_milli,
+        uncertainty_milli=scope_milli,
+        rollback_proof_ref=None,
+        estimated_resource_cost_milli=100,
+        predicted_viability_deltas=(),
+        source_event_ids=events,
+        created_at_ms=created_at_ms,
+        impact_sha256=ZERO_SHA256,
+    ).with_computed_impact_sha256()
+    if _impact_floor(impact) != str(risk_class).upper():
+        raise ValueError("action impact floor disagrees with its risk class")
+    return impact
+
+
+# 异常类型 → 九类失败映射。运行时错误码（EmbeddedLifeError.reason 等）优先，
+# 此表兜底。
+_ERROR_CATEGORY_PATTERNS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("policy", "forbidden", "blocked", "not_allowed"), "policy_block"),
+    (("permission", "unauthorized", "forbidden_resource"), "insufficient_permission"),
+    (("timeout", "connection", "network", "unreachable", "oserror"), "environment_error"),
+    (("input", "argument", "schema", "invalid_json", "decode"), "input_error"),
+    (("stale", "expired", "conflict", "discontinuous"), "stale_context"),
+    (("preference",), "user_preference_mismatch"),
+    (("reasoning", "model", "generation"), "model_reasoning_error"),
+    (("tool", "action", "executor"), "tool_error"),
+)
+
+_EXCEPTION_CATEGORIES: tuple[tuple[tuple[type[BaseException], ...], str], ...] = (
+    ((PermissionError,), "insufficient_permission"),
+    ((TimeoutError, ConnectionError, OSError), "environment_error"),
+    ((ValueError, TypeError, KeyError), "input_error"),
+)
+
+
+def failure_category_from_error(error: BaseException | None) -> str:
+    """按异常类型与错误文本映射九类失败；兜底 unknown。"""
+    if error is None:
+        return "unknown"
+    for types, category in _EXCEPTION_CATEGORIES:
+        if isinstance(error, types):
+            return category
+    text = f"{type(error).__name__} {error}".casefold()
+    for needles, category in _ERROR_CATEGORY_PATTERNS:
+        if any(needle in text for needle in needles):
+            return category
+    return "unknown"
+
+
+def failure_category_from_step_error(step: Mapping[str, Any]) -> str:
+    """能力步骤失败的九类映射；缺错误信息时按工具失败处理。"""
+    for key in ("error_code", "reason_code", "error"):
+        text = str(step.get(key) or "").casefold()
+        if not text:
+            continue
+        for needles, category in _ERROR_CATEGORY_PATTERNS:
+            if any(needle in text for needle in needles):
+                return category
+    return "tool_error"
+
+
+def observed_quality_from_steps(steps: Sequence[Mapping[str, Any]]) -> int:
+    """步骤成功比例 → 观察质量毫值；无步骤的内部行动回退 800。"""
+    rows = [step for step in steps if isinstance(step, Mapping)]
+    if not rows:
+        return 800
+    ok_count = sum(1 for step in rows if step.get("ok") is True)
+    return ok_count * 1000 // len(rows)
+
+
+def prediction_from_snapshot(snapshot: Mapping[str, Any]) -> PredictionSnapshot:
+    """从注册表持久化的快照字典重建预测（哈希与文本按 canonical 重算）。"""
+    from contracts import canonical_json_bytes
+
+    payload = {str(key): value for key, value in snapshot.items()}
+    try:
+        predicted = int(payload.get("predicted_success_milli"))
+    except (TypeError, ValueError):
+        predicted = DEFAULT_PREDICTED_SUCCESS_MILLI
+    return PredictionSnapshot(
+        predicted_success_milli=max(0, min(1000, predicted)),
+        basis=str(payload.get("basis") or "default"),
+        snapshot=payload,
+        snapshot_sha256=canonical_sha256(payload),
+        prior_prediction=canonical_json_bytes(payload).decode("utf-8"),
+    )
+
+
+__all__ = [
+    "DEFAULT_PREDICTED_SUCCESS_MILLI",
+    "PredictionSnapshot",
+    "ZERO_SHA256",
+    "build_action_impact",
+    "build_life_event",
+    "build_open_episode",
+    "build_outcome_evidence",
+    "build_prediction",
+    "failure_category_from_error",
+    "failure_category_from_step_error",
+    "fingerprint",
+    "observed_quality_from_steps",
+    "prediction_from_snapshot",
+]

--- a/app/life-service/runtime314/life_service/panel_projection.py
+++ b/app/life-service/runtime314/life_service/panel_projection.py
@@ -282,6 +282,44 @@ def motivation_drift_projection(
     }]
 
 
+def reflection_card_projection(card: Any) -> dict[str, Any]:
+    """P8 反思卡面板投影（只读）：来自因果反思链的权威记录。"""
+    return {
+        "reflection_id": str(getattr(card, "reflection_id", "") or ""),
+        "episode_id": str(getattr(card, "episode_id", "") or ""),
+        "expected_outcome": str(getattr(card, "expected_outcome", "") or "")[:800],
+        "observed_outcome": str(getattr(card, "observed_outcome", "") or "")[:800],
+        "prediction_error_milli": int(getattr(card, "prediction_error_milli", 0) or 0),
+        "failure_dimensions": list(getattr(card, "failure_dimensions", ()) or ()),
+        "counterfactual_actions": list(getattr(card, "counterfactual_actions", ()) or ()),
+        "next_minimal_experiment": getattr(card, "next_minimal_experiment", None),
+        "confidence_milli": int(getattr(card, "confidence_milli", 0) or 0),
+        "created_at_ms": int(getattr(card, "created_at_ms", 0) or 0),
+        "source": "causal_reflection_chain",
+        "revision": str(getattr(card, "reflection_sha256", "") or "")[:12],
+    }
+
+
+def capability_profile_projection(profile: Any) -> dict[str, Any]:
+    """能力认知层 profile 面板投影（只读）：熟练度与审查级别。"""
+    return {
+        "capability_id": str(getattr(profile, "capability_id", "") or ""),
+        "version": str(getattr(profile, "version", "") or ""),
+        "profile_revision": int(getattr(profile, "profile_revision", 0) or 0),
+        "verified_successes": int(getattr(profile, "verified_successes", 0) or 0),
+        "verified_failures": int(getattr(profile, "verified_failures", 0) or 0),
+        "independent_context_count": int(getattr(profile, "independent_context_count", 0) or 0),
+        "proficiency_mean_milli": int(getattr(profile, "proficiency_mean_milli", 0) or 0),
+        "proficiency_lower_bound_milli": int(
+            getattr(profile, "proficiency_lower_bound_milli", 0) or 0
+        ),
+        "review_level": str(getattr(profile, "review_level", "") or ""),
+        "rollback_count": int(getattr(profile, "rollback_count", 0) or 0),
+        "impact_floor": str(getattr(profile, "impact_floor", "") or ""),
+        "updated_at_ms": int(getattr(profile, "updated_at_ms", 0) or 0),
+    }
+
+
 def model_budget_projection(
     settings: Mapping[str, Any],
     scheduler: Mapping[str, Any],
@@ -400,6 +438,7 @@ def fallback_context_projection(
 
 __all__ = [
     "boundary_projection",
+    "capability_profile_projection",
     "catalog_tasks_for_day",
     "fallback_context_projection",
     "long_term_goals",
@@ -408,6 +447,7 @@ __all__ = [
     "preference_projection",
     "record_day",
     "records_for_day",
+    "reflection_card_projection",
     "reflection_projection",
     "action_value_projection",
 ]

--- a/app/life-service/runtime314/life_service/proactive_initiative.py
+++ b/app/life-service/runtime314/life_service/proactive_initiative.py
@@ -237,6 +237,49 @@ def evaluate_proactive_candidate(
     if daily_limit <= 0 or sum(1 for value in deliveries if now_ms - value < 86_400_000) >= daily_limit:
         return _decision(kind="no_op", reason_code="life.proactive.daily_limit", allowed=False)
 
+    # F1 忽略率门禁：用户持续不理会时抬高开口门槛并拉长间隔，学会"闭嘴"。
+    # 样本不足（新键缺失/为空的旧上下文，或未过回复窗口）一律不加门禁。
+    engagement_window = _strict_nonnegative_int(
+        settings.get("proactive_engagement_window_size"), default=8
+    )
+    min_reply_rate_milli = _strict_nonnegative_int(
+        settings.get("proactive_min_reply_rate_milli"), default=200
+    )
+    engagement_required_bonus = 0
+    if engagement_window > 0 and min_reply_rate_milli > 0:
+        outcome_rows = [
+            row for row in (context.get("recent_delivery_outcomes") or [])
+            if isinstance(row, Mapping)
+        ]
+        samples = sorted(
+            (
+                row for row in outcome_rows
+                if isinstance(row.get("created_at_ms"), int)
+                and not isinstance(row.get("created_at_ms"), bool)
+                and row.get("created_at_ms") >= 0
+                and isinstance(row.get("replied"), bool)
+            ),
+            key=lambda row: -row["created_at_ms"],
+        )[:engagement_window]
+        if len(samples) >= engagement_window:
+            replies = sum(1 for row in samples if row["replied"])
+            reply_rate_milli = replies * 1000 // len(samples)
+            if reply_rate_milli < min_reply_rate_milli:
+                interval_multiplier = 4 if reply_rate_milli == 0 else 2
+                if (
+                    last_delivery_ms
+                    and min_interval_ms
+                    and now_ms - last_delivery_ms < min_interval_ms * interval_multiplier
+                ):
+                    return _decision(
+                        kind="no_op",
+                        reason_code="life.proactive.engagement_low",
+                        allowed=False,
+                    )
+                # 按忽略程度动态抬高效用门槛：回复率越低要求越高。
+                severity_milli = min(1000, min_reply_rate_milli - reply_rate_milli)
+                engagement_required_bonus = (severity_milli * 300) // 1000
+
     stale_after_ms = _strict_nonnegative_int(
         settings.get("proactive_evidence_stale_after_seconds"), default=86_400
     ) * 1000
@@ -287,7 +330,8 @@ def evaluate_proactive_candidate(
     score = compute_agency_score(**score_inputs).model_dump(mode="json")
     threshold = _strict_nonnegative_int(settings.get("proactive_min_utility_lcb_milli"), default=120)
     margin = _strict_nonnegative_int(settings.get("proactive_min_margin_milli"), default=80)
-    required = max(threshold, margin)
+    engagement_adjusted = threshold + engagement_required_bonus
+    required = max(threshold, margin, engagement_adjusted)
     if int(score.get("utility_lcb_milli") or 0) < required:
         return _decision(
             kind="no_op",

--- a/app/life-service/runtime314/life_service/store.py
+++ b/app/life-service/runtime314/life_service/store.py
@@ -4006,6 +4006,124 @@ class LifeShadowStore:
             raise LifeShadowStoreError("life projection head disagrees with replay")
         return summary
 
+    # ---------- P8 反思链只读投影（生产接线用；零 schema 变更零迁移） ----------
+
+    def life_event_head(self, life_id: str) -> LifeEventEnvelope | None:
+        """One life's chain-head event, or None before genesis."""
+        row = self._connection.execute(
+            """
+            SELECT envelope FROM life_events
+            WHERE life_id = ? AND event_id = (
+                SELECT head_event_id FROM projection_heads WHERE life_id = ?
+            )
+            """,
+            (life_id, life_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _parse_stored_contract(
+            bytes(row["envelope"]), LifeEventEnvelope, "life event"
+        )
+
+    def list_reflection_cards(
+        self, life_id: str, *, limit: int = 20
+    ) -> tuple[ReflectionCard, ...]:
+        """Most recent reflection cards for panel display (newest first)."""
+        rows = self._connection.execute(
+            """
+            SELECT payload FROM reflection_cards
+            WHERE life_id = ?
+            ORDER BY created_at_ms DESC, reflection_id DESC
+            LIMIT ?
+            """,
+            (life_id, max(1, min(int(limit), 100))),
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), ReflectionCard, "reflection card")
+            for row in rows
+        )
+
+    def latest_capability_profiles(self, life_id: str) -> tuple[CapabilityProfile, ...]:
+        """Latest profile revision per (capability_id, version), sorted by id."""
+        rows = self._connection.execute(
+            """
+            SELECT p.payload FROM capability_profiles AS p
+            JOIN (
+                SELECT capability_id, version, life_id, MAX(profile_revision) AS max_revision
+                FROM capability_profiles
+                WHERE life_id = ?
+                GROUP BY capability_id, version, life_id
+            ) AS latest
+              ON latest.capability_id = p.capability_id
+             AND latest.version = p.version
+             AND latest.life_id = p.life_id
+             AND latest.max_revision = p.profile_revision
+            ORDER BY p.capability_id, p.version
+            """,
+            (life_id,),
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), CapabilityProfile, "capability profile")
+            for row in rows
+        )
+
+    def list_capability_evidence(
+        self,
+        life_id: str,
+        *,
+        capability_id: str | None = None,
+        limit: int = 50,
+    ) -> tuple[CapabilityEvidence, ...]:
+        """Most recent capability evidence (newest first), optionally filtered."""
+        filter_sql = "" if not capability_id else "AND capability_id = ?"
+        params: list[Any] = [life_id]
+        if capability_id:
+            params.append(capability_id)
+        params.append(max(1, min(int(limit), 200)))
+        rows = self._connection.execute(
+            f"""
+            SELECT payload FROM capability_evidence
+            WHERE life_id = ? {filter_sql}
+            ORDER BY created_at_ms DESC, evidence_id DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), CapabilityEvidence, "capability evidence")
+            for row in rows
+        )
+
+    def open_causal_episodes(
+        self, life_id: str, *, limit: int = 32
+    ) -> tuple[CausalEpisode, ...]:
+        """Episodes whose LATEST revision is still OPEN, oldest first.
+
+        Closed episodes keep their OPEN revision-1 rows as history, so a plain
+        terminal_status filter would resurrect closed episodes as orphans.
+        """
+        rows = self._connection.execute(
+            """
+            SELECT e.payload FROM causal_episodes AS e
+            JOIN (
+                SELECT episode_id, MAX(revision) AS max_revision
+                FROM causal_episodes
+                WHERE life_id = ?
+                GROUP BY episode_id
+            ) AS latest
+              ON latest.episode_id = e.episode_id
+             AND latest.max_revision = e.revision
+            WHERE e.life_id = ? AND e.terminal_status = 'OPEN'
+            ORDER BY e.created_at_ms, e.episode_id
+            LIMIT ?
+            """,
+            (life_id, life_id, max(1, min(int(limit), 256))),
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), CausalEpisode, "causal episode")
+            for row in rows
+        )
+
     def _verify_causal_memory_state(self) -> None:
         tombstones: dict[str, PrivacyDeletionTombstone] = {}
         destroyed_payload_ids: set[str] = set()

--- a/docs/repair-logs/2026-08-21_P8.1_reflection-lane-production-wiring.md
+++ b/docs/repair-logs/2026-08-21_P8.1_reflection-lane-production-wiring.md
@@ -1,0 +1,101 @@
+# P8.1 Reflection Lane Production Wiring（评价驱动 QC · 第 1 类真实缺陷）
+
+Date: 2026-08-21 (Asia/Shanghai)
+
+## Scope
+
+对五系统（自主行动/自我反思/自我迭代/自主学习/自主消息）的专项评价发现一批
+"建成未接线"或"闭环缺口"类缺陷。本篇为 P8 收尾补课：P8 建成了完整的因果
+反思与能力学习**合约层**（episode/outcome/reflection/evidence/profile/
+rollback，48 张严格表全部就位并有测试），但生产运行时**零调用**——反思链
+从未在真实任务/能力执行中运转。只修真实缺陷，不动刻意设计（用户确认门、
+shadow 默认、IM 应答式、反思证据权重=0 的认识论分层），不碰研究级难题。
+
+用户已拍板：F3 做完整链；事前预测用确定性基线；F6 三个调度器一并修。
+
+## Confirmed findings and fixes
+
+| # | 缺陷 | 系统 | 修复 |
+|---|------|------|------|
+| F1 | proactive acked/replied 信号零消费者——系统学不会"闭嘴" | 自主消息 | `_build_proactive_context` 新增 `recent_delivery_outcomes` 投影（仍在 6h 回复窗口内的投递不计入）；门禁按最近 N 条回复率动态抬高效用门槛并延长有效间隔（×2/零回复×4），新 reason_code `life.proactive.engagement_low`；样本不足一律放行（向后兼容） |
+| F2 | proactive live 模式无 UI 开关（只能调 API） | 自主消息 | 设置面板新分组"主动沟通"：`proactive_enabled` 复选 + `proactive_mode` 下拉（影子/正式发送），复用现成渲染与保存链路；并行消费现成未用的 `getProactiveStatus()` 展示状态行 |
+| F3 | P8 反果反思链零生产调用（完整链接线，含能力学习） | 自我反思 | 见下节"架构决策"与六步实施 |
+| F4 | motivation_drift 检测只产面板文案无人消费 | 自我反思 | `_drift_affinity` 复用同一投影复算，按 expected−observed 给欠采样活动加分；只影响自由行动分支，due 到点必做次序不变，样本<10 不加权；activity_scope 注入摘要供模型感知 |
+| F5 | 能力系统只有负向反馈，无正向强化/闲置淘汰 | 自主学习 | health 档案新增 success_streak/last_success_at_ms；纯函数 `health_score_milli`（Hoeffding 保守率 × 7 天半衰 + 连胜加成）；overlay 排序改综合分；>7 天无结果的 active 能力标 idle 派生字段，32 条截断自然淘汰 |
+| F6 | learning/self-iteration/capability-patch 三调度器均不记账预算 | 自主学习 | 照 proactive 双池模式：通用子预算助手（日重置/只读窥探/预留双累加/成败记账），三调度器入口检查+worker 按次记账，settings 三组子预算（6/8、4/6、6/8）入白名单与范围表 |
+
+## P8.1 架构决策（规划代理以代码证据验证）
+
+- **决策 A · 双体系共存**：capability_health（pointer.health）与
+  capability_learning（profile）写路径零交集。health = 运行时可用性治理
+  （唯一能改"当前哪个版本可用"）；profile = 认知层熟练度（Hoeffding 下界、
+  review_level），只作 overlay 排序与展示的只读输入。自动回滚规则：verified
+  +capability 归因失败累积 ≥3 且 impact_floor ∈ {A0,A1,A2} 才 rollback
+  （熟练度归零）；A3+ 只升 HUMAN_REVIEW/CORE_REVIEW；**rollback 不改 pointer**
+  （C3 双体系互斥测试锁死）。
+- **决策 B · 统一 builder**：`src/life_service/episode_builder.py` 纯函数
+  （无 I/O、不 import runtime）；所有 store 写入在 embedded_runtime 的
+  `self._lock` 内完成。
+- **决策 C · 确定性预测基线**：`predicted_success_milli` = 活动历史完成率 /
+  pointer.health 成功率毫值映射，无历史回退 700；预测快照（含哈希与依据）
+  **随 OPEN episode 先于执行落账**，事后可审计防编造。诚实基线：不伪造
+  `supported_cause_ids`（生产无假设写入口）→ `causal_support=
+  "correlation_only"`、成功证据 `eligible_success=False`——成功晋升等未来
+  假设管线，这是 P8 出口条件的认识论分层。因此 capability learning 只在
+  证据 eligible（失败或未来假设支持的成败）时提交；correlation_only 的
+  成功返回 `not_committed`。
+- **决策 D · 消费路径**：面板新独立键 `reflection_cards`（source=
+  "causal_reflection_chain"/revision）；overlay 行挂 profile 并按综合分
+  `max(health_score_milli, proficiency_lower_bound_milli)` 排序；activity_scope
+  可选注入最近 5 条反思摘要（顶层键不含 credential 类词）。
+- **决策 E · 并发**：所有 life_events 链操作（读 head→构造→append）在
+  `self._lock` 内；失败即放弃该次反思并 journal（`life.episode.failed`），
+  绝不向上抛、不重试同 seed（episode/event identity 确定性推导，重放安全）。
+- **决策 F · 三不碰**：不进记忆晋升（不调 commit_life_event_l1，S1 锁死）、
+  不产生用户提问（preference_domain=None）、不进 proactive。
+- **熔断**：`TIANGONG_LIFE_REFLECTION_CHAIN=0` 整条反思链停摆（默认开）。
+
+## 六步实施（每步独立可测可提交）
+
+1. store 5 只读方法（零 schema 变更零迁移）：life_event_head /
+   list_reflection_cards / latest_capability_profiles / list_capability_evidence /
+   open_causal_episodes（按最新 revision 过滤——闭合 episode 保留 OPEN 的
+   revision-1 历史行，朴素过滤会把已闭合 episode 复活成孤儿）。
+2. episode_builder + 单测 B1-B5。
+3. 任务源接线（挂点 1-4：启动事前落账/完成闭环/异常失败闭环/陈旧恢复
+   ABORTED）→ T1-T4。
+4. 能力源接线（挂点 5-6：health 基线预测+影响面+OPEN；recorded→反思→证据
+   →学习→回滚规则，返回体追加只读键）→ C1-C3。
+5. 消费面（面板/overlay/scope 注入）→ P1/P2/S1/S2。
+6. 本篇 + CHECKPOINT 补记 + 架构计划决策记录。
+
+## 实施注记（与计划的偏差）
+
+- 闲置标记（F5）从"调度器扫描时持久化"改为 **overlay 投影时派生**：行为
+  完全一致（排序沉底 + 32 条截断淘汰 + 面板可见），但不写 pointer、不动
+  pointer_sha256、零迁移风险。
+- 挂点 1 从"调度器选中任务时"移到 **worker 构建完 activity_scope 之后、
+  调用 decider 之前**：同样是执行前，但能以真实 scope sha 做
+  context_state_hashes，且避免二次构建 scope。
+- 部署基线注记：反思链生命事件的签名密钥为进程内 Ed25519（链只校验哈希
+  连续性不验签，密钥随进程重启轮换）。若未来需要跨进程验签，挂接正式写者
+  密钥即可，链数据无需迁移。
+
+## Adversarial regression
+
+- `tests/test_episode_builder.py` B1-B5：快照确定性/链形签名/影响面一致性/
+  失败映射/证据诚实基线。
+- `tests/test_life_reflection_chain_wiring.py` T1-T4/C1-C3/P1/P2/S1/S2：
+  事前落账先于 decider 执行（事件阻塞验证）、成功/失败/孤儿三类闭环、
+  3×verified 失败自动回滚且 pointer 仍 active（双体系互斥）、面板/overlay/
+  scope 三消费面、防泄密键守卫。
+- F4/F2/F6/F5/F1 各自测试见对应提交（欠采样翻转+due 不变、live 开关往返、
+  三调度器预算五场景、健康分排序+闲置沉底、忽略率门禁六场景）。
+
+## Non-changes
+
+- 反思证据权重=0 的认识论分层保持（成功晋升等未来假设管线，本周期不建
+  假设写入口）。
+- settle_patch 语义保持负向修复专用。
+- 刻意设计未动：用户确认门、proactive shadow 默认、IM 应答式。
+- 研究级难题未碰：内生动机、热重载、打包版自我迭代、进化引擎真实化。

--- a/src/life_service/activity_scope.py
+++ b/src/life_service/activity_scope.py
@@ -183,6 +183,7 @@ def build_activity_scope(
     soul: Mapping[str, Any] | None,
     scope: Mapping[str, Any],
     derivation_store: Any | None = None,
+    reflection_rows: Any | None = None,
 ) -> dict[str, Any]:
     """Build a bounded, canonical evidence projection for one learning turn."""
     memory_rows, memory_terms = _memory_refs(scope)
@@ -289,6 +290,19 @@ def build_activity_scope(
         "long_term_goals": goals,
         "preferences": preferences,
         "motivation_drift": motivation_drift,
+        # P8 反思链最近摘要（可选注入，默认缺省零影响）：让决策模型感知
+        # 上一次行动的预测偏差与教训，只读不改权重。
+        "recent_reflections": [
+            {
+                "reflection_id": str(row.get("reflection_id") or ""),
+                "observed_outcome": str(row.get("observed_outcome") or "")[:400],
+                "prediction_error_milli": int(row.get("prediction_error_milli") or 0),
+                "failure_dimensions": list(row.get("failure_dimensions") or [])[:4],
+                "next_minimal_experiment": str(row.get("next_minimal_experiment") or "")[:200] or None,
+            }
+            for row in (reflection_rows or [])[:5]
+            if isinstance(row, Mapping)
+        ],
         "boundaries": boundaries,
         "rejected_learning_fingerprints": sorted(set(item for item in rejected if item)),
         "repository_evidence": repository_evidence,

--- a/src/life_service/activity_scope.py
+++ b/src/life_service/activity_scope.py
@@ -16,6 +16,7 @@ from contracts import canonical_sha256
 from .panel_projection import (
     boundary_projection,
     long_term_goals,
+    motivation_drift_projection,
     preference_projection,
 )
 
@@ -238,6 +239,30 @@ def build_activity_scope(
     preferences = _canonical_safe(preference_projection(
         list(settings.get("autonomy_activity_types") or [])
     ))
+    # 动机漂移摘要（只读）：让模型在决策时感知"最近行为偏离长期偏好"，
+    # 与自由行动排序的 _drift_affinity 使用同一投影函数，口径一致。
+    completed_catalog = [
+        row for row in (autonomy.get("tasks") or {}).values()
+        if isinstance(row, Mapping)
+        and str(row.get("status") or "") == "completed"
+        and str(row.get("source") or "") == "life_activity_catalog"
+    ]
+    completed_catalog.sort(
+        key=lambda row: (int(row.get("updated_at_ms") or 0), int(row.get("sequence") or 0)),
+        reverse=True,
+    )
+    motivation_drift = [
+        {
+            "title": str(row.get("title") or ""),
+            "status": str(row.get("status") or ""),
+            "drift_detected": bool(row.get("drift_detected")),
+            # canonical 契约禁用 float，漂移分以毫值整数表示（0-1000）。
+            "drift_score_milli": int(round(float(row.get("drift_score") or 0) * 1000)),
+            "summary": str(row.get("summary") or ""),
+            "observed_actions": int(row.get("observed_actions") or 0),
+        }
+        for row in motivation_drift_projection(completed_catalog[:30], preferences)
+    ]
     declared_boundaries = [
         str(value)
         for value in soul_view.get("boundaries", [])
@@ -263,6 +288,7 @@ def build_activity_scope(
         "capabilities": capabilities,
         "long_term_goals": goals,
         "preferences": preferences,
+        "motivation_drift": motivation_drift,
         "boundaries": boundaries,
         "rejected_learning_fingerprints": sorted(set(item for item in rejected if item)),
         "repository_evidence": repository_evidence,

--- a/src/life_service/capability_health.py
+++ b/src/life_service/capability_health.py
@@ -31,6 +31,8 @@ DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
 DEFAULT_MAX_PATCH_ROUNDS = 2
 # 幂等 outcome_id 保留上限（FIFO），避免健康档案无限膨胀。
 SEEN_OUTCOME_CAP = 200
+# 健康分新鲜度半衰期：7 天未用衰减一半（与能力学习的 LEARNING_COOLDOWN_MS 对齐）。
+HEALTH_FRESHNESS_HALF_LIFE_MS = 7 * 86_400_000
 
 
 def canonical_sha256(value: Mapping[str, Any]) -> str:
@@ -62,6 +64,8 @@ def initial_health(artifact_id: str, *, now_ms: int) -> dict[str, Any]:
         "successes": 0,
         "failures": 0,
         "consecutive_failures": 0,
+        "success_streak": 0,
+        "last_success_at_ms": 0,
         "patch_rounds": 0,
         "patch_pending": None,
         "patch_history": [],
@@ -137,9 +141,13 @@ def ingest_outcome(
     if result == "success":
         health["successes"] = int(health.get("successes") or 0) + 1
         health["consecutive_failures"] = 0
+        # 正向强化：连胜与最近成功时间是健康分的组成部分。
+        health["success_streak"] = int(health.get("success_streak") or 0) + 1
+        health["last_success_at_ms"] = occurred_ms
     else:
         health["failures"] = int(health.get("failures") or 0) + 1
         health["consecutive_failures"] = int(health.get("consecutive_failures") or 0) + 1
+        health["success_streak"] = 0
     health["seen_outcome_ids"] = seen
     health["last_outcome_at_ms"] = occurred_ms
     value["health"] = health
@@ -152,6 +160,36 @@ def ingest_outcome(
     ):
         return value, "request_patch", "consecutive_failures"
     return value, "none", "recorded"
+
+
+def health_score_milli(health: Mapping[str, Any], now_ms: int) -> int:
+    """综合健康分（0-1000 毫值），用于能力排序：成功者靠前、闲置者自然沉底。
+
+    组成：保守成功率（Hoeffding 风格下界，样本少时向中性 500 收缩）
+    × 新鲜度（7 天半衰，越久未用越向 500 衰减） + 连胜加成（封顶 100）。
+    """
+    _int(now_ms, "now_ms")
+    uses = int(health.get("uses") or 0)
+    successes = int(health.get("successes") or 0)
+    if uses <= 0:
+        rate = 0.5
+    else:
+        raw = successes / uses
+        # Hoeffding 风格保守下界（α=0.05，ln(1/α)≈3）：样本少时显著低于观测率。
+        penalty = (3.0 / (2.0 * uses)) ** 0.5
+        conservative = max(0.0, raw - penalty)
+        # 向中性 0.5 收缩：样本越少越接近"不知道"，而不是"差"。
+        weight = uses / (uses + 10)
+        rate = 0.5 + weight * (conservative - 0.5)
+    last_ms = int(health.get("last_outcome_at_ms") or 0)
+    if last_ms <= 0:
+        decay = 1.0
+    else:
+        half_lives = max(0, int(now_ms) - last_ms) / HEALTH_FRESHNESS_HALF_LIFE_MS
+        decay = 1.0 - 0.5 ** half_lives
+    rate_milli = 500.0 + (rate - 0.5) * 1000.0 * (1.0 - decay)
+    streak_bonus = min(100, int(health.get("success_streak") or 0) * 10)
+    return max(0, min(1000, int(round(rate_milli)) + streak_bonus))
 
 
 def propose_patch(
@@ -310,6 +348,8 @@ def reactivate_pointer(
     health["consecutive_failures"] = 0
     health["patch_rounds"] = 0
     health["patch_pending"] = None
+    # 重新激活等于重新赢得信任：连胜清零，从头积累。
+    health["success_streak"] = 0
     health["reactivated_at_ms"] = _int(now_ms, "now_ms")
     value["health"] = health
     value["status"] = "active"
@@ -344,6 +384,7 @@ __all__ = [
     "initial_health",
     "attach_health",
     "ingest_outcome",
+    "health_score_milli",
     "propose_patch",
     "settle_patch",
     "degrade_pointer",

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -87,8 +87,10 @@ from .learning_executor import execute_learning_preview
 from .capability_health import (
     DEFAULT_MAX_CONSECUTIVE_FAILURES,
     DEFAULT_MAX_PATCH_ROUNDS,
+    HEALTH_FRESHNESS_HALF_LIFE_MS,
     attach_health,
     degrade_pointer,
+    health_score_milli,
     ingest_outcome,
     propose_patch,
     reactivate_pointer,
@@ -6514,6 +6516,7 @@ class EmbeddedLifeRuntime:
             raise EmbeddedLifeError("life.identity.id_invalid", status=409)
         scope = self._scope_state(life_id)
         pointers = scope.get("capability_pointers") if isinstance(scope.get("capability_pointers"), Mapping) else {}
+        now_ms = time.time_ns() // 1_000_000
         rows = []
         for raw in scope["capabilities"].values():
             if not isinstance(raw, Mapping) or raw.get("status") != "published" or raw.get("kind") not in {"skill", "tool"}:
@@ -6526,8 +6529,29 @@ class EmbeddedLifeRuntime:
             activation_status = str(pointer.get("status") or "pending")
             row["activation_status"] = activation_status
             row["runtime_usable"] = activation_status == "active"
+            health = pointer.get("health") if isinstance(pointer.get("health"), Mapping) else {}
+            row["health_score_milli"] = health_score_milli(health, now_ms)
+            row["last_outcome_at_ms"] = int(health.get("last_outcome_at_ms") or 0)
+            # 闲置标记（派生，不持久化）：>7 天无真实执行结果的 active 能力。
+            # 只影响排序自然沉底与 32 条截断淘汰，不降级、不禁用；补丁验证中的不算闲置。
+            last_outcome_ms = row["last_outcome_at_ms"]
+            row["idle"] = bool(
+                activation_status == "active"
+                and last_outcome_ms > 0
+                and now_ms - last_outcome_ms > HEALTH_FRESHNESS_HALF_LIFE_MS
+                and not health.get("patch_pending")
+            )
             rows.append(row)
-        rows.sort(key=lambda item: (str(item.get("kind")), str(item.get("title")), int(item.get("version") or 0)))
+        # 健康分排序：成功且常用的能力靠前，闲置者自然沉底（32 条截断即淘汰）。
+        rows.sort(
+            key=lambda item: (
+                -int(item.get("health_score_milli") or 0),
+                -int(item.get("last_outcome_at_ms") or 0),
+                str(item.get("kind")),
+                str(item.get("title")),
+                int(item.get("version") or 0),
+            )
+        )
         model_context = []
         active_rows = [row for row in rows if row.get("activation_status") == "active"]
         for row in active_rows[:32]:
@@ -6539,6 +6563,7 @@ class EmbeddedLifeRuntime:
                 "title": row.get("title"),
                 "summary": row.get("summary"),
                 "risk_level": row.get("risk_level"),
+                "health_score_milli": row.get("health_score_milli"),
                 "task_intents": list(spec.get("task_intents") or [])[:24],
                 "required_actions": list(row.get("required_actions") or [])[:16],
                 "steps": list(spec.get("steps") or [])[:16],
@@ -6839,6 +6864,7 @@ class EmbeddedLifeRuntime:
                 key: health.get(key)
                 for key in (
                     "uses", "successes", "failures", "consecutive_failures",
+                    "success_streak", "last_success_at_ms", "last_outcome_at_ms",
                     "patch_rounds", "patch_history",
                 )
             },

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -64,6 +64,7 @@ from .legacy_fusion import default_body, default_schedule, normalize_body, norma
 from .panel_projection import (
     action_value_projection,
     boundary_projection,
+    capability_profile_projection,
     catalog_tasks_for_day,
     fallback_context_projection,
     long_term_goals,
@@ -72,6 +73,7 @@ from .panel_projection import (
     preference_projection,
     record_day,
     records_for_day,
+    reflection_card_projection,
     reflection_projection,
 )
 from .artifact_executor import (
@@ -2481,6 +2483,13 @@ class EmbeddedLifeRuntime:
         """熔断开关：TIANGONG_LIFE_REFLECTION_CHAIN=0 时整条反思链停摆。"""
         return str(os.environ.get("TIANGONG_LIFE_REFLECTION_CHAIN") or "1").strip() != "0"
 
+    def _recent_reflection_rows(self, life_id: str) -> list[Any] | None:
+        """最近反思卡（供 activity scope 注入；store 不可用时返回 None 零影响）。"""
+        try:
+            return list(self._contract_store().list_reflection_cards(life_id, limit=5))
+        except Exception:
+            return None
+
     def _reflection_signer(self) -> tuple[str, Any]:
         """进程内 Ed25519 写者。链只校验哈希连续性不验签；密钥随进程。"""
         key = getattr(self, "_reflection_signer_key", None)
@@ -3196,6 +3205,7 @@ class EmbeddedLifeRuntime:
                         life_id=life_id,
                         soul=self._soul(),
                         scope=self._scope_state(life_id),
+                        reflection_rows=self._recent_reflection_rows(life_id),
                     )
                     task = deepcopy(self._autonomy_state(life_id)["tasks"][task_id])
                     # F3 挂点1：事前预测先落账（OPEN episode），事后不可编造；
@@ -3556,7 +3566,7 @@ class EmbeddedLifeRuntime:
 
         def worker() -> None:
             try:
-                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id))
+                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id), reflection_rows=self._recent_reflection_rows(life_id))
                 decision = self._learning_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("learning model decision is invalid")
@@ -3654,7 +3664,7 @@ class EmbeddedLifeRuntime:
 
         def worker() -> None:
             try:
-                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id))
+                scope = build_activity_scope(life_id=life_id, soul=self._soul(), scope=self._scope_state(life_id), reflection_rows=self._recent_reflection_rows(life_id))
                 decision = self._self_iteration_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("self-iteration model decision is invalid")
@@ -5100,6 +5110,17 @@ class EmbeddedLifeRuntime:
             completed_autonomous_tasks,
             preferences,
         )
+        # P8 反思链卡片（只读独立键，不动现有 reflections/action_values）。
+        reflection_cards: list[dict[str, Any]] = []
+        try:
+            reflection_cards = [
+                reflection_card_projection(card)
+                for card in self._contract_store().list_reflection_cards(
+                    str(self._active().get("life_id") or ""), limit=20
+                )
+            ]
+        except Exception:
+            reflection_cards = []
         affect_state = deepcopy(scope["affect"])
         affect_state.setdefault(
             "drives",
@@ -5235,6 +5256,7 @@ class EmbeddedLifeRuntime:
             },
             "drift": drift_rows,
             "reflections": reflection_rows,
+            "reflection_cards": reflection_cards,
             "action_values": action_value_rows,
             "learning": {
                 "candidate_count": len(learning_pending),
@@ -7130,6 +7152,15 @@ class EmbeddedLifeRuntime:
         scope = self._scope_state(life_id)
         pointers = scope.get("capability_pointers") if isinstance(scope.get("capability_pointers"), Mapping) else {}
         now_ms = time.time_ns() // 1_000_000
+        # 认知层 profile（capability_learning 双体系之认知侧，只读输入）。
+        profiles_by_capability: dict[str, Any] = {}
+        try:
+            profiles_by_capability = {
+                str(profile.capability_id): profile
+                for profile in self._contract_store().latest_capability_profiles(life_id)
+            }
+        except Exception:
+            profiles_by_capability = {}
         rows = []
         for raw in scope["capabilities"].values():
             if not isinstance(raw, Mapping) or raw.get("status") != "published" or raw.get("kind") not in {"skill", "tool"}:
@@ -7145,6 +7176,12 @@ class EmbeddedLifeRuntime:
             health = pointer.get("health") if isinstance(pointer.get("health"), Mapping) else {}
             row["health_score_milli"] = health_score_milli(health, now_ms)
             row["last_outcome_at_ms"] = int(health.get("last_outcome_at_ms") or 0)
+            profile = profiles_by_capability.get(str(row.get("artifact_id") or ""))
+            proficiency = int(getattr(profile, "proficiency_lower_bound_milli", 0) or 0) if profile else 0
+            row["profile"] = capability_profile_projection(profile) if profile else None
+            row["proficiency_lower_bound_milli"] = proficiency
+            # 决策 D：双体系综合分——运行时健康与认知熟练度任一看好即靠前。
+            row["composite_score_milli"] = max(int(row["health_score_milli"]), proficiency)
             # 闲置标记（派生，不持久化）：>7 天无真实执行结果的 active 能力。
             # 只影响排序自然沉底与 32 条截断淘汰，不降级、不禁用；补丁验证中的不算闲置。
             last_outcome_ms = row["last_outcome_at_ms"]
@@ -7155,10 +7192,11 @@ class EmbeddedLifeRuntime:
                 and not health.get("patch_pending")
             )
             rows.append(row)
-        # 健康分排序：成功且常用的能力靠前，闲置者自然沉底（32 条截断即淘汰）。
+        # 综合分排序：成功、常用、有认知熟练度的能力靠前，闲置者自然沉底
+        # （32 条截断即淘汰）。
         rows.sort(
             key=lambda item: (
-                -int(item.get("health_score_milli") or 0),
+                -int(item.get("composite_score_milli") or 0),
                 -int(item.get("last_outcome_at_ms") or 0),
                 str(item.get("kind")),
                 str(item.get("title")),
@@ -7177,6 +7215,7 @@ class EmbeddedLifeRuntime:
                 "summary": row.get("summary"),
                 "risk_level": row.get("risk_level"),
                 "health_score_milli": row.get("health_score_milli"),
+                "proficiency_lower_bound_milli": row.get("proficiency_lower_bound_milli"),
                 "task_intents": list(spec.get("task_intents") or [])[:24],
                 "required_actions": list(row.get("required_actions") or [])[:16],
                 "steps": list(spec.get("steps") or [])[:16],

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -748,6 +748,9 @@ class EmbeddedLifeRuntime:
                 "proactive_min_utility_lcb_milli": 120,
                 "proactive_min_margin_milli": 80,
                 "proactive_reply_link_window_seconds": 21600,
+                # F1 忽略率门禁：用户持续不回复时抬高开口门槛（0 = 禁用门禁）。
+                "proactive_engagement_window_size": 8,
+                "proactive_min_reply_rate_milli": 200,
                 "learned_boundary_rules": [],
             },
             "inbox": [],
@@ -3301,6 +3304,25 @@ class EmbeddedLifeRuntime:
             and str(row.get("reason") or "") == "life.proactive.native"
             and int(row.get("created_at_ms") or 0) > 0
         ]
+        context_settings = scope.get("settings") if isinstance(scope.get("settings"), Mapping) else {}
+        # F1：投递结果投影（replied/acked）供忽略率门禁消费。仍在回复链接
+        # 窗口内的投递不算数——用户还来得及回，不能提前记为忽略。
+        reply_window_ms = max(
+            60, int(context_settings.get("proactive_reply_link_window_seconds") or 21600)
+        ) * 1000
+        delivery_outcomes = [
+            {
+                "created_at_ms": int(row.get("created_at_ms") or 0),
+                "candidate_kind": str(row.get("candidate_kind") or ""),
+                "replied": bool(row.get("replied")),
+                "acked": bool(row.get("acked")),
+            }
+            for row in scope.get("proactive_chats", [])
+            if isinstance(row, Mapping)
+            and str(row.get("reason") or "") == "life.proactive.native"
+            and int(row.get("created_at_ms") or 0) > 0
+            and now_ms - int(row.get("created_at_ms") or 0) > reply_window_ms
+        ]
         affect = scope.get("affect") if isinstance(scope.get("affect"), Mapping) else {}
         return {
             "schema": "tiangong.life.initiative-context.v1",
@@ -3311,6 +3333,7 @@ class EmbeddedLifeRuntime:
             "last_user_activity_at_ms": int(scheduler.get("last_user_activity_at_ms") or 0),
             "last_user_run_id": str(scheduler.get("last_user_run_id") or ""),
             "recent_delivery_times_ms": deliveries[-64:],
+            "recent_delivery_outcomes": delivery_outcomes[-64:],
             "observations": observations[:40],
             "recent_tasks": task_projection,
             "relationships": self._project_proactive_relationships(life_id=life_id),
@@ -8722,6 +8745,8 @@ class EmbeddedLifeRuntime:
                         "proactive_min_utility_lcb_milli",
                         "proactive_min_margin_milli",
                         "proactive_reply_link_window_seconds",
+                        "proactive_engagement_window_size",
+                        "proactive_min_reply_rate_milli",
                     }
                     # Preserve namespaced/extension settings used by plugins and
                     # tests.  Known safety-sensitive keys are strongly typed;
@@ -8787,6 +8812,8 @@ class EmbeddedLifeRuntime:
                         "proactive_min_utility_lcb_milli": (0, 4000),
                         "proactive_min_margin_milli": (0, 4000),
                         "proactive_reply_link_window_seconds": (60, 604800),
+                        "proactive_engagement_window_size": (0, 64),
+                        "proactive_min_reply_rate_milli": (0, 1000),
                     }
                     for key, (minimum, maximum) in limits.items():
                         if key not in updates:

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -707,6 +707,14 @@ class EmbeddedLifeRuntime:
                 "heartbeat_enabled": True,
                 "llm_daily_budget": 20,
                 "llm_daily_attempt_budget": 30,
+                # 学习/自我迭代/能力补丁三个调度器各自的子预算：与 proactive
+                # 同样隔离于全局生命模型预算，防止单一子系统吃满整天的量。
+                "learning_llm_daily_budget": 6,
+                "learning_llm_daily_attempt_budget": 8,
+                "self_iteration_llm_daily_budget": 4,
+                "self_iteration_llm_daily_attempt_budget": 6,
+                "capability_patch_llm_daily_budget": 6,
+                "capability_patch_llm_daily_attempt_budget": 8,
                 "share_enabled": True,
                 "share_quiet_if_user_active": True,
                 "share_min_interval_seconds": 2700,
@@ -785,6 +793,24 @@ class EmbeddedLifeRuntime:
                 "proactive_model_failures": 0,
                 "proactive_model_timeouts": 0,
                 "proactive_model_skipped": 0,
+                "learning_model_budget_date": "",
+                "learning_model_attempts": 0,
+                "learning_model_successes": 0,
+                "learning_model_failures": 0,
+                "learning_model_timeouts": 0,
+                "learning_model_skipped": 0,
+                "self_iteration_model_budget_date": "",
+                "self_iteration_model_attempts": 0,
+                "self_iteration_model_successes": 0,
+                "self_iteration_model_failures": 0,
+                "self_iteration_model_timeouts": 0,
+                "self_iteration_model_skipped": 0,
+                "capability_patch_model_budget_date": "",
+                "capability_patch_model_attempts": 0,
+                "capability_patch_model_successes": 0,
+                "capability_patch_model_failures": 0,
+                "capability_patch_model_timeouts": 0,
+                "capability_patch_model_skipped": 0,
                 "last_user_run_id": "",
             },
             "updated_at": utc_now(),
@@ -2923,6 +2949,11 @@ class EmbeddedLifeRuntime:
         if not callable(getattr(self, "_learning_decider", None)):
             scheduler["last_learning_decision_error"] = "life.learning.model_bridge_unavailable"
             return
+        if not self._reserve_sub_model_call_locked(scheduler=scheduler, settings=settings, pool="learning"):
+            scheduler["last_learning_decision_at_ms"] = now_ms
+            scheduler["last_learning_decision_error"] = "life.learning.model_budget_exhausted"
+            self._persist(life_id)
+            return
         scheduler["learning_decision_inflight"] = True
         scheduler["last_learning_decision_at_ms"] = now_ms
         scheduler["last_learning_decision_error"] = ""
@@ -2934,6 +2965,11 @@ class EmbeddedLifeRuntime:
                 decision = self._learning_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("learning model decision is invalid")
+                with self._lock:
+                    self._account_sub_model_success_locked(
+                        self._scope_state(life_id).setdefault("scheduler", {}),
+                        pool="learning",
+                    )
                 target = str(decision.get("target") or decision.get("artifact_kind") or "").strip().casefold()
                 with self._lock:
                     if target in {"", "none", "no_learning", "no-learning"}:
@@ -2971,7 +3007,13 @@ class EmbeddedLifeRuntime:
                 # instead of recording only the exception type.
                 detail = re.sub(r"\s+", " ", str(exc)).strip()[:160]
                 with self._lock:
-                    self._scope_state(life_id).setdefault("scheduler", {})[
+                    scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
+                    self._account_sub_model_failure_locked(
+                        scheduler_state,
+                        pool="learning",
+                        timeout=isinstance(exc, TimeoutError),
+                    )
+                    scheduler_state[
                         "last_learning_decision_error"
                     ] = f"life.learning.decision_failed:{type(exc).__name__}:{detail}"
             finally:
@@ -3005,6 +3047,11 @@ class EmbeddedLifeRuntime:
         if not callable(getattr(self, "_self_iteration_decider", None)):
             scheduler["last_self_iteration_decision_error"] = "life.self_iteration.model_bridge_unavailable"
             return
+        if not self._reserve_sub_model_call_locked(scheduler=scheduler, settings=settings, pool="self_iteration"):
+            scheduler["last_self_iteration_decision_at_ms"] = now_ms
+            scheduler["last_self_iteration_decision_error"] = "life.self_iteration.model_budget_exhausted"
+            self._persist(life_id)
+            return
         scheduler["self_iteration_decision_inflight"] = True
         scheduler["last_self_iteration_decision_at_ms"] = now_ms
         scheduler["last_self_iteration_decision_error"] = ""
@@ -3016,6 +3063,11 @@ class EmbeddedLifeRuntime:
                 decision = self._self_iteration_decider(scope)
                 if not isinstance(decision, Mapping):
                     raise ValueError("self-iteration model decision is invalid")
+                with self._lock:
+                    self._account_sub_model_success_locked(
+                        self._scope_state(life_id).setdefault("scheduler", {}),
+                        pool="self_iteration",
+                    )
                 target = str(decision.get("target") or "").strip().casefold()
                 with self._lock:
                     if target in {"", "none", "no_upgrade", "no-upgrade"}:
@@ -3028,7 +3080,13 @@ class EmbeddedLifeRuntime:
             except Exception as exc:
                 detail = re.sub(r"\s+", " ", str(exc)).strip()[:160]
                 with self._lock:
-                    self._scope_state(life_id).setdefault("scheduler", {})[
+                    scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
+                    self._account_sub_model_failure_locked(
+                        scheduler_state,
+                        pool="self_iteration",
+                        timeout=isinstance(exc, TimeoutError),
+                    )
+                    scheduler_state[
                         "last_self_iteration_decision_error"
                     ] = f"life.self_iteration.decision_failed:{type(exc).__name__}:{detail}"
             finally:
@@ -3319,6 +3377,117 @@ class EmbeddedLifeRuntime:
         scheduler["model_attempts"] = int(scheduler.get("model_attempts") or 0) + 1
         scheduler["proactive_model_attempts"] = int(scheduler.get("proactive_model_attempts") or 0) + 1
         return True
+
+    # 学习/自我迭代/能力补丁三个调度器的子预算隔离：与 proactive 同模式，
+    # 全局池 + 子池双检查双累加，防止任何一个子系统占满全局生命模型预算。
+    _MODEL_SUB_BUDGET_POOLS = {
+        "learning": {
+            "prefix": "learning_model_",
+            "success_key": "learning_llm_daily_budget",
+            "success_default": 6,
+            "attempt_key": "learning_llm_daily_attempt_budget",
+            "attempt_default": 8,
+        },
+        "self_iteration": {
+            "prefix": "self_iteration_model_",
+            "success_key": "self_iteration_llm_daily_budget",
+            "success_default": 4,
+            "attempt_key": "self_iteration_llm_daily_attempt_budget",
+            "attempt_default": 6,
+        },
+        "capability_patch": {
+            "prefix": "capability_patch_model_",
+            "success_key": "capability_patch_llm_daily_budget",
+            "success_default": 6,
+            "attempt_key": "capability_patch_llm_daily_attempt_budget",
+            "attempt_default": 8,
+        },
+    }
+
+    def _reset_sub_model_budget_if_needed(self, scheduler: dict[str, Any], *, pool: str) -> None:
+        config = self._MODEL_SUB_BUDGET_POOLS[pool]
+        prefix = str(config["prefix"])
+        budget_day = utc_now()[:10]
+        # Preserve the existing global Life-model hard cap.
+        if str(scheduler.get("model_budget_date") or "") != budget_day:
+            scheduler.update({
+                "model_budget_date": budget_day,
+                "model_attempts": 0,
+                "model_successes": 0,
+                "model_failures": 0,
+                "model_timeouts": 0,
+                "model_skipped": 0,
+            })
+        if str(scheduler.get(f"{prefix}budget_date") or "") != budget_day:
+            scheduler.update({
+                f"{prefix}budget_date": budget_day,
+                f"{prefix}attempts": 0,
+                f"{prefix}successes": 0,
+                f"{prefix}failures": 0,
+                f"{prefix}timeouts": 0,
+                f"{prefix}skipped": 0,
+            })
+
+    def _sub_model_budget_exhausted(
+        self,
+        scheduler: dict[str, Any],
+        *,
+        settings: Mapping[str, Any],
+        pool: str,
+    ) -> bool:
+        """Check-only peek (no counter changes); performs the daily reset."""
+        config = self._MODEL_SUB_BUDGET_POOLS[pool]
+        prefix = str(config["prefix"])
+        self._reset_sub_model_budget_if_needed(scheduler, pool=pool)
+        global_success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
+        global_attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
+        sub_success_limit = self._daily_limit_setting(settings, str(config["success_key"]), int(config["success_default"]))
+        sub_attempt_limit = self._daily_limit_setting(settings, str(config["attempt_key"]), int(config["attempt_default"]))
+        return (
+            (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
+            or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
+            or (sub_success_limit and int(scheduler.get(f"{prefix}successes") or 0) >= sub_success_limit)
+            or (sub_attempt_limit and int(scheduler.get(f"{prefix}attempts") or 0) >= sub_attempt_limit)
+        )
+
+    def _reserve_sub_model_call_locked(
+        self,
+        *,
+        scheduler: dict[str, Any],
+        settings: Mapping[str, Any],
+        pool: str,
+    ) -> bool:
+        """Reserve one real LLM call against both the global and the sub pool."""
+        config = self._MODEL_SUB_BUDGET_POOLS[pool]
+        prefix = str(config["prefix"])
+        if self._sub_model_budget_exhausted(scheduler, settings=settings, pool=pool):
+            scheduler["model_skipped"] = int(scheduler.get("model_skipped") or 0) + 1
+            scheduler[f"{prefix}skipped"] = int(scheduler.get(f"{prefix}skipped") or 0) + 1
+            return False
+        scheduler["model_attempts"] = int(scheduler.get("model_attempts") or 0) + 1
+        scheduler[f"{prefix}attempts"] = int(scheduler.get(f"{prefix}attempts") or 0) + 1
+        return True
+
+    def _account_sub_model_success_locked(self, scheduler: dict[str, Any], *, pool: str) -> None:
+        prefix = str(self._MODEL_SUB_BUDGET_POOLS[pool]["prefix"])
+        self._reset_sub_model_budget_if_needed(scheduler, pool=pool)
+        scheduler["model_successes"] = int(scheduler.get("model_successes") or 0) + 1
+        scheduler[f"{prefix}successes"] = int(scheduler.get(f"{prefix}successes") or 0) + 1
+
+    def _account_sub_model_failure_locked(
+        self,
+        scheduler: dict[str, Any],
+        *,
+        pool: str,
+        timeout: bool = False,
+    ) -> None:
+        prefix = str(self._MODEL_SUB_BUDGET_POOLS[pool]["prefix"])
+        self._reset_sub_model_budget_if_needed(scheduler, pool=pool)
+        scheduler["model_failures"] = int(scheduler.get("model_failures") or 0) + 1
+        scheduler[f"{prefix}failures"] = int(scheduler.get(f"{prefix}failures") or 0) + 1
+        if timeout:
+            scheduler["model_timeouts"] = int(scheduler.get("model_timeouts") or 0) + 1
+            scheduler[f"{prefix}timeouts"] = int(scheduler.get(f"{prefix}timeouts") or 0) + 1
 
     def _schedule_native_proactive(self, *, life_id: str) -> None:
         """Schedule the sole post-P15 proactive producer without blocking heartbeat."""
@@ -7146,6 +7315,12 @@ class EmbeddedLifeRuntime:
             return
         if not callable(getattr(self, "_capability_patch_decider", None)):
             return
+        # 子池已耗尽时不再起线程；真正的按次记账在 worker 内每个补丁目标前完成。
+        if self._sub_model_budget_exhausted(scheduler, settings=scope_state["settings"], pool="capability_patch"):
+            scheduler["last_capability_health_at_ms"] = now_ms
+            scheduler["last_capability_health_error"] = "life.capability_patch.model_budget_exhausted"
+            self._persist(life_id)
+            return
         scheduler["capability_health_inflight"] = True
         scheduler["last_capability_health_at_ms"] = now_ms
         self._persist(life_id)
@@ -7179,10 +7354,39 @@ class EmbeddedLifeRuntime:
                         pointer=target["pointer"],
                         scope=self._scope_state(life_id),
                     )
-                    decision = self._capability_patch_decider(material)
-                    if not isinstance(decision, Mapping):
+                    # 每个补丁目标一次真实的模型调用，逐一记账。
+                    with self._lock:
+                        scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
+                        if not self._reserve_sub_model_call_locked(
+                            scheduler=scheduler_state,
+                            settings=self._scope_state(life_id)["settings"],
+                            pool="capability_patch",
+                        ):
+                            scheduler_state["last_capability_health_error"] = "life.capability_patch.model_budget_exhausted"
+                            self._persist(life_id)
+                            return
+                    try:
+                        decision = self._capability_patch_decider(material)
+                        valid_decision = isinstance(decision, Mapping)
+                    except Exception:
+                        with self._lock:
+                            self._account_sub_model_failure_locked(
+                                self._scope_state(life_id).setdefault("scheduler", {}),
+                                pool="capability_patch",
+                            )
+                        continue
+                    if not valid_decision:
+                        with self._lock:
+                            self._account_sub_model_failure_locked(
+                                self._scope_state(life_id).setdefault("scheduler", {}),
+                                pool="capability_patch",
+                            )
                         continue
                     with self._lock:
+                        self._account_sub_model_success_locked(
+                            self._scope_state(life_id).setdefault("scheduler", {}),
+                            pool="capability_patch",
+                        )
                         proposed = self._capability_patch_propose(
                             {"life_id": life_id, "artifact_id": artifact["artifact_id"], "actor": "life_health"},
                             decision=decision,
@@ -8459,6 +8663,12 @@ class EmbeddedLifeRuntime:
                         "heartbeat_enabled",
                         "llm_daily_budget",
                         "llm_daily_attempt_budget",
+                        "learning_llm_daily_budget",
+                        "learning_llm_daily_attempt_budget",
+                        "self_iteration_llm_daily_budget",
+                        "self_iteration_llm_daily_attempt_budget",
+                        "capability_patch_llm_daily_budget",
+                        "capability_patch_llm_daily_attempt_budget",
                         "share_enabled",
                         "share_quiet_if_user_active",
                         "share_min_interval_seconds",

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -27,12 +27,14 @@ from contracts import (
     CausalContextItem,
     CausalEpisodeVNext,
     LifeAuthorityHead,
+    LifeEventEnvelope,
     LifeRevisionVector,
     RootExperienceHead,
     RunLifeBinding,
     canonical_json_bytes,
     canonical_sha256,
 )
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from .autonomous_tasks import (
     ACTIVE_TASK_STATES,
@@ -96,6 +98,19 @@ from .capability_health import (
     reactivate_pointer,
     runtime_usable,
     settle_patch,
+)
+from .capability_learning import build_capability_evidence
+from .episode_builder import (
+    build_action_impact,
+    build_life_event,
+    build_open_episode,
+    build_outcome_evidence,
+    build_prediction,
+    failure_category_from_error,
+    failure_category_from_step_error,
+    fingerprint,
+    observed_quality_from_steps,
+    prediction_from_snapshot,
 )
 from .memory_classification import classify_memory, normalize_relations
 from .memory_lifecycle import advance_lifecycle, initial_lifecycle, normalize_lifecycle, recall_lifecycle
@@ -2441,12 +2456,521 @@ class EmbeddedLifeRuntime:
                         f"{recovered.get('attempt_count', 0)}"
                     ),
                 )
+                # F3 挂点4：陈旧恢复 → 仍 OPEN 的 episode 以 ABORTED 收尾，消孤儿。
+                with self._lock:
+                    self._abort_runtime_episode_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=task_id,
+                        reason="life.autonomy.stale_running_recovered",
+                    )
                 self._persist(life_id)
             except Exception:
                 scope["autonomy"] = before
                 raise
             recovered_count += 1
         return recovered_count
+
+    # ---------- P8 反思链生产接线（F3：任务/能力双源，事前预测先落账） ----------
+    # 决策 E：所有 life_events 链操作（读 head→构造→append）在 self._lock 内；
+    # 任一环节失败即放弃该次反思并 journal（life.episode.failed），绝不向上抛。
+
+    _REFLECTION_EPISODE_REGISTRY_CAP = 32
+
+    def _reflection_chain_enabled(self) -> bool:
+        """熔断开关：TIANGONG_LIFE_REFLECTION_CHAIN=0 时整条反思链停摆。"""
+        return str(os.environ.get("TIANGONG_LIFE_REFLECTION_CHAIN") or "1").strip() != "0"
+
+    def _reflection_signer(self) -> tuple[str, Any]:
+        """进程内 Ed25519 写者。链只校验哈希连续性不验签；密钥随进程。"""
+        key = getattr(self, "_reflection_signer_key", None)
+        if key is None:
+            key = Ed25519PrivateKey.generate()
+            self._reflection_signer_key = key
+        return "life_reflection_chain", lambda digest: key.sign(digest).hex()
+
+    def _reflection_journal_failure(
+        self, life_id: str, phase: str, exc: BaseException | None
+    ) -> None:
+        try:
+            self.system.journal.append(
+                life_id,
+                "life.episode.failed",
+                {
+                    "phase": str(phase),
+                    "error_type": type(exc).__name__ if exc else "",
+                    "detail": re.sub(r"\s+", " ", str(exc or ""))[:160],
+                },
+                actor="life_reflection",
+                idempotency_key=(
+                    f"life.reflection.failed:{phase}:{time.time_ns() // 1_000_000}"
+                ),
+            )
+        except Exception:
+            pass  # 观测性日志失败不得影响主流程
+
+    def _runtime_life_event_locked(
+        self,
+        *,
+        life_id: str,
+        event_kind: str,
+        content: Mapping[str, Any],
+        correlation_id: str,
+        causation_id: str | None = None,
+    ) -> LifeEventEnvelope | None:
+        """向权威链追加一个反思链事件；不可用/失败时返回 None。"""
+        try:
+            store = self._contract_store()
+            head = store.life_event_head(life_id)
+            now_ms = time.time_ns() // 1_000_000
+            key_id, sign = self._reflection_signer()
+            event = build_life_event(
+                life_id=life_id,
+                sequence=1 if head is None else head.sequence + 1,
+                writer_epoch=1 if head is None else head.writer_epoch,
+                previous_event_hash=None if head is None else head.event_hash,
+                event_kind=event_kind,
+                content=content,
+                occurred_at_ms=now_ms,
+                observed_at_ms=now_ms,
+                correlation_id=correlation_id,
+                causation_id=causation_id,
+                signer_key_id=key_id,
+                sign=sign,
+            )
+            store.append_event(event)
+            return event
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, f"event:{event_kind}", exc)
+            return None
+
+    def _open_runtime_episode_locked(
+        self,
+        *,
+        life_id: str,
+        source: str,
+        ref_id: str,
+        event_kind: str,
+        intention: str,
+        context_sha256: str,
+        prediction: Any,
+        action_risk: str,
+        candidate_action_ids: tuple[str, ...] = (),
+        selected_action_id: str | None = None,
+        started_event: LifeEventEnvelope | None = None,
+        registry_extra: Mapping[str, Any] | None = None,
+    ) -> str | None:
+        """事前落账：started 事件 → OPEN episode → 注册表登记（FIFO 32）。"""
+        if not self._reflection_chain_enabled():
+            return None
+        try:
+            started = started_event or self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind=event_kind,
+                content={
+                    "ref": ref_id,
+                    "source": source,
+                    "intention": intention[:800],
+                    "predicted_success_milli": prediction.predicted_success_milli,
+                    "prediction_snapshot_sha256": prediction.snapshot_sha256,
+                    "action_risk": action_risk,
+                },
+                correlation_id=f"{source}:{ref_id}",
+            )
+            if started is None:
+                return None
+            episode = build_open_episode(
+                life_id=life_id,
+                trigger_event_ids=[started.event_id],
+                context_state_hashes=[context_sha256 or started.event_hash],
+                intention=intention[:20_000],
+                prediction=prediction,
+                candidate_action_ids=candidate_action_ids,
+                selected_action_id=selected_action_id,
+                created_at_ms=time.time_ns() // 1_000_000,
+            )
+            self._contract_store().put_causal_episode(episode)
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "open", exc)
+            return None
+        scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+        registry = [
+            row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+        ]
+        registry.append({
+            "source": source,
+            "ref": ref_id,
+            "episode_id": episode.episode_id,
+            "correlation_id": f"{source}:{ref_id}",
+            "predicted_success_milli": prediction.predicted_success_milli,
+            "prediction_snapshot": prediction.snapshot,
+            "context_sha256": context_sha256,
+            "action_risk": action_risk,
+            "opened_at_ms": time.time_ns() // 1_000_000,
+            **(dict(registry_extra) if registry_extra else {}),
+        })
+        scheduler["open_episodes"] = registry[-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+        try:
+            self.system.journal.append(
+                life_id,
+                "life.episode.opened",
+                {"episode_id": episode.episode_id, "source": source, "ref": ref_id},
+                actor="life_reflection",
+                idempotency_key=f"life.reflection.open:{episode.episode_id}",
+            )
+        except Exception:
+            pass
+        self._persist(life_id)
+        return episode.episode_id
+
+    def _commit_runtime_reflection_locked(
+        self,
+        *,
+        life_id: str,
+        source: str,
+        ref_id: str,
+        outcome_status: str,
+        observed_outcome: str,
+        observed_quality_milli: int,
+        completion_decision: Mapping[str, Any],
+        terminal_fact_parts: Mapping[str, Any],
+        event_kind: str,
+        failure_category: str | None = None,
+        journal_event: str = "life.episode.committed",
+    ) -> None:
+        """事后收尾：outcome 事件 → 结果证据 → 原子闭环反思 → 注册表移除。"""
+        if not self._reflection_chain_enabled():
+            return
+        try:
+            scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+            registry = [
+                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+            ]
+            entry = next(
+                (
+                    row for row in registry
+                    if str(row.get("source") or "") == source
+                    and str(row.get("ref") or "") == ref_id
+                ),
+                None,
+            )
+            if entry is None:
+                return  # 没有事前落账（链路关闭或 opening 失败），无从收尾
+            outcome_event = self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind=event_kind,
+                content={
+                    "ref": ref_id,
+                    "source": source,
+                    "outcome_status": outcome_status,
+                    "quality_milli": observed_quality_milli,
+                    **{str(key): value for key, value in terminal_fact_parts.items()},
+                },
+                correlation_id=str(entry.get("correlation_id") or f"{source}:{ref_id}"),
+            )
+            if outcome_event is None:
+                return
+            prediction = prediction_from_snapshot(entry.get("prediction_snapshot") or {})
+            outcome = build_outcome_evidence(
+                life_id=life_id,
+                episode_id=str(entry.get("episode_id") or ""),
+                outcome_status=outcome_status,
+                observed_outcome=observed_outcome[:50_000],
+                observed_quality_milli=observed_quality_milli,
+                prediction=prediction,
+                completion_decision_sha256=fingerprint(dict(completion_decision)),
+                terminal_fact_hashes=[outcome_event.event_hash],
+                outcome_event_ids=[outcome_event.event_id],
+                context_fingerprint_sha256=str(entry.get("context_sha256") or ""),
+                action_risk=str(entry.get("action_risk") or "A1"),
+                failure_category=failure_category,
+                occurred_at_ms=time.time_ns() // 1_000_000,
+            )
+            result = self._contract_store().commit_episode_reflection(
+                outcome, now_ms=time.time_ns() // 1_000_000
+            )
+            scheduler["open_episodes"] = [
+                row for row in registry if row is not entry
+            ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+            try:
+                self.system.journal.append(
+                    life_id,
+                    journal_event,
+                    {
+                        "episode_id": entry.get("episode_id"),
+                        "source": source,
+                        "ref": ref_id,
+                        "outcome_status": outcome_status,
+                        "reflection_id": result.reflection.reflection_id,
+                    },
+                    actor="life_reflection",
+                    idempotency_key=f"life.reflection.commit:{entry.get('episode_id')}",
+                )
+            except Exception:
+                pass
+            self._persist(life_id)
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "commit", exc)
+
+    def _abort_runtime_episode_locked(
+        self, *, life_id: str, source: str, ref_id: str, reason: str
+    ) -> None:
+        """陈旧恢复：仍 OPEN 的 episode 以 ABORTED 收尾，消除孤儿。"""
+        if not self._reflection_chain_enabled():
+            return
+        self._commit_runtime_reflection_locked(
+            life_id=life_id,
+            source=source,
+            ref_id=ref_id,
+            outcome_status="aborted",
+            observed_outcome=f"运行中断，任务未收尾：{reason}"[:50_000],
+            observed_quality_milli=0,
+            completion_decision={"ref": ref_id, "status": "aborted", "reason": reason},
+            terminal_fact_parts={"abort_reason": reason[:200]},
+            event_kind=f"{source}.attempt.aborted",
+        )
+
+    def _open_capability_episode_locked(
+        self,
+        *,
+        life_id: str,
+        artifact: Mapping[str, Any],
+        pointer: Mapping[str, Any],
+        execution_id: str,
+    ) -> None:
+        """F3 挂点5：能力执行前 → health 基线预测 + started 事件 + 影响面 + OPEN episode。"""
+        if not self._reflection_chain_enabled():
+            return
+        try:
+            health = pointer.get("health") if isinstance(pointer.get("health"), Mapping) else {}
+            prediction = build_prediction(
+                basis_inputs={
+                    "source": "capability",
+                    "artifact_id": str(artifact.get("artifact_id") or ""),
+                    "version": str(artifact.get("version") or ""),
+                },
+                successes=int(health.get("successes") or 0),
+                uses=int(health.get("uses") or 0),
+            )
+            started = self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind="capability.invoke.started",
+                content={
+                    "execution_id": execution_id,
+                    "artifact_id": str(artifact.get("artifact_id") or ""),
+                    "predicted_success_milli": prediction.predicted_success_milli,
+                    "prediction_snapshot_sha256": prediction.snapshot_sha256,
+                    "action_risk": str(artifact.get("risk_level") or "A3"),
+                },
+                correlation_id=f"capability:{execution_id}",
+            )
+            if started is None:
+                return
+            impact = build_action_impact(
+                life_id=life_id,
+                action_id=str(artifact.get("artifact_id") or ""),
+                risk_class=str(artifact.get("risk_level") or "A3"),
+                source_event_ids=[started.event_id],
+                created_at_ms=time.time_ns() // 1_000_000,
+            )
+            self._contract_store().put_action_impact(impact)
+            self._open_runtime_episode_locked(
+                life_id=life_id,
+                source="capability",
+                ref_id=execution_id,
+                event_kind="capability.invoke.started",
+                intention=str(artifact.get("summary") or artifact.get("title") or "能力执行")[:20_000],
+                context_sha256=str(artifact.get("artifact_sha256") or ""),
+                prediction=prediction,
+                action_risk=str(artifact.get("risk_level") or "A3"),
+                candidate_action_ids=(str(artifact.get("artifact_id") or ""),),
+                selected_action_id=str(artifact.get("artifact_id") or ""),
+                started_event=started,
+                registry_extra={
+                    "capability_id": str(artifact.get("artifact_id") or ""),
+                    "capability_version": str(artifact.get("version") or ""),
+                    "capability_scope": str(artifact.get("title") or ""),
+                    "action_impact": impact.model_dump(mode="json"),
+                },
+            )
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "capability_open", exc)
+
+    # 决策 A：verified + capability 归因的失败证据累积到该阈值且影响面
+    # A0-A2 时才自动回滚（熟练度归零）；A3+ 只升 HUMAN_REVIEW/CORE_REVIEW。
+    CAPABILITY_AUTO_ROLLBACK_FAILURES = 3
+
+    def _commit_capability_reflection_locked(
+        self,
+        *,
+        life_id: str,
+        artifact: Mapping[str, Any],
+        execution: Mapping[str, Any],
+        records: list[dict[str, Any]],
+        execution_id: str,
+        completed: bool,
+    ) -> dict[str, Any] | None:
+        """F3 挂点6：能力执行后 → 闭环反思 → 能力证据 → 学习 → 回滚规则。"""
+        if not self._reflection_chain_enabled():
+            return None
+        try:
+            store = self._contract_store()
+            scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+            registry = [
+                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+            ]
+            entry = next(
+                (
+                    row for row in registry
+                    if str(row.get("source") or "") == "capability"
+                    and str(row.get("ref") or "") == execution_id
+                ),
+                None,
+            )
+            if entry is None:
+                return None
+            from contracts import ActionImpact
+
+            impact = ActionImpact.model_validate_json(
+                canonical_json_bytes(entry.get("action_impact") or {})
+            )
+            failed_steps = [row for row in records if row.get("ok") is not True]
+            quality = observed_quality_from_steps(records)
+            summary = {
+                "execution_id": execution_id,
+                "artifact_id": entry.get("capability_id"),
+                "status": str(execution.get("status") or ""),
+                "quality_milli": quality,
+                "failed_steps": len(failed_steps),
+            }
+            outcome_event = self._runtime_life_event_locked(
+                life_id=life_id,
+                event_kind="capability.outcome.recorded",
+                content=summary,
+                correlation_id=str(entry.get("correlation_id") or f"capability:{execution_id}"),
+            )
+            if outcome_event is None:
+                return None
+            prediction = prediction_from_snapshot(entry.get("prediction_snapshot") or {})
+            # 步骤错误码在执行记录的 result 里，合并后做九类映射。
+            category = (
+                failure_category_from_step_error(
+                    {**(failed_steps[0].get("result") or {}), **failed_steps[0]}
+                )
+                if failed_steps
+                else None
+            )
+            outcome = build_outcome_evidence(
+                life_id=life_id,
+                episode_id=str(entry.get("episode_id") or ""),
+                outcome_status="success" if completed else "failure",
+                observed_outcome=(
+                    f"能力执行{'成功' if completed else '失败'}：{entry.get('capability_scope') or ''}"
+                )[:50_000],
+                observed_quality_milli=quality,
+                prediction=prediction,
+                completion_decision_sha256=fingerprint(dict(summary)),
+                terminal_fact_hashes=[outcome_event.event_hash],
+                outcome_event_ids=[outcome_event.event_id],
+                context_fingerprint_sha256=str(entry.get("context_sha256") or ""),
+                action_risk=str(entry.get("action_risk") or "A3"),
+                failure_category=category,
+                occurred_at_ms=time.time_ns() // 1_000_000,
+            )
+            reflected = store.commit_episode_reflection(
+                outcome, now_ms=time.time_ns() // 1_000_000
+            )
+            evidence = build_capability_evidence(
+                outcome,
+                reflected.reflection,
+                impact,
+                capability_id=str(entry.get("capability_id") or ""),
+                capability_version=str(entry.get("capability_version") or ""),
+                now_ms=time.time_ns() // 1_000_000,
+            )
+            # 决策 C 诚实基线：生产路径成功证据 correlation_only，两个
+            # eligible 位均为 False。profile 契约要求证据集至少含一条
+            # eligible 证据，因此只在 eligible（失败或未来假设支持的成败）
+            # 时提交学习；成功反思照常闭环，熟练度晋升等未来假设管线。
+            learned = None
+            if evidence.eligible_success or evidence.eligible_failure:
+                learned = store.commit_capability_learning(
+                    (evidence,),
+                    scope=str(entry.get("capability_scope") or "能力学习"),
+                    now_ms=time.time_ns() // 1_000_000,
+                )
+            rollback_applied = False
+            version = str(entry.get("capability_version") or "")
+            historical = [
+                row for row in store.list_capability_evidence(
+                    life_id, capability_id=str(entry.get("capability_id") or ""), limit=200
+                )
+                if row.capability_version == version
+                and row.eligible_failure
+                and row.impact_floor in {"A0", "A1", "A2"}
+            ]
+            if len(historical) >= self.CAPABILITY_AUTO_ROLLBACK_FAILURES:
+                store.apply_capability_rollback(
+                    capability_id=str(entry.get("capability_id") or ""),
+                    capability_version=version,
+                    life_id=life_id,
+                    trigger_evidence_ids=tuple(
+                        sorted(row.evidence_id for row in historical)
+                    ),
+                    now_ms=time.time_ns() // 1_000_000,
+                )
+                rollback_applied = True
+            scheduler["open_episodes"] = [
+                row for row in registry if row is not entry
+            ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+            if learned is not None:
+                try:
+                    self.system.journal.append(
+                        life_id,
+                        "life.capability.learning.committed",
+                        {
+                            "episode_id": entry.get("episode_id"),
+                            "capability_id": entry.get("capability_id"),
+                            "outcome": learned.decision.outcome,
+                            "review_level": learned.decision.review_level,
+                            "rollback_applied": rollback_applied,
+                        },
+                        actor="life_reflection",
+                        idempotency_key=f"life.capability.learning:{entry.get('episode_id')}",
+                    )
+                except Exception:
+                    pass
+            self._persist(life_id)
+            learning_summary = (
+                {
+                    "profile_sha256": learned.profile.profile_sha256,
+                    "decision_id": learned.decision.learning_decision_id,
+                    "outcome": learned.decision.outcome,
+                    "review_level": learned.decision.review_level,
+                    "proficiency_lower_bound_milli": learned.profile.proficiency_lower_bound_milli,
+                }
+                if learned is not None
+                else {
+                    # 诚实基线：证据未达 eligible（如 correlation_only 的成功），
+                    # 本次不进入能力学习，反思照常闭环。
+                    "outcome": "not_committed",
+                    "reason": "capability.evidence_not_eligible",
+                }
+            )
+            learning_summary["rollback_applied"] = rollback_applied
+            return {
+                "reflection": {
+                    "reflection_id": reflected.reflection.reflection_id,
+                    "episode_id": reflected.reflection.episode_id,
+                    "source": "causal_reflection_chain",
+                    "observed_outcome": reflected.reflection.observed_outcome,
+                    "prediction_error_milli": reflected.reflection.prediction_error_milli,
+                },
+                "capability_learning": learning_summary,
+            }
+        except Exception as exc:
+            self._reflection_journal_failure(life_id, "capability_commit", exc)
+            return None
 
     _ACTIVITY_WINDOW_HOURS = {
         "上午": (6, 11),
@@ -2674,6 +3198,37 @@ class EmbeddedLifeRuntime:
                         scope=self._scope_state(life_id),
                     )
                     task = deepcopy(self._autonomy_state(life_id)["tasks"][task_id])
+                    # F3 挂点1：事前预测先落账（OPEN episode），事后不可编造；
+                    # 预测依据 = 该活动的真实完成历史。
+                    activity_id = str(task.get("activity_id") or "")
+                    history = [
+                        row for row in self._autonomy_state(life_id)["tasks"].values()
+                        if isinstance(row, Mapping)
+                        and str(row.get("activity_id") or "") == activity_id
+                        and str(row.get("status") or "") in {"completed", "failed"}
+                    ]
+                    self._open_runtime_episode_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=task_id,
+                        event_kind="autonomy.task.attempt.started",
+                        intention=str(task.get("objective") or task.get("title") or "自主行动"),
+                        context_sha256=str(activity_scope.get("scope_sha256") or ""),
+                        prediction=build_prediction(
+                            basis_inputs={
+                                "source": "autonomy",
+                                "task_id": task_id,
+                                "activity_id": activity_id,
+                            },
+                            successes=sum(
+                                1 for row in history if str(row.get("status") or "") == "completed"
+                            ),
+                            uses=len(history),
+                        ),
+                        action_risk=str(task.get("risk_class") or "A0"),
+                        candidate_action_ids=(task_id,),
+                        selected_action_id=task_id,
+                    )
                 decision = self._autonomy_decider(activity_scope, task)
                 if not isinstance(decision, Mapping):
                     raise ValueError("autonomy model result is invalid")
@@ -2710,6 +3265,24 @@ class EmbeddedLifeRuntime:
                         actor="life_autonomy",
                         idempotency_key=f"autonomy.task.model-complete:{task_id}:{completed.get('attempt_count', 0)}",
                     )
+                    # F3 挂点2：任务完成 → 闭环反思（质量 900，终态事实=结果哈希）。
+                    self._commit_runtime_reflection_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=task_id,
+                        outcome_status="success",
+                        observed_outcome=str(result.get("summary") or "任务完成。"),
+                        observed_quality_milli=900,
+                        completion_decision={
+                            "task_id": task_id,
+                            "status": "completed",
+                            "attempt_count": completed.get("attempt_count"),
+                        },
+                        terminal_fact_parts={
+                            "summary": str(result.get("summary") or "")[:800],
+                        },
+                        event_kind="autonomy.task.attempt.finished",
+                    )
                     self._sync_daily_summary(life_id)
                     self._persist(life_id)
             except Exception as exc:
@@ -2733,6 +3306,23 @@ class EmbeddedLifeRuntime:
                             {"task_id": task_id, "task": blocked},
                             actor="life_autonomy",
                             idempotency_key=f"autonomy.task.model-blocked:{task_id}:{blocked.get('attempt_count', 0)}",
+                        )
+                        # F3 挂点3：任务异常 → 失败闭环（九类映射 + 反事实模板）。
+                        self._commit_runtime_reflection_locked(
+                            life_id=life_id,
+                            source="autonomy",
+                            ref_id=task_id,
+                            outcome_status="failure",
+                            observed_outcome=f"任务失败：{type(exc).__name__}",
+                            observed_quality_milli=100,
+                            completion_decision={
+                                "task_id": task_id,
+                                "status": "failed",
+                                "attempt_count": blocked.get("attempt_count"),
+                            },
+                            terminal_fact_parts={"error_type": type(exc).__name__},
+                            event_kind="autonomy.task.attempt.failed",
+                            failure_category=failure_category_from_error(exc),
                         )
                     scheduler_state = self._scope_state(life_id).setdefault("scheduler", {})
                     activity_detail = re.sub(r"\s+", " ", str(exc)).strip()[:160]
@@ -7985,6 +8575,15 @@ class EmbeddedLifeRuntime:
         existing = scope["executions"].get(execution_id)
         if isinstance(existing, Mapping):
             return {"ok": True, "replayed": True, "execution": deepcopy(existing)}
+        # F3 挂点5：能力执行前 → health 基线预测 + started 事件 + 影响面 + OPEN
+        # episode（事前落账；失败不影响能力执行本身）。
+        with self._lock:
+            self._open_capability_episode_locked(
+                life_id=life_id,
+                artifact=artifact,
+                pointer=pointer,
+                execution_id=execution_id,
+            )
         records: list[dict[str, Any]] = []
         completed = True
         for position, raw_step in enumerate(steps):
@@ -8079,11 +8678,23 @@ class EmbeddedLifeRuntime:
             scope["executions"] = before
             scope["capability_pointers"][lineage_id] = pointer_before
             raise
+        # F3 挂点6：能力执行后 → 闭环反思 + 能力证据 + 学习 + 回滚规则；
+        # 返回体追加只读观测键，不改变调用契约。
+        with self._lock:
+            reflection_summary = self._commit_capability_reflection_locked(
+                life_id=life_id,
+                artifact=artifact,
+                execution=execution,
+                records=records,
+                execution_id=execution_id,
+                completed=completed,
+            )
         return {
             "ok": completed,
             "execution": deepcopy(execution),
             "pointer": deepcopy(updated_pointer),
             "event": event,
+            **(reflection_summary or {}),
         }
 
     def _execution_recover(self, payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -2469,6 +2469,58 @@ class EmbeddedLifeRuntime:
                     affinity[activity_id] = weighted
         return affinity
 
+    # 动机漂移：最近行动分布偏离长期偏好时，给欠采样活动加分，把自由行动
+    # 拉回用户配置的方向。只读（不写回 kind_weights 等用户可见配置）。
+    _DRIFT_AFFINITY_COEFFICIENT = 150
+    _DRIFT_AFFINITY_MIN_SAMPLE = 10
+
+    def _drift_affinity(self, scope: Mapping[str, Any]) -> dict[str, int]:
+        """Boost under-sampled activities when recent actions drift from preferences."""
+        autonomy = scope.get("autonomy") if isinstance(scope.get("autonomy"), Mapping) else {}
+        completed = [
+            row for row in (autonomy.get("tasks") or {}).values()
+            if isinstance(row, Mapping)
+            and str(row.get("status") or "") == "completed"
+            and str(row.get("source") or "") == "life_activity_catalog"
+        ]
+        completed.sort(
+            key=lambda row: (int(row.get("updated_at_ms") or 0), int(row.get("sequence") or 0)),
+            reverse=True,
+        )
+        settings = scope.get("settings") if isinstance(scope.get("settings"), Mapping) else {}
+        preferences = preference_projection(sorted({
+            str(value)
+            for value in settings.get("autonomy_activity_types") or []
+            if str(value)
+        }))
+        rows = motivation_drift_projection(completed[:30], preferences)
+        if not rows:
+            return {}
+        row = rows[0]
+        # 样本不足时漂移抖动大（insufficient_evidence 或低于最小样本），不加分。
+        if int(row.get("observed_actions") or 0) < self._DRIFT_AFFINITY_MIN_SAMPLE:
+            return {}
+        if not row.get("drift_detected"):
+            return {}
+        observed = row.get("observed_distribution")
+        observed = observed if isinstance(observed, Mapping) else {}
+        expected = preferences.get("kind_weights")
+        expected = expected if isinstance(expected, Mapping) else {}
+        observed_total = sum(int(value or 0) for value in observed.values()) or 1
+        expected_total = sum(max(0.0, float(value or 0)) for value in expected.values()) or 1.0
+        score = min(1.0, max(0.0, float(row.get("drift_score") or 0)))
+        affinity: dict[str, int] = {}
+        for activity_id, weight in expected.items():
+            gap = max(
+                0.0,
+                max(0.0, float(weight or 0)) / expected_total
+                - int(observed.get(activity_id) or 0) / observed_total,
+            )
+            bonus = int(score * gap * self._DRIFT_AFFINITY_COEFFICIENT)
+            if bonus > 0:
+                affinity[str(activity_id)] = bonus
+        return affinity
+
     def _schedule_autonomous_activity_decision(self, *, life_id: str) -> None:
         """Execute one catalog activity through the gateway model bridge.
 
@@ -2548,11 +2600,15 @@ class EmbeddedLifeRuntime:
         ]
         pool = due if due else eligible
         desire = self._desire_affinity(scope)
+        # 漂移加分只在自由行动分支生效：到点计划保持"高优先级先做"的确定性，
+        # 不被欠采样补偿改写次序。
+        drift = {} if due else self._drift_affinity(scope)
         pool.sort(
             key=lambda task: (
                 -(
                     int(task.get("priority") or 0)
                     + desire.get(str(task.get("activity_id") or ""), 0)
+                    + drift.get(str(task.get("activity_id") or ""), 0)
                 ),
                 int(task.get("sequence") or 0),
                 str(task.get("task_id") or ""),

--- a/src/life_service/episode_builder.py
+++ b/src/life_service/episode_builder.py
@@ -1,0 +1,401 @@
+"""P8 反思链生产构建器：纯函数，无 I/O，不 import runtime。
+
+任务/能力执行 →（事前）预测快照 + OPEN episode →（事后）结果证据 →
+store.commit_episode_reflection 原子闭环反思。所有写入由 embedded_runtime
+在 ``self._lock`` 内完成；本模块只负责构造合法契约对象。
+
+诚实基线（决策 C）：生产路径没有因果假设写入口，所以成功证据
+``supported_cause_ids=()`` → ``causal_support="correlation_only"``、
+``eligible_success=False``——成功晋升留给未来假设管线，这是 P8 出口
+条件的认识论分层，不是缺陷。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from contracts import (
+    ActionImpact,
+    CausalEpisode,
+    EpisodeOutcomeEvidence,
+    LifeEventEnvelope,
+    canonical_sha256,
+    derive_life_event_id,
+)
+
+from .capability_learning import _impact_floor
+
+
+ZERO_SHA256 = "0" * 64
+ZERO_SIGNATURE = "0" * 128
+# 无历史时的确定性预测基线（决策 C：不做随机猜测）。
+DEFAULT_PREDICTED_SUCCESS_MILLI = 700
+
+# 风险档位 → 影响面毫值（保证 _impact_floor(impact) == risk_class）。
+_RISK_SCOPE_MILLI = {
+    "A0": 0,
+    "A1": 100,
+    "A2": 300,
+    "A3": 500,
+    "A4": 700,
+    "A5": 900,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PredictionSnapshot:
+    """事前预测快照：先于执行落账，事后可审计防编造。"""
+
+    predicted_success_milli: int
+    basis: str  # "history" | "default"
+    snapshot: dict[str, Any]
+    snapshot_sha256: str
+    prior_prediction: str  # 嵌入 OPEN episode 的可读 JSON 文本
+
+
+def fingerprint(parts: Mapping[str, Any]) -> str:
+    """上下文指纹：canonical 哈希（输入必须 canonical 安全，禁 float）。"""
+    return canonical_sha256(dict(parts))
+
+
+def build_prediction(
+    *,
+    basis_inputs: Mapping[str, Any],
+    successes: int = 0,
+    uses: int = 0,
+    fallback_milli: int = DEFAULT_PREDICTED_SUCCESS_MILLI,
+) -> PredictionSnapshot:
+    """确定性预测：有历史用完成率（毫值整数），无历史回退基线。
+
+    ``basis_inputs`` 记录预测依据（如 activity_id、历史样本数、健康档案
+    摘要），进入快照哈希，事后不可伪造。
+    """
+    if uses > 0:
+        predicted = max(0, min(1000, successes * 1000 // uses))
+        basis = "history"
+    else:
+        predicted = max(0, min(1000, fallback_milli))
+        basis = "default"
+    snapshot = {
+        "domain": "tiangong.life.prediction-snapshot.v1",
+        "basis": basis,
+        "predicted_success_milli": predicted,
+        "sample_successes": int(successes),
+        "sample_uses": int(uses),
+        **{str(key): value for key, value in basis_inputs.items()},
+    }
+    snapshot_sha256 = canonical_sha256(snapshot)
+    from contracts import canonical_json_bytes
+
+    prior_prediction = canonical_json_bytes(snapshot).decode("utf-8")
+    return PredictionSnapshot(
+        predicted_success_milli=predicted,
+        basis=basis,
+        snapshot=snapshot,
+        snapshot_sha256=snapshot_sha256,
+        prior_prediction=prior_prediction,
+    )
+
+
+def build_life_event(
+    *,
+    life_id: str,
+    sequence: int,
+    writer_epoch: int,
+    previous_event_hash: str | None,
+    event_kind: str,
+    content: Mapping[str, Any],
+    occurred_at_ms: int,
+    observed_at_ms: int,
+    correlation_id: str,
+    causation_id: str | None = None,
+    signer_key_id: str,
+    sign: Callable[[str], str],
+    source_kind: str = "reflection",
+    evidence_class: str = "reflection",
+) -> LifeEventEnvelope:
+    """构造链形生命事件：确定性 identity + 哈希链 + 外部签名回调。"""
+    content_sha256 = canonical_sha256({"domain": "life.reflection.content.v1", "content": dict(content)})
+    ingress_id = f"internal:{event_kind}:{sequence}"
+    dedupe_key = canonical_sha256(
+        {"dedupe": event_kind, "correlation_id": correlation_id, "life_id": life_id, "sequence": sequence}
+    )
+    unsigned = LifeEventEnvelope(
+        event_id=derive_life_event_id(
+            life_id=life_id,
+            writer_epoch=writer_epoch,
+            sequence=sequence,
+            ingress_id=ingress_id,
+        ),
+        life_id=life_id,
+        sequence=sequence,
+        writer_epoch=writer_epoch,
+        source_service="life_reflection_chain",
+        source_kind=source_kind,
+        event_kind=event_kind,
+        occurred_at_ms=occurred_at_ms,
+        observed_at_ms=max(occurred_at_ms, observed_at_ms),
+        principal_ref=life_id,
+        subject_refs=(life_id,),
+        evidence_class=evidence_class,
+        source_credibility_milli=1000,
+        privacy_scope="system",
+        content_object_id=f"obj:{content_sha256[:40]}",
+        content_sha256=content_sha256,
+        dedupe_key=dedupe_key,
+        causation_id=causation_id,
+        correlation_id=correlation_id,
+        previous_event_hash=previous_event_hash,
+        event_hash=ZERO_SHA256,
+        signer_key_id=signer_key_id,
+        signature=ZERO_SIGNATURE,
+    ).with_computed_event_hash()
+    return unsigned.model_copy(update={"signature": sign(unsigned.event_hash.encode("ascii"))})
+
+
+def build_open_episode(
+    *,
+    life_id: str,
+    trigger_event_ids: Sequence[str],
+    context_state_hashes: Sequence[str],
+    intention: str,
+    prediction: PredictionSnapshot,
+    candidate_action_ids: Sequence[str] = (),
+    selected_action_id: str | None = None,
+    created_at_ms: int,
+) -> CausalEpisode:
+    """构造 OPEN 事前 episode；identity 由触发事件+预测快照确定性推导。"""
+    triggers = tuple(sorted(set(str(value) for value in trigger_event_ids)))
+    contexts = tuple(sorted(set(str(value) for value in context_state_hashes)))
+    if not triggers or not contexts:
+        raise ValueError("open episode requires trigger events and context hashes")
+    episode_id = "cep_" + canonical_sha256(
+        {
+            "domain": "tiangong.life.reflection-episode-id.v1",
+            "life_id": life_id,
+            "trigger_event_ids": triggers,
+            "prediction_snapshot_sha256": prediction.snapshot_sha256,
+            "intention": intention,
+        }
+    )
+    return CausalEpisode(
+        episode_id=episode_id,
+        life_id=life_id,
+        revision=1,
+        supersedes_episode_sha256=None,
+        trigger_event_ids=triggers,
+        context_state_hashes=contexts,
+        intention=intention,
+        prior_prediction=prediction.prior_prediction,
+        candidate_action_ids=tuple(sorted(set(str(value) for value in candidate_action_ids))),
+        selected_action_id=selected_action_id,
+        authorization_ref=None,
+        mediator_event_ids=(),
+        outcome_event_ids=(),
+        outcome_evaluation=None,
+        prediction_error_milli=None,
+        terminal_status="OPEN",
+        created_at_ms=created_at_ms,
+        closed_at_ms=None,
+        episode_sha256=ZERO_SHA256,
+    ).with_computed_episode_sha256()
+
+
+def build_outcome_evidence(
+    *,
+    life_id: str,
+    episode_id: str,
+    outcome_status: str,
+    observed_outcome: str,
+    observed_quality_milli: int,
+    prediction: PredictionSnapshot,
+    completion_decision_sha256: str,
+    terminal_fact_hashes: Sequence[str],
+    outcome_event_ids: Sequence[str],
+    context_fingerprint_sha256: str,
+    action_risk: str,
+    failure_category: str | None = None,
+    method_attribution: str = "capability",
+    counterfactual_actions: Sequence[str] = (),
+    next_minimal_experiment: str | None = None,
+    occurred_at_ms: int,
+) -> EpisodeOutcomeEvidence:
+    """构造结果证据；失败时补反事实与最小实验模板（若未提供）。"""
+    if outcome_status == "success":
+        if failure_category is not None:
+            raise ValueError("success outcome cannot carry a failure category")
+    elif failure_category is None:
+        failure_category = "stale_context" if outcome_status == "aborted" else "unknown"
+    if outcome_status == "failure" and not counterfactual_actions:
+        counterfactual_actions = ("复跑同一任务，先执行只读探针再决定是否继续。",)
+        next_minimal_experiment = next_minimal_experiment or (
+            "先执行只读探针确认环境与输入，再重试原任务。"
+        )
+    facts = tuple(sorted(set(str(value) for value in terminal_fact_hashes)))
+    events = tuple(sorted(set(str(value) for value in outcome_event_ids)))
+    if not facts or not events:
+        raise ValueError("episode outcome requires terminal facts and outcome events")
+    outcome_evidence_id = "oev_" + canonical_sha256(
+        {
+            "domain": "tiangong.life.outcome-evidence-id.v1",
+            "life_id": life_id,
+            "episode_id": episode_id,
+            "outcome_status": outcome_status,
+            "prediction_snapshot_sha256": prediction.snapshot_sha256,
+            "occurred_at_ms": occurred_at_ms,
+        }
+    )
+    return EpisodeOutcomeEvidence(
+        outcome_evidence_id=outcome_evidence_id,
+        life_id=life_id,
+        episode_id=episode_id,
+        outcome_status=outcome_status,
+        observed_outcome=observed_outcome,
+        observed_quality_milli=max(0, min(1000, observed_quality_milli)),
+        predicted_success_milli=prediction.predicted_success_milli,
+        prediction_snapshot_hash=prediction.snapshot_sha256,
+        completion_decision_sha256=completion_decision_sha256,
+        terminal_fact_hashes=facts,
+        outcome_event_ids=events,
+        failure_category=failure_category,
+        method_attribution=method_attribution,
+        supported_cause_ids=(),
+        counterevidence_refs=(),
+        alternative_explanation_refs=(),
+        context_fingerprint_sha256=context_fingerprint_sha256,
+        preference_domain=None,
+        user_preference_uncertainty_milli=0,
+        action_risk=action_risk,
+        counterfactual_actions=tuple(counterfactual_actions),
+        next_minimal_experiment=next_minimal_experiment,
+        candidate_user_question=None,
+        occurred_at_ms=occurred_at_ms,
+        evidence_sha256=ZERO_SHA256,
+    ).with_computed_evidence_sha256()
+
+
+def build_action_impact(
+    *,
+    life_id: str,
+    action_id: str,
+    risk_class: str,
+    source_event_ids: Sequence[str],
+    created_at_ms: int,
+) -> ActionImpact:
+    """按风险档位构造影响面；保证 _impact_floor(impact) == risk_class。"""
+    scope_milli = _RISK_SCOPE_MILLI.get(str(risk_class).upper())
+    if scope_milli is None:
+        raise ValueError(f"action impact risk class is invalid: {risk_class}")
+    events = tuple(sorted(set(str(value) for value in source_event_ids)))
+    if not events:
+        raise ValueError("action impact requires source events")
+    impact_id = "imp_" + canonical_sha256(
+        {
+            "domain": "tiangong.life.reflection-impact-id.v1",
+            "life_id": life_id,
+            "action_id": action_id,
+            "risk_class": str(risk_class).upper(),
+            "created_at_ms": created_at_ms,
+        }
+    )
+    impact = ActionImpact(
+        impact_id=impact_id,
+        life_id=life_id,
+        action_id=action_id,
+        dynamic_risk=str(risk_class).upper(),
+        affected_internal_nodes=(),
+        touches_identity=False,
+        touches_soul=False,
+        touches_memory_keys=False,
+        touches_policy=False,
+        touches_core_code=False,
+        workspace_scope_milli=scope_milli,
+        external_recipient_count=0,
+        credential_scope_milli=0,
+        privacy_scope_milli=scope_milli,
+        blast_radius_milli=scope_milli,
+        irreversibility_milli=scope_milli,
+        uncertainty_milli=scope_milli,
+        rollback_proof_ref=None,
+        estimated_resource_cost_milli=100,
+        predicted_viability_deltas=(),
+        source_event_ids=events,
+        created_at_ms=created_at_ms,
+        impact_sha256=ZERO_SHA256,
+    ).with_computed_impact_sha256()
+    if _impact_floor(impact) != str(risk_class).upper():
+        raise ValueError("action impact floor disagrees with its risk class")
+    return impact
+
+
+# 异常类型 → 九类失败映射。运行时错误码（EmbeddedLifeError.reason 等）优先，
+# 此表兜底。
+_ERROR_CATEGORY_PATTERNS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("policy", "forbidden", "blocked", "not_allowed"), "policy_block"),
+    (("permission", "unauthorized", "forbidden_resource"), "insufficient_permission"),
+    (("timeout", "connection", "network", "unreachable", "oserror"), "environment_error"),
+    (("input", "argument", "schema", "invalid_json", "decode"), "input_error"),
+    (("stale", "expired", "conflict", "discontinuous"), "stale_context"),
+    (("preference",), "user_preference_mismatch"),
+    (("reasoning", "model", "generation"), "model_reasoning_error"),
+    (("tool", "action", "executor"), "tool_error"),
+)
+
+_EXCEPTION_CATEGORIES: tuple[tuple[tuple[type[BaseException], ...], str], ...] = (
+    ((PermissionError,), "insufficient_permission"),
+    ((TimeoutError, ConnectionError, OSError), "environment_error"),
+    ((ValueError, TypeError, KeyError), "input_error"),
+)
+
+
+def failure_category_from_error(error: BaseException | None) -> str:
+    """按异常类型与错误文本映射九类失败；兜底 unknown。"""
+    if error is None:
+        return "unknown"
+    for types, category in _EXCEPTION_CATEGORIES:
+        if isinstance(error, types):
+            return category
+    text = f"{type(error).__name__} {error}".casefold()
+    for needles, category in _ERROR_CATEGORY_PATTERNS:
+        if any(needle in text for needle in needles):
+            return category
+    return "unknown"
+
+
+def failure_category_from_step_error(step: Mapping[str, Any]) -> str:
+    """能力步骤失败的九类映射；缺错误信息时按工具失败处理。"""
+    for key in ("error_code", "reason_code", "error"):
+        text = str(step.get(key) or "").casefold()
+        if not text:
+            continue
+        for needles, category in _ERROR_CATEGORY_PATTERNS:
+            if any(needle in text for needle in needles):
+                return category
+    return "tool_error"
+
+
+def observed_quality_from_steps(steps: Sequence[Mapping[str, Any]]) -> int:
+    """步骤成功比例 → 观察质量毫值；无步骤的内部行动回退 800。"""
+    rows = [step for step in steps if isinstance(step, Mapping)]
+    if not rows:
+        return 800
+    ok_count = sum(1 for step in rows if step.get("ok") is True)
+    return ok_count * 1000 // len(rows)
+
+
+__all__ = [
+    "DEFAULT_PREDICTED_SUCCESS_MILLI",
+    "PredictionSnapshot",
+    "ZERO_SHA256",
+    "build_action_impact",
+    "build_life_event",
+    "build_open_episode",
+    "build_outcome_evidence",
+    "build_prediction",
+    "failure_category_from_error",
+    "failure_category_from_step_error",
+    "fingerprint",
+    "observed_quality_from_steps",
+]

--- a/src/life_service/episode_builder.py
+++ b/src/life_service/episode_builder.py
@@ -385,6 +385,24 @@ def observed_quality_from_steps(steps: Sequence[Mapping[str, Any]]) -> int:
     return ok_count * 1000 // len(rows)
 
 
+def prediction_from_snapshot(snapshot: Mapping[str, Any]) -> PredictionSnapshot:
+    """从注册表持久化的快照字典重建预测（哈希与文本按 canonical 重算）。"""
+    from contracts import canonical_json_bytes
+
+    payload = {str(key): value for key, value in snapshot.items()}
+    try:
+        predicted = int(payload.get("predicted_success_milli"))
+    except (TypeError, ValueError):
+        predicted = DEFAULT_PREDICTED_SUCCESS_MILLI
+    return PredictionSnapshot(
+        predicted_success_milli=max(0, min(1000, predicted)),
+        basis=str(payload.get("basis") or "default"),
+        snapshot=payload,
+        snapshot_sha256=canonical_sha256(payload),
+        prior_prediction=canonical_json_bytes(payload).decode("utf-8"),
+    )
+
+
 __all__ = [
     "DEFAULT_PREDICTED_SUCCESS_MILLI",
     "PredictionSnapshot",
@@ -398,4 +416,5 @@ __all__ = [
     "failure_category_from_step_error",
     "fingerprint",
     "observed_quality_from_steps",
+    "prediction_from_snapshot",
 ]

--- a/src/life_service/panel_projection.py
+++ b/src/life_service/panel_projection.py
@@ -282,6 +282,44 @@ def motivation_drift_projection(
     }]
 
 
+def reflection_card_projection(card: Any) -> dict[str, Any]:
+    """P8 反思卡面板投影（只读）：来自因果反思链的权威记录。"""
+    return {
+        "reflection_id": str(getattr(card, "reflection_id", "") or ""),
+        "episode_id": str(getattr(card, "episode_id", "") or ""),
+        "expected_outcome": str(getattr(card, "expected_outcome", "") or "")[:800],
+        "observed_outcome": str(getattr(card, "observed_outcome", "") or "")[:800],
+        "prediction_error_milli": int(getattr(card, "prediction_error_milli", 0) or 0),
+        "failure_dimensions": list(getattr(card, "failure_dimensions", ()) or ()),
+        "counterfactual_actions": list(getattr(card, "counterfactual_actions", ()) or ()),
+        "next_minimal_experiment": getattr(card, "next_minimal_experiment", None),
+        "confidence_milli": int(getattr(card, "confidence_milli", 0) or 0),
+        "created_at_ms": int(getattr(card, "created_at_ms", 0) or 0),
+        "source": "causal_reflection_chain",
+        "revision": str(getattr(card, "reflection_sha256", "") or "")[:12],
+    }
+
+
+def capability_profile_projection(profile: Any) -> dict[str, Any]:
+    """能力认知层 profile 面板投影（只读）：熟练度与审查级别。"""
+    return {
+        "capability_id": str(getattr(profile, "capability_id", "") or ""),
+        "version": str(getattr(profile, "version", "") or ""),
+        "profile_revision": int(getattr(profile, "profile_revision", 0) or 0),
+        "verified_successes": int(getattr(profile, "verified_successes", 0) or 0),
+        "verified_failures": int(getattr(profile, "verified_failures", 0) or 0),
+        "independent_context_count": int(getattr(profile, "independent_context_count", 0) or 0),
+        "proficiency_mean_milli": int(getattr(profile, "proficiency_mean_milli", 0) or 0),
+        "proficiency_lower_bound_milli": int(
+            getattr(profile, "proficiency_lower_bound_milli", 0) or 0
+        ),
+        "review_level": str(getattr(profile, "review_level", "") or ""),
+        "rollback_count": int(getattr(profile, "rollback_count", 0) or 0),
+        "impact_floor": str(getattr(profile, "impact_floor", "") or ""),
+        "updated_at_ms": int(getattr(profile, "updated_at_ms", 0) or 0),
+    }
+
+
 def model_budget_projection(
     settings: Mapping[str, Any],
     scheduler: Mapping[str, Any],
@@ -400,6 +438,7 @@ def fallback_context_projection(
 
 __all__ = [
     "boundary_projection",
+    "capability_profile_projection",
     "catalog_tasks_for_day",
     "fallback_context_projection",
     "long_term_goals",
@@ -408,6 +447,7 @@ __all__ = [
     "preference_projection",
     "record_day",
     "records_for_day",
+    "reflection_card_projection",
     "reflection_projection",
     "action_value_projection",
 ]

--- a/src/life_service/proactive_initiative.py
+++ b/src/life_service/proactive_initiative.py
@@ -237,6 +237,49 @@ def evaluate_proactive_candidate(
     if daily_limit <= 0 or sum(1 for value in deliveries if now_ms - value < 86_400_000) >= daily_limit:
         return _decision(kind="no_op", reason_code="life.proactive.daily_limit", allowed=False)
 
+    # F1 忽略率门禁：用户持续不理会时抬高开口门槛并拉长间隔，学会"闭嘴"。
+    # 样本不足（新键缺失/为空的旧上下文，或未过回复窗口）一律不加门禁。
+    engagement_window = _strict_nonnegative_int(
+        settings.get("proactive_engagement_window_size"), default=8
+    )
+    min_reply_rate_milli = _strict_nonnegative_int(
+        settings.get("proactive_min_reply_rate_milli"), default=200
+    )
+    engagement_required_bonus = 0
+    if engagement_window > 0 and min_reply_rate_milli > 0:
+        outcome_rows = [
+            row for row in (context.get("recent_delivery_outcomes") or [])
+            if isinstance(row, Mapping)
+        ]
+        samples = sorted(
+            (
+                row for row in outcome_rows
+                if isinstance(row.get("created_at_ms"), int)
+                and not isinstance(row.get("created_at_ms"), bool)
+                and row.get("created_at_ms") >= 0
+                and isinstance(row.get("replied"), bool)
+            ),
+            key=lambda row: -row["created_at_ms"],
+        )[:engagement_window]
+        if len(samples) >= engagement_window:
+            replies = sum(1 for row in samples if row["replied"])
+            reply_rate_milli = replies * 1000 // len(samples)
+            if reply_rate_milli < min_reply_rate_milli:
+                interval_multiplier = 4 if reply_rate_milli == 0 else 2
+                if (
+                    last_delivery_ms
+                    and min_interval_ms
+                    and now_ms - last_delivery_ms < min_interval_ms * interval_multiplier
+                ):
+                    return _decision(
+                        kind="no_op",
+                        reason_code="life.proactive.engagement_low",
+                        allowed=False,
+                    )
+                # 按忽略程度动态抬高效用门槛：回复率越低要求越高。
+                severity_milli = min(1000, min_reply_rate_milli - reply_rate_milli)
+                engagement_required_bonus = (severity_milli * 300) // 1000
+
     stale_after_ms = _strict_nonnegative_int(
         settings.get("proactive_evidence_stale_after_seconds"), default=86_400
     ) * 1000
@@ -287,7 +330,8 @@ def evaluate_proactive_candidate(
     score = compute_agency_score(**score_inputs).model_dump(mode="json")
     threshold = _strict_nonnegative_int(settings.get("proactive_min_utility_lcb_milli"), default=120)
     margin = _strict_nonnegative_int(settings.get("proactive_min_margin_milli"), default=80)
-    required = max(threshold, margin)
+    engagement_adjusted = threshold + engagement_required_bonus
+    required = max(threshold, margin, engagement_adjusted)
     if int(score.get("utility_lcb_milli") or 0) < required:
         return _decision(
             kind="no_op",

--- a/src/life_service/store.py
+++ b/src/life_service/store.py
@@ -4006,6 +4006,124 @@ class LifeShadowStore:
             raise LifeShadowStoreError("life projection head disagrees with replay")
         return summary
 
+    # ---------- P8 反思链只读投影（生产接线用；零 schema 变更零迁移） ----------
+
+    def life_event_head(self, life_id: str) -> LifeEventEnvelope | None:
+        """One life's chain-head event, or None before genesis."""
+        row = self._connection.execute(
+            """
+            SELECT envelope FROM life_events
+            WHERE life_id = ? AND event_id = (
+                SELECT head_event_id FROM projection_heads WHERE life_id = ?
+            )
+            """,
+            (life_id, life_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _parse_stored_contract(
+            bytes(row["envelope"]), LifeEventEnvelope, "life event"
+        )
+
+    def list_reflection_cards(
+        self, life_id: str, *, limit: int = 20
+    ) -> tuple[ReflectionCard, ...]:
+        """Most recent reflection cards for panel display (newest first)."""
+        rows = self._connection.execute(
+            """
+            SELECT payload FROM reflection_cards
+            WHERE life_id = ?
+            ORDER BY created_at_ms DESC, reflection_id DESC
+            LIMIT ?
+            """,
+            (life_id, max(1, min(int(limit), 100))),
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), ReflectionCard, "reflection card")
+            for row in rows
+        )
+
+    def latest_capability_profiles(self, life_id: str) -> tuple[CapabilityProfile, ...]:
+        """Latest profile revision per (capability_id, version), sorted by id."""
+        rows = self._connection.execute(
+            """
+            SELECT p.payload FROM capability_profiles AS p
+            JOIN (
+                SELECT capability_id, version, life_id, MAX(profile_revision) AS max_revision
+                FROM capability_profiles
+                WHERE life_id = ?
+                GROUP BY capability_id, version, life_id
+            ) AS latest
+              ON latest.capability_id = p.capability_id
+             AND latest.version = p.version
+             AND latest.life_id = p.life_id
+             AND latest.max_revision = p.profile_revision
+            ORDER BY p.capability_id, p.version
+            """,
+            (life_id,),
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), CapabilityProfile, "capability profile")
+            for row in rows
+        )
+
+    def list_capability_evidence(
+        self,
+        life_id: str,
+        *,
+        capability_id: str | None = None,
+        limit: int = 50,
+    ) -> tuple[CapabilityEvidence, ...]:
+        """Most recent capability evidence (newest first), optionally filtered."""
+        filter_sql = "" if not capability_id else "AND capability_id = ?"
+        params: list[Any] = [life_id]
+        if capability_id:
+            params.append(capability_id)
+        params.append(max(1, min(int(limit), 200)))
+        rows = self._connection.execute(
+            f"""
+            SELECT payload FROM capability_evidence
+            WHERE life_id = ? {filter_sql}
+            ORDER BY created_at_ms DESC, evidence_id DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), CapabilityEvidence, "capability evidence")
+            for row in rows
+        )
+
+    def open_causal_episodes(
+        self, life_id: str, *, limit: int = 32
+    ) -> tuple[CausalEpisode, ...]:
+        """Episodes whose LATEST revision is still OPEN, oldest first.
+
+        Closed episodes keep their OPEN revision-1 rows as history, so a plain
+        terminal_status filter would resurrect closed episodes as orphans.
+        """
+        rows = self._connection.execute(
+            """
+            SELECT e.payload FROM causal_episodes AS e
+            JOIN (
+                SELECT episode_id, MAX(revision) AS max_revision
+                FROM causal_episodes
+                WHERE life_id = ?
+                GROUP BY episode_id
+            ) AS latest
+              ON latest.episode_id = e.episode_id
+             AND latest.max_revision = e.revision
+            WHERE e.life_id = ? AND e.terminal_status = 'OPEN'
+            ORDER BY e.created_at_ms, e.episode_id
+            LIMIT ?
+            """,
+            (life_id, life_id, max(1, min(int(limit), 256))),
+        ).fetchall()
+        return tuple(
+            _parse_stored_contract(bytes(row["payload"]), CausalEpisode, "causal episode")
+            for row in rows
+        )
+
     def _verify_causal_memory_state(self) -> None:
         tombstones: dict[str, PrivacyDeletionTombstone] = {}
         destroyed_payload_ids: set[str] = set()

--- a/tests/test_capability_health.py
+++ b/tests/test_capability_health.py
@@ -213,3 +213,84 @@ def test_patch_round_limit_is_parameterized_not_hardcoded():
     )
     assert applied is False
     assert reason == "degraded"
+
+
+# ---------- F5：正向强化（streak / 最近成功）与综合健康分 ----------
+
+
+def test_success_streak_accumulates_resets_and_records_last_success():
+    pointer = make_pointer()
+    pointer, _, _ = ingest_outcome(
+        pointer, {**make_outcome("s1", outcome="success"), "occurred_at_ms": 1000}, now_ms=1000
+    )
+    assert pointer["health"]["success_streak"] == 1
+    assert pointer["health"]["last_success_at_ms"] == 1000
+    pointer, _, _ = ingest_outcome(
+        pointer, {**make_outcome("s2", outcome="success"), "occurred_at_ms": 2000}, now_ms=2000
+    )
+    assert pointer["health"]["success_streak"] == 2
+    assert pointer["health"]["last_success_at_ms"] == 2000
+    pointer, _, _ = ingest_outcome(
+        pointer, {**make_outcome("f1"), "occurred_at_ms": 3000}, now_ms=3000
+    )
+    assert pointer["health"]["success_streak"] == 0
+    # 失败不清除最近成功时间：那是历史事实，供健康分新鲜度使用。
+    assert pointer["health"]["last_success_at_ms"] == 2000
+
+
+def test_reactivate_resets_success_streak():
+    pointer = make_pointer()
+    for index in range(3):
+        pointer, _, _ = ingest_outcome(
+            pointer,
+            {**make_outcome(f"s{index}", outcome="success"), "occurred_at_ms": 1000 + index},
+            now_ms=1000 + index,
+        )
+    pointer = degrade_pointer(pointer, reason="test", now_ms=5000)
+    pointer = reactivate_pointer(pointer, actor="user", now_ms=6000)
+    assert pointer["health"]["success_streak"] == 0
+
+
+def test_health_score_milli_neutral_without_evidence_and_rises_with_successes():
+    from life_service.capability_health import health_score_milli
+
+    # 无任何执行结果：中性 500。
+    assert health_score_milli({"uses": 0, "successes": 0}, now_ms=10_000) == 500
+    fresh = {
+        "uses": 20,
+        "successes": 20,
+        "success_streak": 20,
+        "last_outcome_at_ms": 9_000,
+    }
+    high = health_score_milli(fresh, now_ms=10_000)
+    assert high > 600
+    # 失败为主且近期：低于中性。
+    bad = {
+        "uses": 5,
+        "successes": 0,
+        "success_streak": 0,
+        "last_outcome_at_ms": 9_000,
+    }
+    assert health_score_milli(bad, now_ms=10_000) < 500
+
+
+def test_health_score_milli_decays_toward_neutral_when_idle():
+    from life_service.capability_health import health_score_milli
+
+    health = {
+        "uses": 20,
+        "successes": 20,
+        "success_streak": 20,
+        "last_outcome_at_ms": 0,
+    }
+    day = 86_400_000
+    now_ms = 100 * day
+    fresh = dict(health, last_outcome_at_ms=now_ms - 1 * day)
+    week_idle = dict(health, last_outcome_at_ms=now_ms - 8 * day)
+    month_idle = dict(health, last_outcome_at_ms=now_ms - 30 * day)
+    score_fresh = health_score_milli(fresh, now_ms)
+    score_week = health_score_milli(week_idle, now_ms)
+    score_month = health_score_milli(month_idle, now_ms)
+    # 7 天半衰：闲置越久越向中性收缩，但历史成功者仍略高于完全未知。
+    assert score_fresh > score_week > score_month
+    assert 500 < score_month < score_week < score_fresh

--- a/tests/test_episode_builder.py
+++ b/tests/test_episode_builder.py
@@ -1,0 +1,244 @@
+"""F3 步骤 2：episode_builder 纯函数单测（B1-B5）。"""
+
+from __future__ import annotations
+
+import json
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from contracts import LifeEventEnvelope
+from life_service.capability_learning import _impact_floor
+from life_service.episode_builder import (
+    DEFAULT_PREDICTED_SUCCESS_MILLI,
+    build_action_impact,
+    build_life_event,
+    build_open_episode,
+    build_outcome_evidence,
+    build_prediction,
+    failure_category_from_error,
+    failure_category_from_step_error,
+    fingerprint,
+    observed_quality_from_steps,
+)
+
+
+LIFE_ID = "life_builder_test"
+
+
+def make_signer():
+    key = Ed25519PrivateKey.generate()
+    key_id = "life_reflection_test_signer"
+    return key_id, key.sign
+
+
+def test_b1_prediction_snapshot_is_deterministic_and_auditable():
+    first = build_prediction(
+        basis_inputs={"activity_id": "daily_planning", "history_note": "近30次"},
+        successes=21,
+        uses=30,
+    )
+    second = build_prediction(
+        basis_inputs={"activity_id": "daily_planning", "history_note": "近30次"},
+        successes=21,
+        uses=30,
+    )
+    # B1：确定性——相同输入相同快照哈希，可重放审计。
+    assert first.snapshot_sha256 == second.snapshot_sha256
+    assert first.predicted_success_milli == 700
+    assert first.basis == "history"
+    parsed = json.loads(first.prior_prediction)
+    assert parsed["predicted_success_milli"] == 700
+    assert parsed["sample_successes"] == 21
+    assert parsed["sample_uses"] == 30
+    # 无历史回退确定性基线，不随机猜测。
+    fallback = build_prediction(basis_inputs={"activity_id": "x"}, successes=0, uses=0)
+    assert fallback.predicted_success_milli == DEFAULT_PREDICTED_SUCCESS_MILLI
+    assert fallback.basis == "default"
+    # 依据进入哈希：不同依据不同快照。
+    other = build_prediction(
+        basis_inputs={"activity_id": "system_health", "history_note": "近30次"},
+        successes=21,
+        uses=30,
+    )
+    assert other.snapshot_sha256 != first.snapshot_sha256
+    assert fingerprint({"life_id": LIFE_ID, "task_id": "t1"}) == fingerprint(
+        {"task_id": "t1", "life_id": LIFE_ID}
+    )
+
+
+def test_b2_life_events_form_a_hash_chain_with_signatures():
+    key_id, sign = make_signer()
+    first = build_life_event(
+        life_id=LIFE_ID,
+        sequence=1,
+        writer_epoch=1,
+        previous_event_hash=None,
+        event_kind="life.reflection.episode.opened",
+        content={"task_id": "t1", "intention": "验证链形"},
+        occurred_at_ms=1_000,
+        observed_at_ms=1_000,
+        correlation_id="corr-t1",
+        signer_key_id=key_id,
+        sign=sign,
+    )
+    second = build_life_event(
+        life_id=LIFE_ID,
+        sequence=2,
+        writer_epoch=1,
+        previous_event_hash=first.event_hash,
+        event_kind="life.reflection.episode.committed",
+        content={"task_id": "t1", "outcome": "success"},
+        occurred_at_ms=1_500,
+        observed_at_ms=1_600,
+        correlation_id="corr-t1",
+        causation_id=first.event_id,
+        signer_key_id=key_id,
+        sign=sign,
+    )
+    assert first.previous_event_hash is None
+    assert second.previous_event_hash == first.event_hash
+    for event in (first, second):
+        assert isinstance(event, LifeEventEnvelope)
+        assert event.has_valid_event_hash()
+        assert event.signature != "0" * 128
+        assert event.signer_key_id == key_id
+    assert first.event_id != second.event_id
+
+
+def test_b3_action_impact_floor_always_matches_risk_class():
+    for risk in ("A0", "A1", "A2", "A3", "A4", "A5"):
+        impact = build_action_impact(
+            life_id=LIFE_ID,
+            action_id="action_probe",
+            risk_class=risk,
+            source_event_ids=("lev_" + "1" * 64,),
+            created_at_ms=2_000,
+        )
+        assert impact.has_valid_impact_sha256()
+        assert _impact_floor(impact) == risk, risk
+    try:
+        build_action_impact(
+            life_id=LIFE_ID,
+            action_id="a",
+            risk_class="A6",
+            source_event_ids=("lev_" + "1" * 64,),
+            created_at_ms=2_000,
+        )
+        raise AssertionError("A6 should be rejected")
+    except ValueError:
+        pass
+
+
+def test_b4_failure_categories_map_from_errors_and_steps():
+    assert failure_category_from_error(None) == "unknown"
+    assert failure_category_from_error(PermissionError("denied")) == "insufficient_permission"
+    assert failure_category_from_error(TimeoutError("too slow")) == "environment_error"
+    assert failure_category_from_error(ValueError("bad input schema")) == "input_error"
+    assert failure_category_from_error(RuntimeError("action policy blocked by gate")) == "policy_block"
+    assert failure_category_from_error(RuntimeError("stale context conflict")) == "stale_context"
+    assert failure_category_from_error(RuntimeError("完全未知的怪错")) == "unknown"
+    assert failure_category_from_step_error({"error_code": "artifact.executor.tool_error"}) == "tool_error"
+    assert failure_category_from_step_error({"error_code": "permission.denied"}) == "insufficient_permission"
+    assert failure_category_from_step_error({}) == "tool_error"
+    assert observed_quality_from_steps([]) == 800
+    assert observed_quality_from_steps([{"ok": True}, {"ok": True}, {"ok": False}, {"ok": True}]) == 750
+
+
+def test_b5_outcome_evidence_honest_baseline_and_failure_templates():
+    prediction = build_prediction(basis_inputs={"activity_id": "x"}, successes=7, uses=10)
+    episode = build_open_episode(
+        life_id=LIFE_ID,
+        trigger_event_ids=("lev_" + "1" * 64,),
+        context_state_hashes=(fingerprint({"scope": 1}),),
+        intention="完成一次可验证的内部整理",
+        prediction=prediction,
+        candidate_action_ids=("action_probe",),
+        selected_action_id="action_probe",
+        created_at_ms=1_000,
+    )
+    assert episode.terminal_status == "OPEN"
+    assert episode.has_valid_episode_sha256()
+    # 同触发+同预测 → 同 identity（失败重试不产生新 episode）。
+    replay = build_open_episode(
+        life_id=LIFE_ID,
+        trigger_event_ids=("lev_" + "1" * 64,),
+        context_state_hashes=(fingerprint({"scope": 1}),),
+        intention="完成一次可验证的内部整理",
+        prediction=prediction,
+        candidate_action_ids=("action_probe",),
+        selected_action_id="action_probe",
+        created_at_ms=9_999,
+    )
+    assert replay.episode_id == episode.episode_id
+
+    success = build_outcome_evidence(
+        life_id=LIFE_ID,
+        episode_id=episode.episode_id,
+        outcome_status="success",
+        observed_outcome="任务完成，产出了当日计划。",
+        observed_quality_milli=900,
+        prediction=prediction,
+        completion_decision_sha256="4" * 64,
+        terminal_fact_hashes=("5" * 64,),
+        outcome_event_ids=("lev_" + "2" * 64,),
+        context_fingerprint_sha256=fingerprint({"scope": 1}),
+        action_risk="A1",
+        occurred_at_ms=2_000,
+    )
+    assert success.has_valid_evidence_sha256()
+    # 诚实基线：无假设 → correlation_only，成功证据不可晋升（eligible=False）。
+    assert success.supported_cause_ids == ()
+    assert success.failure_category is None
+    try:
+        build_outcome_evidence(
+            life_id=LIFE_ID,
+            episode_id=episode.episode_id,
+            outcome_status="success",
+            observed_outcome="任务完成。",
+            observed_quality_milli=900,
+            prediction=prediction,
+            completion_decision_sha256="4" * 64,
+            terminal_fact_hashes=("5" * 64,),
+            outcome_event_ids=("lev_" + "2" * 64,),
+            context_fingerprint_sha256=fingerprint({"scope": 1}),
+            action_risk="A1",
+            failure_category="tool_error",
+            occurred_at_ms=2_000,
+        )
+        raise AssertionError("success with category should be rejected")
+    except ValueError:
+        pass
+
+    failure = build_outcome_evidence(
+        life_id=LIFE_ID,
+        episode_id=episode.episode_id,
+        outcome_status="failure",
+        observed_outcome="任务失败：工具返回错误。",
+        observed_quality_milli=100,
+        prediction=prediction,
+        completion_decision_sha256="4" * 64,
+        terminal_fact_hashes=("5" * 64,),
+        outcome_event_ids=("lev_" + "3" * 64,),
+        context_fingerprint_sha256=fingerprint({"scope": 1}),
+        action_risk="A1",
+        occurred_at_ms=2_000,
+    )
+    assert failure.failure_category == "unknown"
+    assert failure.counterfactual_actions
+    assert failure.next_minimal_experiment
+
+    aborted = build_outcome_evidence(
+        life_id=LIFE_ID,
+        episode_id=episode.episode_id,
+        outcome_status="aborted",
+        observed_outcome="运行中断，任务未收尾。",
+        observed_quality_milli=0,
+        prediction=prediction,
+        completion_decision_sha256="4" * 64,
+        terminal_fact_hashes=("5" * 64,),
+        outcome_event_ids=("lev_" + "4" * 64,),
+        context_fingerprint_sha256=fingerprint({"scope": 1}),
+        action_risk="A1",
+        occurred_at_ms=2_000,
+    )
+    assert aborted.failure_category == "stale_context"

--- a/tests/test_frontend_gateway_routing.py
+++ b/tests/test_frontend_gateway_routing.py
@@ -273,6 +273,7 @@ class FrontendGatewayRoutingTests(unittest.TestCase):
             bound_client_methods,
             {
                 "ackProactiveChat",
+                "getProactiveStatus",
                 "activateIdentity",
                 "bindIdentity",
                 "capabilityDiscard",

--- a/tests/test_life_autonomy_activity_catalog.py
+++ b/tests/test_life_autonomy_activity_catalog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 import time
+import types
 from pathlib import Path
 
 from life_service.autonomous_tasks import DEFAULT_ACTIVITY_TYPES
@@ -146,5 +147,152 @@ def test_model_internal_activity_creates_truthful_autonomous_record(tmp_path: Pa
         assert latest["result"]["external_side_effects"] is False
         assert latest["result"]["execution_scope"] == "internal_life_state"
         assert "内部规划" in latest["result"]["summary"]
+    finally:
+        life.close()
+
+
+def _drift_task(
+    task_id: str,
+    activity_id: str,
+    *,
+    priority: int,
+    sequence: int,
+    status: str = "pending",
+) -> dict:
+    return {
+        "task_id": task_id,
+        "source": "life_activity_catalog",
+        "activity_id": activity_id,
+        "task_kind": activity_id,
+        "title": activity_id,
+        "objective": "漂移排序测试",
+        "status": status,
+        "risk_class": "A0",
+        "priority": priority,
+        "sequence": sequence,
+        "time_window": "上午",
+        "created_at_ms": 1_000 + sequence,
+        "updated_at_ms": 1_000 + sequence,
+    }
+
+
+def _drift_history(count: int, activity_id: str, *, prefix: str = "done", start_ms: int = 10_000) -> dict:
+    return {
+        f"{prefix}-{index}": {
+            **_drift_task(
+                f"{prefix}-{index}",
+                activity_id,
+                priority=500,
+                sequence=index,
+                status="completed",
+            ),
+            "updated_at_ms": start_ms + index,
+        }
+        for index in range(count)
+    }
+
+
+def test_drift_affinity_boosts_undersampled_activity(tmp_path: Path) -> None:
+    life = _runtime(tmp_path)
+    try:
+        scope = {
+            "settings": {"autonomy_activity_types": ["learning_review", "system_health"]},
+            "autonomy": {"enabled": True, "tasks": _drift_history(30, "system_health")},
+        }
+        affinity = life._drift_affinity(scope)
+        # 偏好里排前面的 learning_review 被 30 次 system_health 欠采样，应获得加分；
+        # 已被过度采样的 system_health 不加。
+        assert affinity.get("learning_review", 0) > 0
+        assert "system_health" not in affinity
+    finally:
+        life.close()
+
+
+def test_drift_affinity_requires_drift_and_enough_samples(tmp_path: Path) -> None:
+    life = _runtime(tmp_path)
+    try:
+        def scope_with(tasks: dict) -> dict:
+            return {
+                "settings": {"autonomy_activity_types": ["learning_review", "system_health"]},
+                "autonomy": {"enabled": True, "tasks": tasks},
+            }
+
+        # 无历史（insufficient_evidence）与样本 <10（分布抖动大）都不加分
+        assert life._drift_affinity(scope_with({})) == {}
+        assert life._drift_affinity(scope_with(_drift_history(9, "system_health"))) == {}
+        # 近 30 次分布与偏好一致（stable）不加分
+        mixed = _drift_history(15, "learning_review", prefix="done-a")
+        mixed.update(_drift_history(15, "system_health", prefix="done-b", start_ms=50_000))
+        assert life._drift_affinity(scope_with(mixed)) == {}
+    finally:
+        life.close()
+
+
+def test_drift_reorders_free_time_pool_but_not_due_tasks(tmp_path: Path, monkeypatch) -> None:
+    life = _runtime(tmp_path)
+    selected: list[dict] = []
+    called = threading.Event()
+    try:
+        scope = life._scope_state()
+        scope["settings"]["autonomy_activity_types"] = ["learning_review", "system_health"]
+        scope["affect"] = {"emotions": {}}
+        autonomy = life._autonomy_state()
+        autonomy["enabled"] = True
+        tasks = _drift_history(30, "system_health")
+        tasks["pending-high"] = _drift_task("pending-high", "system_health", priority=760, sequence=101)
+        tasks["pending-low"] = _drift_task("pending-low", "learning_review", priority=740, sequence=102)
+        autonomy["tasks"] = tasks
+
+        def decide(scope_view: dict, task: dict) -> dict:
+            selected.append({
+                "task_id": task["task_id"],
+                "drift_status": (
+                    scope_view.get("motivation_drift") or [{}])[0].get("status"),
+            })
+            called.set()
+            return {
+                "title": "漂移测试",
+                "summary": "已完成内部复盘，无需外部副作用。",
+                "findings": [],
+                "next_steps": [],
+                "uncertainties": [],
+            }
+
+        life.set_autonomy_decider(decide)
+        life_id = str(life._active()["life_id"])
+
+        def run_decision(hour: int) -> str:
+            called.clear()
+            monkeypatch.setattr(
+                time,
+                "localtime",
+                lambda secs: types.SimpleNamespace(tm_hour=hour),
+            )
+            life._schedule_autonomous_activity_decision(life_id=life_id)
+            assert called.wait(2), f"decider not called at hour {hour}"
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                scheduler = life._scope_state(life_id).get("scheduler") or {}
+                states = life._autonomy_state(life_id)["tasks"]
+                finished = (
+                    not bool(scheduler.get("autonomy_decision_inflight"))
+                    and str(states[selected[-1]["task_id"]].get("status") or "") == "completed"
+                )
+                if finished:
+                    break
+                time.sleep(0.02)
+            return selected[-1]["task_id"]
+
+        # 凌晨 3 点："上午"窗口（6-11）关闭 → 自由行动分支。偏好排名更高的
+        # learning_review 被 30 次 system_health 欠采样，漂移加分把它顶过 760 优先级。
+        assert run_decision(3) == "pending-low"
+        assert selected[0]["drift_status"] == "drift"
+
+        # 上午 8 点：窗口打开 → 到点必做分支，漂移不参与排序，高优先级先做。
+        life._scope_state(life_id).setdefault("scheduler", {})["last_autonomy_decision_at_ms"] = 0
+        life._autonomy_state(life_id)["tasks"]["pending-low-2"] = _drift_task(
+            "pending-low-2", "learning_review", priority=740, sequence=103,
+        )
+        assert run_decision(8) == "pending-high"
     finally:
         life.close()

--- a/tests/test_life_capability_health_flow.py
+++ b/tests/test_life_capability_health_flow.py
@@ -368,3 +368,84 @@ def test_reactivate_requires_user_and_unmarks_mapping(tmp_path):
         assert "runtime_usable: true" in content
     finally:
         life.close()
+
+
+# ---------- F5：正向强化排序 + 闲置标记 ----------
+
+
+def test_overlay_ranks_recent_successes_above_idle_and_marks_idle(tmp_path):
+    from life_service.capability_health import ingest_outcome
+
+    life, life_id, fresh = _setup_runtime(tmp_path)
+    try:
+        day = 86_400_000
+        now_ms = time.time_ns() // 1_000_000
+        scope = life._scope_state(life_id)
+        # 第二个能力：标题字典序更靠前（旧排序会排第一），但最近成功在 8 天前。
+        idle_learning = _learning(life_id)
+        idle_learning["learning_id"] = "learn_idle_test"
+        idle_learning["title"] = "AAA闲置技能"
+        compiled = compile_artifact(idle_learning, action_catalog=list(_ACTION_CATALOG))
+        idle_artifact = publish_artifact(compiled)
+        scope["capabilities"][idle_artifact["artifact_id"]] = {
+            **idle_artifact,
+            "origin": "life_learning",
+        }
+        idle_pointer = {
+            "schema": "tiangong.life.capability-pointer.v1",
+            "life_id": life_id,
+            "lineage_id": idle_artifact["lineage_id"],
+            "kind": "skill",
+            "status": "active",
+            "current_artifact_id": idle_artifact["artifact_id"],
+            "current_artifact_sha256": idle_artifact["artifact_sha256"],
+            "history": [],
+            "pointer_sha256": "",
+        }
+        from life_service.capability_health import attach_health as _attach
+
+        idle_pointer = _attach(idle_pointer, artifact=idle_artifact, now_ms=now_ms)
+        idle_pointer, _, _ = ingest_outcome(
+            idle_pointer,
+            {
+                "outcome_id": "idle_ok_1",
+                "artifact_id": idle_artifact["artifact_id"],
+                "outcome": "success",
+                "occurred_at_ms": now_ms - 8 * day,
+            },
+            now_ms=now_ms,
+        )
+        scope["capability_pointers"][idle_artifact["lineage_id"]] = idle_pointer
+        # 第一个能力改名让字典序落后，并连续成功 10 次（最近）。
+        fresh_pointer = scope["capability_pointers"][fresh["lineage_id"]]
+        for index in range(10):
+            fresh_pointer, _, _ = ingest_outcome(
+                fresh_pointer,
+                {
+                    "outcome_id": f"fresh_ok_{index}",
+                    "artifact_id": fresh["artifact_id"],
+                    "outcome": "success",
+                    "occurred_at_ms": now_ms - index * 1000,
+                },
+                now_ms=now_ms,
+            )
+        scope["capability_pointers"][fresh["lineage_id"]] = fresh_pointer
+        life._persist(life_id)
+
+        overlay = life._capability_overlay_payload({"life_id": life_id})
+        rows = overlay["artifacts"]
+        assert len(rows) == 2
+        # 健康分排序：最近连续成功的能力必须排在闲置能力之前（与标题字典序相反）。
+        assert rows[0]["artifact_id"] == fresh["artifact_id"]
+        assert rows[1]["artifact_id"] == idle_artifact["artifact_id"]
+        assert rows[1]["idle"] is True
+        assert rows[0]["idle"] is False
+        assert rows[0]["health_score_milli"] > rows[1]["health_score_milli"]
+        # 模型上下文携带健康分（模型可见）。
+        context = {
+            row["artifact_id"]: row
+            for row in overlay["model_context"]
+        }
+        assert context[fresh["artifact_id"]]["health_score_milli"] == rows[0]["health_score_milli"]
+    finally:
+        life.close()

--- a/tests/test_life_frontend_p10.py
+++ b/tests/test_life_frontend_p10.py
@@ -88,6 +88,46 @@ class LifeFrontendP10Tests(unittest.TestCase):
         self.assertNotIn("灵魂 · 生命上下文配置", html)
         self.assertNotIn("打开灵魂配置", html)
 
+    def test_proactive_settings_group_offers_live_mode_switch(self) -> None:
+        payload = {
+            "settings": {
+                "available": True,
+                "editable": True,
+                "readonly": False,
+                "source": "embedded_life_runtime",
+                "proactive_enabled": True,
+                "proactive_mode": "shadow",
+            },
+            "proactive_status": {
+                "ok": True,
+                "pending": 2,
+                "settings": {"proactive_mode": "shadow"},
+                "scheduler": {
+                    "proactive_model_attempts": 3,
+                    "last_proactive_reason": "life.proactive.quiet_hours",
+                },
+            },
+        }
+        script = f"""
+          import {{ renderSettings }} from {json.dumps(LIFE_PANEL.as_uri())};
+          const html = renderSettings({json.dumps(payload, ensure_ascii=False)});
+          process.stdout.write(JSON.stringify({{ html }}));
+        """
+        html = run_node(script)["html"]
+        for expected in (
+            "主动沟通",
+            'name="proactive_enabled"',
+            'name="proactive_mode"',
+            'value="shadow" selected',
+            "影子（只记录不发送）",
+            "正式发送",
+            "当前模式：影子（只记录不发送）",
+            "待处理：2 条",
+            "今日决策：3 次",
+            "life.proactive.quiet_hours",
+        ):
+            self.assertIn(expected, html)
+
     def test_life_inbox_opens_full_message_in_main_chat_only(self) -> None:
         script = f"""
           import {{ deliverInboxMessageToChat }} from {json.dumps(LIFE_SUMMARY.as_uri())};

--- a/tests/test_life_reflection_chain_wiring.py
+++ b/tests/test_life_reflection_chain_wiring.py
@@ -1,0 +1,367 @@
+"""F3 步骤 3：任务源反思链接线（挂点 1-4）T1-T4。
+
+任务启动 →（事前）预测快照 + OPEN episode → 任务完成/异常 →（事后）
+结果证据 + 原子闭环反思；陈旧恢复把孤儿 OPEN episode 以 ABORTED 收尾。
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from life_service.embedded_runtime import EmbeddedLifeRuntime
+from life_service.episode_builder import build_prediction
+
+
+def runtime(root: Path) -> EmbeddedLifeRuntime:
+    life = EmbeddedLifeRuntime(
+        data_root=root / "life-data",
+        runtime_root=root / "life-runtime",
+        mode="embedded",
+    )
+    life.scheduler.stop(timeout_seconds=2)
+    return life
+
+
+def request(life: EmbeddedLifeRuntime, method: str, path: str, payload=None) -> dict:
+    status, body, _ = life.request(method, path, payload)
+    assert status == 200, (path, status, body)
+    return body
+
+
+def seed(life: EmbeddedLifeRuntime) -> None:
+    request(
+        life,
+        "POST",
+        "/api/v1/v3/life/settings",
+        {"settings": {"autonomy_activity_types": ["daily_planning"]}},
+    )
+    request(
+        life,
+        "POST",
+        "/api/v1/v3/life/memory/assert",
+        {
+            "memory_id": "mem_reflection_wiring",
+            "content": {"text": "用户希望生命体做可验证且不过度打扰的事。"},
+            "confidence_milli": 900,
+        },
+    )
+
+
+def wait_task_status(life: EmbeddedLifeRuntime, life_id: str, task_id: str, statuses: set[str], timeout: float = 3.0) -> dict:
+    deadline = time.monotonic() + timeout
+    result = {}
+    while time.monotonic() < deadline:
+        row = life._autonomy_state(life_id)["tasks"].get(task_id)
+        if isinstance(row, dict) and str(row.get("status") or "") in statuses:
+            result = row
+            break
+        time.sleep(0.02)
+    assert result, f"task {task_id} never reached {statuses}"
+    return result
+
+
+def wait_reflection_closed(life: EmbeddedLifeRuntime, life_id: str, timeout: float = 3.0) -> None:
+    """状态先行、反思闭环在后：轮询到 episode 闭合且注册表清空。"""
+    store = life._contract_store()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        registry = life._scope_state(life_id)["scheduler"].get("open_episodes") or []
+        if not registry and not store.open_causal_episodes(life_id):
+            return
+        time.sleep(0.02)
+    raise AssertionError("reflection chain never closed the episode")
+
+
+def test_t1_t2_task_success_closes_preregistered_episode(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        decider_entered = threading.Event()
+        release_decider = threading.Event()
+        try:
+            seed(life)
+            life_id = str(life._active()["life_id"])
+
+            def decide(_scope: dict, _task: dict) -> dict:
+                decider_entered.set()
+                release_decider.wait(3)
+                return {
+                    "title": "今日规划",
+                    "summary": "已完成内部规划，先推进一个可验证的小步骤。",
+                    "findings": [],
+                    "next_steps": [],
+                    "uncertainties": [],
+                }
+
+            life.set_autonomy_decider(decide)
+            first = request(life, "POST", "/api/v1/v3/life/autonomy/tick", {"reason": "t1"})
+            task_id = next(
+                item["task_id"] for item in first["tasks"]
+                if item.get("source") == "life_activity_catalog"
+            )
+            assert decider_entered.wait(3)
+            store = life._contract_store()
+            # T1：decider 执行前，OPEN episode 已带着事前预测落账。
+            opens = store.open_causal_episodes(life_id)
+            assert len(opens) == 1
+            assert "predicted_success_milli" in opens[0].prior_prediction
+            registry = life._scope_state(life_id)["scheduler"]["open_episodes"]
+            assert len(registry) == 1
+            assert registry[0]["ref"] == task_id
+            episode_id = opens[0].episode_id
+            release_decider.set()
+
+            wait_task_status(life, life_id, task_id, {"completed"})
+            # T2：完成后 episode 闭环、反思卡落库、注册表清空。
+            wait_reflection_closed(life, life_id)
+            cards = store.list_reflection_cards(life_id)
+            assert len(cards) == 1
+            card = cards[0]
+            assert card.episode_id == episode_id
+            assert "已完成内部规划" in card.observed_outcome
+            assert store.open_causal_episodes(life_id) == ()
+            assert life._scope_state(life_id)["scheduler"]["open_episodes"] == []
+        finally:
+            release_decider.set()
+            life.close()
+
+
+def test_t3_task_failure_maps_category_and_closes_episode(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            seed(life)
+            life_id = str(life._active()["life_id"])
+
+            def decide(_scope: dict, _task: dict) -> dict:
+                raise TimeoutError("model bridge timed out")
+
+            life.set_autonomy_decider(decide)
+            first = request(life, "POST", "/api/v1/v3/life/autonomy/tick", {"reason": "t3"})
+            task_id = next(
+                item["task_id"] for item in first["tasks"]
+                if item.get("source") == "life_activity_catalog"
+            )
+            wait_task_status(life, life_id, task_id, {"blocked"})
+            store = life._contract_store()
+            wait_reflection_closed(life, life_id)
+            cards = store.list_reflection_cards(life_id)
+            assert len(cards) == 1
+            # 异常类型 → 九类映射：TimeoutError → environment_error
+            assert cards[0].failure_dimensions == ("environment_error",)
+            assert cards[0].counterfactual_actions
+            assert cards[0].next_minimal_experiment
+            assert store.open_causal_episodes(life_id) == ()
+        finally:
+            life.close()
+
+
+def test_t4_stale_recovery_aborts_orphan_open_episode(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            life_id = str(life._active()["life_id"])
+            now_ms = time.time_ns() // 1_000_000
+            # 伪造一个陈旧 running 任务 + 事前已落账的 OPEN episode。
+            autonomy = life._autonomy_state(life_id)
+            autonomy["tasks"]["task_orphan"] = {
+                "task_id": "task_orphan",
+                "source": "life_activity_catalog",
+                "activity_id": "daily_planning",
+                "title": "孤儿任务",
+                "objective": "验证陈旧恢复",
+                "status": "running",
+                "risk_class": "A0",
+                "priority": 500,
+                "sequence": 1,
+                "time_window": "空闲时",
+                "created_at_ms": now_ms - 10_000_000,
+                "updated_at_ms": now_ms - 10_000_000,
+            }
+            with life._lock:
+                episode_id = life._open_runtime_episode_locked(
+                    life_id=life_id,
+                    source="autonomy",
+                    ref_id="task_orphan",
+                    event_kind="autonomy.task.attempt.started",
+                    intention="验证陈旧恢复",
+                    context_sha256="e" * 64,
+                    prediction=build_prediction(
+                        basis_inputs={"source": "autonomy", "task_id": "task_orphan"},
+                    ),
+                    action_risk="A0",
+                )
+            assert episode_id
+            store = life._contract_store()
+            assert len(store.open_causal_episodes(life_id)) == 1
+
+            recovered = life._recover_stale_running_autonomy_tasks(
+                life_id=life_id, now_ms=now_ms, stale_after_ms=600_000
+            )
+            assert recovered == 1
+            # 孤儿 OPEN episode 以 ABORTED 收尾，不再悬挂。
+            assert store.open_causal_episodes(life_id) == ()
+            cards = store.list_reflection_cards(life_id)
+            assert len(cards) == 1
+            assert life._scope_state(life_id)["scheduler"]["open_episodes"] == []
+        finally:
+            life.close()
+
+
+# ---------- F3 步骤 4：能力源接线（挂点 5-6）C1-C3 ----------
+
+
+def _capability_runtime(tmp_path: Path, *, risk_level: str, invoker):
+    from life_service.artifact_executor import compile_artifact, publish_artifact
+    from life_service.capability_health import attach_health
+    from total_gateway.runtime import (
+        life_capability_workspace_mapper,
+        life_capability_workspace_marker,
+    )
+
+    # 动作目录本身保持低风险：编译器按步骤动作抬 artifact 风险级，
+    # A1 才能让失败证据的影响面进入自动回滚规则的适用范围。
+    action_catalog = [
+        {
+            "action_id": "omni_body",
+            "risk": "A1",
+            "available": True,
+            "effect": "bounded omni action",
+            "argument_schema_sha256": "",
+            "result_schema_sha256": "",
+        }
+    ]
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    life = EmbeddedLifeRuntime(
+        data_root=tmp_path / "life-data",
+        runtime_root=tmp_path / "life-runtime",
+        mode="embedded",
+    )
+    life.scheduler.stop(timeout_seconds=2)
+    life.set_capability_workspace_mapper(life_capability_workspace_mapper(workspace))
+    life.set_capability_workspace_marker(life_capability_workspace_marker(workspace))
+    life.set_capability_workspace_remover(lambda artifact: {"removed": False})
+    life.set_artifact_action_catalog_provider(lambda: list(action_catalog))
+    life.set_artifact_invoker(invoker)
+    life_id = str(life._active()["life_id"])
+    learning = {
+        "life_id": life_id,
+        "learning_id": "learn_reflection_chain",
+        "target": "skill",
+        "title": "反思链测试技能",
+        "summary": "测试能力源反思链接线",
+        "risk_level": risk_level,
+        "draft_artifact": {
+            "content": "# 反思链测试技能\n\n完整正文\n",
+            "required_actions": ["omni_body"],
+            "task_intents": ["测试"],
+            "input_schema": {"type": "object", "properties": {}},
+            "output_schema": {"type": "object"},
+            "acceptance": [{"kind": "all_steps_succeeded"}],
+            "steps": [
+                {
+                    "step_id": "s1",
+                    "action_id": "omni_body",
+                    "arguments_template": {"action": "file.write", "target": "t", "args": {}},
+                    "on_failure": "stop",
+                }
+            ],
+        },
+    }
+    compiled = compile_artifact(learning, action_catalog=list(action_catalog))
+    artifact = publish_artifact(compiled)
+    scope = life._scope_state(life_id)
+    scope["capabilities"][artifact["artifact_id"]] = {**artifact, "origin": "life_learning"}
+    pointer = {
+        "schema": "tiangong.life.capability-pointer.v1",
+        "life_id": life_id,
+        "lineage_id": artifact["lineage_id"],
+        "kind": "skill",
+        "status": "active",
+        "current_artifact_id": artifact["artifact_id"],
+        "current_artifact_sha256": artifact["artifact_sha256"],
+        "history": [],
+        "pointer_sha256": "",
+    }
+    pointer = attach_health(pointer, artifact=artifact, now_ms=time.time_ns() // 1_000_000)
+    scope["capability_pointers"][artifact["lineage_id"]] = pointer
+    life._persist(life_id)
+    return life, life_id, artifact
+
+
+def test_c1_capability_success_preregisters_and_learns(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life, life_id, artifact = _capability_runtime(
+            Path(temporary),
+            risk_level="A1",
+            invoker=lambda action_id, arguments, ctx: {"ok": True, "zhuangtai": "wancheng"},
+        )
+        try:
+            result = life._capability_invoke(
+                {"life_id": life_id, "artifact_id": artifact["artifact_id"]}
+            )
+            assert result["ok"] is True
+            # 返回体追加只读观测键。
+            assert result["reflection"]["source"] == "causal_reflection_chain"
+            # 决策 C 诚实基线：correlation_only 的成功证据不进入能力学习。
+            assert result["capability_learning"]["outcome"] == "not_committed"
+            assert result["capability_learning"]["rollback_applied"] is False
+            store = life._contract_store()
+            assert store.open_causal_episodes(life_id) == ()
+            cards = store.list_reflection_cards(life_id)
+            assert len(cards) == 1
+            assert "能力执行成功" in cards[0].observed_outcome
+            assert store.list_capability_evidence(life_id) == ()
+            assert store.latest_capability_profiles(life_id) == ()
+        finally:
+            life.close()
+
+
+def test_c2_c3_three_verified_failures_auto_rollback_pointer_stays_active(tmp_path: Path) -> None:
+    calls = {"count": 0}
+
+    def failing_invoker(action_id, arguments, ctx):
+        calls["count"] += 1
+        return {"ok": False, "error_code": "permission.denied"}
+
+    with tempfile.TemporaryDirectory() as temporary:
+        life, life_id, artifact = _capability_runtime(
+            Path(temporary), risk_level="A1", invoker=failing_invoker
+        )
+        try:
+            for index in range(3):
+                result = life._capability_invoke(
+                    {
+                        "life_id": life_id,
+                        "artifact_id": artifact["artifact_id"],
+                        "request_id": f"chain-failure-{index}",
+                    }
+                )
+                assert result["ok"] is False
+                # 失败证据是 eligible 的：进入能力学习（样本不足 → hold）。
+                assert result["capability_learning"]["outcome"] == "hold"
+            store = life._contract_store()
+            evidence = store.list_capability_evidence(life_id)
+            assert len(evidence) == 3
+            assert all(item.eligible_failure for item in evidence)
+            # 失败类别从步骤错误码映射：permission.denied → insufficient_permission
+            cards = store.list_reflection_cards(life_id)
+            assert all(
+                card.failure_dimensions == ("insufficient_permission",) for card in cards
+            )
+            profiles = store.latest_capability_profiles(life_id)
+            assert len(profiles) == 1
+            # C2：A1 影响 + 3 条 verified 失败 → 自动回滚，熟练度归零。
+            assert profiles[0].rollback_count == 1
+            assert profiles[0].proficiency_lower_bound_milli == 0
+            # C3：双体系互斥——认知层回滚不触碰运行时治理层：
+            # pointer 仍 active，健康档案照常记账失败。
+            pointer = life._scope_state(life_id)["capability_pointers"][artifact["lineage_id"]]
+            assert pointer["status"] == "active"
+            assert pointer["health"]["consecutive_failures"] == 3
+            assert pointer["health"]["success_streak"] == 0
+        finally:
+            life.close()

--- a/tests/test_life_reflection_chain_wiring.py
+++ b/tests/test_life_reflection_chain_wiring.py
@@ -365,3 +365,121 @@ def test_c2_c3_three_verified_failures_auto_rollback_pointer_stays_active(tmp_pa
             assert pointer["health"]["success_streak"] == 0
         finally:
             life.close()
+
+
+# ---------- F3 步骤 5：消费面 P1/P2/S1/S2 ----------
+
+
+def test_p1_panel_exposes_reflection_cards(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            seed(life)
+            life_id = str(life._active()["life_id"])
+
+            def decide(_scope: dict, _task: dict) -> dict:
+                return {
+                    "title": "今日规划",
+                    "summary": "已完成内部规划，推进一个可验证的小步骤。",
+                    "findings": [],
+                    "next_steps": [],
+                    "uncertainties": [],
+                }
+
+            life.set_autonomy_decider(decide)
+            first = request(life, "POST", "/api/v1/v3/life/autonomy/tick", {"reason": "p1"})
+            task_id = next(
+                item["task_id"] for item in first["tasks"]
+                if item.get("source") == "life_activity_catalog"
+            )
+            wait_task_status(life, life_id, task_id, {"completed"})
+            wait_reflection_closed(life, life_id)
+            panel = request(life, "GET", "/api/v1/v3/life/panel")
+            cards = panel["reflection_cards"]
+            assert len(cards) == 1
+            assert cards[0]["source"] == "causal_reflection_chain"
+            assert cards[0]["revision"]
+            assert "已完成内部规划" in cards[0]["observed_outcome"]
+        finally:
+            life.close()
+
+
+def test_p2_overlay_carries_profile_and_composite_score(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        # 两次失败 + 一次成功：失败证据 eligible → profile 落库（hold）。
+        calls = {"n": 0}
+
+        def flaky_invoker(action_id, arguments, ctx):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                return {"ok": False, "error_code": "tool_error"}
+            return {"ok": True, "zhuangtai": "wancheng"}
+
+        life, life_id, artifact = _capability_runtime(
+            Path(temporary), risk_level="A1", invoker=flaky_invoker
+        )
+        try:
+            for index in range(3):
+                life._capability_invoke(
+                    {
+                        "life_id": life_id,
+                        "artifact_id": artifact["artifact_id"],
+                        "request_id": f"p2-{index}",
+                    }
+                )
+            overlay = life._capability_overlay_payload({"life_id": life_id})
+            rows = overlay["artifacts"]
+            assert len(rows) == 1
+            row = rows[0]
+            # profile 字段挂载 + 双体系综合分。
+            assert row["profile"]["rollback_count"] == 0
+            assert row["proficiency_lower_bound_milli"] == 0
+            assert row["composite_score_milli"] == max(
+                row["health_score_milli"], row["proficiency_lower_bound_milli"]
+            )
+            context = overlay["model_context"][0]
+            assert "proficiency_lower_bound_milli" in context
+            assert "health_score_milli" in context
+        finally:
+            life.close()
+
+
+def test_s1_s2_activity_scope_injects_recent_reflections_without_secret_keys(tmp_path: Path) -> None:
+    from life_service.activity_scope import build_activity_scope
+
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            life_id = str(life._active()["life_id"])
+            rows = [
+                {
+                    "reflection_id": "rfc_test_1",
+                    "observed_outcome": "任务失败：工具返回错误。" + "长" * 600,
+                    "prediction_error_milli": 300,
+                    "failure_dimensions": ["tool_error"],
+                    "next_minimal_experiment": "先执行只读探针。",
+                }
+            ] * 7
+            scope = build_activity_scope(
+                life_id=life_id,
+                soul=None,
+                scope=life._scope_state(life_id),
+                reflection_rows=rows,
+            )
+            # S1：注入最近 5 条、文本截断。
+            assert len(scope["recent_reflections"]) == 5
+            trimmed = scope["recent_reflections"][0]
+            assert len(trimmed["observed_outcome"]) <= 400
+            assert trimmed["prediction_error_milli"] == 300
+            # S2：顶层键不含 credential 类词（防泄密守卫在构建时执行）。
+            top_keys = {str(key).casefold() for key in scope}
+            assert not top_keys & {
+                "api_key", "apikey", "token", "password", "secret", "credential",
+            }
+            # 缺省参数零影响：不传 reflection_rows 时不注入内容。
+            default_scope = build_activity_scope(
+                life_id=life_id, soul=None, scope=life._scope_state(life_id)
+            )
+            assert default_scope["recent_reflections"] == []
+        finally:
+            life.close()

--- a/tests/test_life_scheduler_budgets.py
+++ b/tests/test_life_scheduler_budgets.py
@@ -1,0 +1,209 @@
+"""F6：learning/self-iteration/capability-patch 三个调度器的子预算记账。
+
+照 proactive 双池模式（全局池 + 子池）：预算耗尽时 decider 不被调用、
+skipped 计数正确、跨 UTC 日重置、全局池与子池独立耗尽互不越界。
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+from life_service.embedded_runtime import EmbeddedLifeRuntime
+
+
+def runtime(root: Path) -> EmbeddedLifeRuntime:
+    life = EmbeddedLifeRuntime(
+        data_root=root / "life-data",
+        runtime_root=root / "runtime",
+        mode="embedded",
+    )
+    life.scheduler.stop(timeout_seconds=2)
+    return life
+
+
+def utc_day(offset_days: int = 0) -> str:
+    moment = time.gmtime(time.time() + offset_days * 86_400)
+    return time.strftime("%Y-%m-%d", moment)
+
+
+def seed_pool(scheduler: dict, *, prefix: str, day: str, attempts: int, successes: int = 0) -> None:
+    """把某个子池预置到指定状态；全局池默认留给调用方按需覆盖。"""
+    scheduler.update({
+        f"{prefix}budget_date": day,
+        f"{prefix}attempts": attempts,
+        f"{prefix}successes": successes,
+        f"{prefix}failures": 0,
+        f"{prefix}timeouts": 0,
+        f"{prefix}skipped": 0,
+    })
+
+
+def seed_global(scheduler: dict, *, day: str, attempts: int = 0, successes: int = 0) -> None:
+    scheduler.update({
+        "model_budget_date": day,
+        "model_attempts": attempts,
+        "model_successes": successes,
+        "model_failures": 0,
+        "model_timeouts": 0,
+        "model_skipped": 0,
+    })
+
+
+def wait_scheduler_idle(life: EmbeddedLifeRuntime, life_id: str, *, inflight_key: str, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        scheduler = life._scope_state(life_id).get("scheduler") or {}
+        if not bool(scheduler.get(inflight_key)):
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"scheduler still inflight: {inflight_key}")
+
+
+def test_learning_sub_budget_exhausted_skips_decider_and_counts_skip():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            today = utc_day()
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            seed_global(scheduler, day=today)
+            # 子池尝试数已到默认上限 8：耗尽。
+            seed_pool(scheduler, prefix="learning_model_", day=today, attempts=8, successes=6)
+            calls: list[dict] = []
+            life.set_learning_decider(lambda _scope: calls.append({}) or {"target": "none"})
+            life_id = str(life._active()["life_id"])
+            life._schedule_autonomous_learning_decision(life_id=life_id)
+            assert calls == []
+            assert scheduler["model_skipped"] == 1
+            assert scheduler["learning_model_skipped"] == 1
+            assert scheduler["model_attempts"] == 0
+            assert scheduler["last_learning_decision_error"] == "life.learning.model_budget_exhausted"
+            assert scheduler.get("learning_decision_inflight") is not True
+        finally:
+            life.close()
+
+
+def test_self_iteration_sub_budget_exhausted_skips_decider():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            today = utc_day()
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            seed_global(scheduler, day=today)
+            seed_pool(scheduler, prefix="self_iteration_model_", day=today, attempts=6, successes=4)
+            calls: list[dict] = []
+            life.set_self_iteration_decider(lambda _scope: calls.append({}) or {"target": "none"})
+            life_id = str(life._active()["life_id"])
+            life._schedule_self_iteration_decision(life_id=life_id)
+            assert calls == []
+            assert scheduler["model_skipped"] == 1
+            assert scheduler["self_iteration_model_skipped"] == 1
+            assert scheduler["last_self_iteration_decision_error"] == "life.self_iteration.model_budget_exhausted"
+        finally:
+            life.close()
+
+
+def test_capability_patch_entry_peek_blocks_without_side_effects():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            today = utc_day()
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            seed_global(scheduler, day=today)
+            seed_pool(scheduler, prefix="capability_patch_model_", day=today, attempts=8, successes=6)
+            calls: list[dict] = []
+            life.set_capability_patch_decider(lambda _material: calls.append({}) or {})
+            life_id = str(life._active()["life_id"])
+            life._schedule_capability_health_decision(life_id=life_id)
+            assert calls == []
+            # 入口只窥探不记账：真正的按次记账在 worker 内每个补丁目标前完成。
+            assert scheduler.get("model_skipped", 0) == 0
+            assert scheduler.get("capability_patch_model_skipped", 0) == 0
+            assert scheduler["last_capability_health_error"] == "life.capability_patch.model_budget_exhausted"
+            assert scheduler.get("capability_health_inflight") is not True
+        finally:
+            life.close()
+
+
+def test_cross_utc_day_resets_sub_pool_and_allows_call_again():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            yesterday = utc_day(-1)
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            seed_global(scheduler, day=yesterday, attempts=30, successes=20)
+            seed_pool(scheduler, prefix="learning_model_", day=yesterday, attempts=8, successes=6)
+            calls: list[dict] = []
+            life.set_learning_decider(lambda _scope: calls.append({}) or {"target": "none"})
+            life_id = str(life._active()["life_id"])
+            life._schedule_autonomous_learning_decision(life_id=life_id)
+            wait_scheduler_idle(life, life_id, inflight_key="learning_decision_inflight")
+            assert calls, "跨日后预算应重置并允许调用"
+            assert scheduler["model_attempts"] == 1
+            assert scheduler["learning_model_attempts"] == 1
+            assert scheduler["model_successes"] == 1
+            assert scheduler["learning_model_successes"] == 1
+        finally:
+            life.close()
+
+
+def test_global_pool_exhaustion_blocks_all_schedulers():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            today = utc_day()
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            # 全局尝试数到 30：即使各子池全新，也一律拒绝。
+            seed_global(scheduler, day=today, attempts=30, successes=20)
+            seed_pool(scheduler, prefix="learning_model_", day=today, attempts=0)
+            seed_pool(scheduler, prefix="self_iteration_model_", day=today, attempts=0)
+            learning_calls: list[dict] = []
+            iteration_calls: list[dict] = []
+            life.set_learning_decider(lambda _scope: learning_calls.append({}) or {"target": "none"})
+            life.set_self_iteration_decider(lambda _scope: iteration_calls.append({}) or {"target": "none"})
+            life_id = str(life._active()["life_id"])
+            life._schedule_autonomous_learning_decision(life_id=life_id)
+            life._schedule_self_iteration_decision(life_id=life_id)
+            assert learning_calls == []
+            assert iteration_calls == []
+            assert scheduler["model_skipped"] == 2
+            assert scheduler["learning_model_skipped"] == 1
+            assert scheduler["self_iteration_model_skipped"] == 1
+        finally:
+            life.close()
+
+
+def test_sub_pools_are_independent_learning_full_does_not_block_iteration():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            today = utc_day()
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            seed_global(scheduler, day=today)
+            seed_pool(scheduler, prefix="learning_model_", day=today, attempts=8, successes=6)
+            seed_pool(scheduler, prefix="self_iteration_model_", day=today, attempts=0)
+            learning_calls: list[dict] = []
+            iteration_calls: list[dict] = []
+            life.set_learning_decider(lambda _scope: learning_calls.append({}) or {"target": "none"})
+            life.set_self_iteration_decider(lambda _scope: iteration_calls.append({}) or {"target": "none"})
+            life_id = str(life._active()["life_id"])
+            life._schedule_autonomous_learning_decision(life_id=life_id)
+            life._schedule_self_iteration_decision(life_id=life_id)
+            wait_scheduler_idle(life, life_id, inflight_key="self_iteration_decision_inflight")
+            # 学习子池耗尽 → 拒绝；自我迭代子池独立 → 正常调用并记账。
+            assert learning_calls == []
+            assert scheduler["learning_model_skipped"] == 1
+            assert iteration_calls, "自我迭代子池应独立可用"
+            assert scheduler["self_iteration_model_attempts"] == 1
+            assert scheduler["self_iteration_model_successes"] == 1
+            assert scheduler["model_attempts"] == 1
+            assert scheduler["model_skipped"] == 1
+        finally:
+            life.close()

--- a/tests/test_p16_native_proactive_runtime.py
+++ b/tests/test_p16_native_proactive_runtime.py
@@ -405,3 +405,50 @@ def test_reply_lineage_expires_after_bounded_temporal_window():
             assert row["replied"] is False
         finally:
             life.close()
+
+
+def test_proactive_context_excludes_deliveries_inside_reply_window():
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            life_id = str(life._active()["life_id"])
+            scope = life._scope_state(life_id)
+            day = 86_400_000
+            now_ms = int(time.time() * 1000)
+            scope["proactive_chats"] = [
+                # 旧的未回复投递（10 天前，已过 6h 回复窗口）：计入忽略率样本。
+                {
+                    "message_id": "m_old",
+                    "reason": "life.proactive.native",
+                    "created_at_ms": now_ms - 10 * day,
+                    "replied": False,
+                    "acked": True,
+                    "candidate_kind": "respond",
+                },
+                # 新投递（1 小时前，仍在回复窗口内）：不计入，不能提前记为忽略。
+                {
+                    "message_id": "m_new",
+                    "reason": "life.proactive.native",
+                    "created_at_ms": now_ms - 3_600_000,
+                    "replied": False,
+                    "acked": False,
+                    "candidate_kind": "respond",
+                },
+                # 非本生产者的记录不计入。
+                {
+                    "message_id": "m_other",
+                    "reason": "legacy_share",
+                    "created_at_ms": now_ms - 10 * day,
+                    "replied": False,
+                },
+            ]
+            context = life._build_proactive_context(life_id=life_id, now_ms=now_ms)
+            outcomes = context["recent_delivery_outcomes"]
+            assert [row["created_at_ms"] for row in outcomes] == [now_ms - 10 * day]
+            assert outcomes[0]["replied"] is False
+            assert outcomes[0]["acked"] is True
+            assert outcomes[0]["candidate_kind"] == "respond"
+            # 时间线投影不受影响（仍包含两条本生产者投递）。
+            assert len(context["recent_delivery_times_ms"]) == 2
+        finally:
+            life.close()

--- a/tests/test_p16_proactive_initiative.py
+++ b/tests/test_p16_proactive_initiative.py
@@ -283,3 +283,115 @@ def test_world_evidence_requires_committed_world_authority():
         now_ms=NOW,
     )
     assert allowed["allowed"] is True
+
+
+# ---------- F1：忽略率门禁（用户不理会时学会闭嘴） ----------
+
+
+def _outcome(created_at_ms: int, *, replied: bool = False) -> dict:
+    return {
+        "created_at_ms": created_at_ms,
+        "candidate_kind": "respond",
+        "replied": replied,
+        "acked": True,
+    }
+
+
+def marginal_proposal() -> dict:
+    """效用 LCB=150 的边缘提案：默认门槛 120 放行，抬高后拦截。"""
+    base = proposal()
+    base["score"] = {**base["score"], "goal_gain_milli": 20}
+    return base
+
+
+def test_engagement_gate_silent_on_missing_or_empty_history():
+    # 旧上下文（无新键）与空历史：不加门禁，边缘提案照常放行。
+    decision = evaluate_proactive_candidate(
+        marginal_proposal(), context=context(), settings=settings(), now_ms=NOW
+    )
+    assert decision["allowed"] is True
+    decision = evaluate_proactive_candidate(
+        marginal_proposal(),
+        context=context(recent_delivery_outcomes=[]),
+        settings=settings(),
+        now_ms=NOW,
+    )
+    assert decision["allowed"] is True
+
+
+def test_engagement_gate_requires_minimum_sample_size():
+    # 7 条样本（< 默认窗口 8）：样本不足不加门禁。
+    outcomes = [_outcome(NOW - (index + 1) * 7_200_000) for index in range(7)]
+    decision = evaluate_proactive_candidate(
+        marginal_proposal(),
+        context=context(recent_delivery_outcomes=outcomes),
+        settings=settings(),
+        now_ms=NOW,
+    )
+    assert decision["allowed"] is True
+
+
+def test_low_reply_rate_raises_utility_threshold():
+    # 8 条全部未回复：忽略率门禁抬高门槛（120+60=180 > LCB 150）→ 拦截。
+    outcomes = [_outcome(NOW - (index + 1) * 9_000_000) for index in range(8)]
+    decision = evaluate_proactive_candidate(
+        marginal_proposal(),
+        context=context(recent_delivery_outcomes=outcomes),
+        settings=settings(),
+        now_ms=NOW,
+    )
+    assert decision["allowed"] is False
+    assert decision["reason_code"] == "life.proactive.utility_below_threshold"
+    # 高回复率的对照：门槛不抬高，同一提案放行。
+    replied_outcomes = [_outcome(NOW - (index + 1) * 9_000_000, replied=True) for index in range(8)]
+    control = evaluate_proactive_candidate(
+        marginal_proposal(),
+        context=context(recent_delivery_outcomes=replied_outcomes),
+        settings=settings(),
+        now_ms=NOW,
+    )
+    assert control["allowed"] is True
+
+
+def test_low_reply_rate_extends_effective_interval():
+    # 回复率过低时有效最小间隔 ×4：2 小时前的投递满足默认 1 小时间隔，
+    # 但不满足扩展间隔 → engagement_low 拒绝。
+    delivery_at = NOW - 7_200_000
+    outcomes = [_outcome(delivery_at - index * 7_200_000) for index in range(8)]
+    decision = evaluate_proactive_candidate(
+        proposal(),
+        context=context(
+            recent_delivery_times_ms=[delivery_at],
+            recent_delivery_outcomes=outcomes,
+        ),
+        settings=settings(),
+        now_ms=NOW,
+    )
+    assert decision["allowed"] is False
+    assert decision["reason_code"] == "life.proactive.engagement_low"
+    # 对照：部分回复（2/8=250 ≥ 200）不触发间隔扩展。
+    mixed = [_outcome(delivery_at - 0 * 7_200_000, replied=True) for _ in range(1)] + \
+            [_outcome(delivery_at - index * 7_200_000, replied=True) for index in range(1, 2)] + \
+            [_outcome(delivery_at - index * 7_200_000) for index in range(2, 8)]
+    control = evaluate_proactive_candidate(
+        proposal(),
+        context=context(
+            recent_delivery_times_ms=[delivery_at],
+            recent_delivery_outcomes=mixed,
+        ),
+        settings=settings(),
+        now_ms=NOW,
+    )
+    assert control["allowed"] is True
+
+
+def test_engagement_gate_disabled_via_zero_reply_rate_setting():
+    # proactive_min_reply_rate_milli=0 显式禁用门禁：全忽略也不拦截。
+    outcomes = [_outcome(NOW - (index + 1) * 9_000_000) for index in range(8)]
+    decision = evaluate_proactive_candidate(
+        marginal_proposal(),
+        context=context(recent_delivery_outcomes=outcomes),
+        settings=settings(proactive_min_reply_rate_milli=0),
+        now_ms=NOW,
+    )
+    assert decision["allowed"] is True


### PR DESCRIPTION
## 背景

对五系统（自主行动/自我反思/自我迭代/自主学习/自主消息）的专项评价发现六个"建成未接线"或"闭环缺口"类真实缺陷。本 PR 按已批准计划全部修复，只动真实缺陷，不碰刻意设计与研究级难题。详见 `docs/repair-logs/2026-08-21_P8.1_reflection-lane-production-wiring.md`。

## 修复项

| # | 缺陷 | 修复 |
|---|------|------|
| F1 | proactive acked/replied 信号零消费者——学不会"闭嘴" | 忽略率门禁：按最近 N 条回复率抬高效用门槛并延长间隔（×2/零回复×4），6h 回复窗口内不计入，空历史放行 |
| F2 | proactive live 模式无 UI 开关 | 设置面板"主动沟通"分组（模式下拉+总开关），消费现成 getProactiveStatus 状态行 |
| F3 | P8 反思链零生产调用（六步） | store 5 只读方法 → episode_builder 纯函数 → 任务源四挂点（事前预测落账/完成/失败/孤儿 ABORTED）→ 能力源两挂点（证据/学习/回滚规则）→ 消费面（面板 reflection_cards、overlay 综合分、scope 注入）→ 文档三篇 |
| F4 | motivation_drift 只产面板文案 | 漂移加分接入自由行动排序；due 到点必做不变；样本<10 不加权 |
| F5 | 能力系统只有负向反馈 | 连胜+健康分（Hoeffding 保守率×7天半衰）驱动 overlay 排序；闲置 7 天标 idle 自然沉底淘汰 |
| F6 | 三调度器不记账预算 | 照 proactive 双池模式：日重置/入口预留/成败双池累加，子预算 6/8、4/6、6/8 |
| 附 | hotfix_20260727 无条件覆盖新源码 | 加源码版本守卫（含 _drift_affinity 标记即跳过），全量测试下不再回退新逻辑 |

## 关键架构决策（P8.1）

- 双体系共存：capability_health 管运行时可用性（唯一写 pointer），capability_learning 管认知熟练度（只读输入）；verified 失败 ≥3 且 A0-A2 自动回滚，rollback 不改 pointer（C3 测试锁死）
- 确定性预测基线：真实完成率毫值映射（无历史 700），快照随 OPEN episode 先于执行落账，事后可审计防编造
- 诚实基线：成功证据 correlation_only 不进能力学习（认识论分层保持，成功晋升等未来假设管线）
- 三不碰：不进记忆晋升、不产生用户提问、不进 proactive；熔断 TIANGONG_LIFE_REFLECTION_CHAIN=0

## 验证

- 全量回归 3160 通过 / 0 失败（本机 24 分钟；修复 hotfix 守卫前 5 败，已定位并修复）
- 新增测试：episode_builder B1-B5、反思链接线 T1-T4/C1-C3/P1/P2/S1/S2、预算 6 场景、健康分/闲置、门禁 6 场景、漂移排序 3 场景、live 开关渲染
- 守卫回归重点全绿：legacy_proactive_freeze / p17_m4_architecture_guards / p18_m3_learning_poisoning / embedded_lifecycle / life_frontend_p10

🤖 Generated with [Claude Code](https://claude.com/claude-code)