### PR TITLE
fix: close Life QC and provider credential contract gaps

### DIFF
--- a/app/backend/tiangong-backend/v3/peizhi.py
+++ b/app/backend/tiangong-backend/v3/peizhi.py
@@ -211,6 +211,27 @@ PROVIDER_MATCH_WEIGHTS = {
 MOREN_PROVIDER = L4_OPENAI_FALLBACK_PROVIDER   # 默认对话Provider；未命中时走 OpenAI 兼容优化
 CUSTOM_PROVIDER_ID = "custom"                  # 用户自定义/未命名服务商的持久化身份
 
+# P18.1 credential authority: new desktop writes are keyed by persisted
+# provider identity, never by the L4 optimization family. Historical family
+# IDs remain read-compatible so upgrades do not orphan an existing vault/env.
+CREDENTIAL_IDENTITY_ALIASES = {
+    "deepseek_v4": "deepseek",
+    "glm_5_1": "zhipu",
+    "glm_5_2": "zhipu",
+    "minimax_m3": "minimax",
+    "gpt_5_5": "openai",
+    "gpt_5_6": "openai",
+}
+CREDENTIAL_IDENTITY_ENV_NAMES = {
+    "deepseek": ("TIANGONG_DEEPSEEK_API_KEY",),
+    "openai": ("TIANGONG_OPENAI_API_KEY",),
+    "zhipu": ("TIANGONG_ZHIPU_API_KEY",),
+    "minimax": ("TIANGONG_MINIMAX_API_KEY",),
+    "mimo": ("TIANGONG_MIMO_API_KEY",),
+    "anthropic": ("TIANGONG_ANTHROPIC_API_KEY",),
+    "google": ("TIANGONG_GOOGLE_API_KEY",),
+}
+
 
 def normalize_provider_id(provider_id: str | None) -> str:
     raw = str(provider_id or "").strip()
@@ -258,6 +279,20 @@ def normalize_provider_identity(provider_id: str | None) -> str:
         "gpt_5_6": "gpt_5_6",
     }
     return identity_aliases.get(key, raw)
+
+
+def provider_identity_env_names(provider_id: str | None) -> tuple[str, ...]:
+    """Return canonical desktop env slots for persisted provider identity.
+
+    L4 family IDs are accepted only as read-compatibility aliases. Returned
+    slots always use the provider-identity namespace written by Electron.
+    """
+
+    normalized_identity = normalize_provider_identity(provider_id)
+    credential_identity = CREDENTIAL_IDENTITY_ALIASES.get(
+        normalized_identity, normalized_identity
+    )
+    return CREDENTIAL_IDENTITY_ENV_NAMES.get(credential_identity, ())
 
 
 def normalize_provider_base_url(base_url: str | None) -> str:
@@ -550,10 +585,17 @@ def _candidate_provider_keys(provider_id: str | None) -> tuple[str, ...]:
     return tuple(keys)
 
 def duqu_api_miyao(provider_id: str) -> str | None:
-    """读取API密钥：先环境变量 → 再配置文件 → 再默认文件"""
+    """读取API密钥：identity env → legacy family env → 配置文件。"""
     import os, json as _json
-    provider_id = normalize_provider_id(provider_id)
-    # 环境变量
+    raw_provider_id = str(provider_id or "").strip()
+    # P18.1 new authority: Electron persists/injects the provider IDENTITY.
+    # Read that slot first. Family/vendor slots below are migration fallbacks.
+    for env_name in provider_identity_env_names(raw_provider_id):
+        val = os.environ.get(env_name)
+        if val:
+            return val
+    provider_id = normalize_provider_id(raw_provider_id)
+    # 旧 family / vendor 环境变量（只读兼容）
     env_map = {
         "gpt_5_6": ("TIANGONG_GPT_5_6_API_KEY", "OPENAI_API_KEY"),
         "openai": ("TIANGONG_GPT_5_6_API_KEY", "OPENAI_API_KEY"),
@@ -594,15 +636,15 @@ def duqu_api_miyao(provider_id: str) -> str | None:
 def duqu_endpoint_api_miyao(provider_id: str, base_url: str) -> str | None:
     """Return only a credential explicitly bound to ``base_url``.
 
-    Official vendor origins use the vendor slot. Every custom origin has an
-    independent slot under ``_custom_endpoint_keys`` and never inherits a
-    provider key. Local/private endpoints are keyless unless the user stores a
-    custom key for that exact canonical origin.
+    Official vendor origins use the persisted provider-identity slot first.
+    Historical L4-family/vendor slots are read-only migration fallbacks. Every
+    custom origin keeps its independent endpoint-hash slot and never inherits a
+    provider key.
     """
-    provider_id = normalize_provider_id(provider_id)
-    binding = validate_model_endpoint(provider_id, base_url, resolve_dns=False)
+    identity_provider = normalize_provider_identity(provider_id)
+    binding = validate_model_endpoint(identity_provider, base_url, resolve_dns=False)
     if binding.official:
-        return duqu_api_miyao(provider_id)
+        return duqu_api_miyao(identity_provider)
     scope = str(binding.custom_scope or "")
     env_name = f"TIANGONG_{scope.upper().replace('-', '_')}_API_KEY"
     value = str(os.environ.get(env_name) or "").strip()

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "ca2c60e7f9763c9df42326aebe9fc59f5d79772ab1015ea4e13608ca2ec62eed",
+  "tree_sha256": "129e8372394697e5fe8faf6e3216913f286312bcbff3b59d6b60484aaa74ab41",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -485,12 +485,20 @@ class EmbeddedLifeRuntime:
                 binding_factory=None,
             )
             self._state = self._load_state()
+            reflection_recovered = self._reconcile_open_reflection_episodes(active_life_id)
             heartbeat_recovered = self._reconcile_scheduler_heartbeat(active_life_id)
             recovered_inflight = recover_inflight_scheduler_flags(self._state)
             projection_changed = self._reconcile_authoritative_journal(active_life_id)
             classification_changed = self._ensure_memory_classification(active_life_id)
             memory_contract_changed = self._reconcile_memory_contract(active_life_id)
-            if projection_changed or classification_changed or memory_contract_changed or heartbeat_recovered or recovered_inflight:
+            if (
+                projection_changed
+                or classification_changed
+                or memory_contract_changed
+                or heartbeat_recovered
+                or recovered_inflight
+                or reflection_recovered
+            ):
                 self._persist(active_life_id)
             heartbeat_seconds = float(os.environ.get("TIANGONG_LIFE_HEARTBEAT_SECONDS") or 30.0)
             self.scheduler = start_embedded_scheduler(
@@ -2479,6 +2487,156 @@ class EmbeddedLifeRuntime:
 
     _REFLECTION_EPISODE_REGISTRY_CAP = 32
 
+    def _reflection_registry_entry_from_episode_locked(
+        self, *, life_id: str, episode: Any, event_by_id: Mapping[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        """Rehydrate one OPEN episode cache row from authoritative evidence."""
+        if str(getattr(episode, "life_id", "") or "") != life_id:
+            return None
+        if str(getattr(episode, "terminal_status", "") or "") != "OPEN":
+            return None
+        trigger_ids = tuple(getattr(episode, "trigger_event_ids", ()) or ())
+        if not trigger_ids:
+            return None
+        store = self._contract_store()
+        events = event_by_id or {
+            str(event.event_id): event for event in store.load_events(life_id)
+        }
+        trigger_id = str(trigger_ids[0])
+        trigger = events.get(trigger_id)
+        if trigger is None:
+            return None
+        correlation_id = str(getattr(trigger, "correlation_id", "") or "")
+        if ":" not in correlation_id:
+            return None
+        source, ref_id = correlation_id.split(":", 1)
+        source, ref_id = source.strip(), ref_id.strip()
+        if not source or not ref_id:
+            return None
+        try:
+            snapshot = json.loads(str(getattr(episode, "prior_prediction", "") or ""))
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(snapshot, Mapping):
+            return None
+        context_hashes = tuple(getattr(episode, "context_state_hashes", ()) or ())
+        entry: dict[str, Any] = {
+            "source": source,
+            "ref": ref_id,
+            "episode_id": str(getattr(episode, "episode_id", "") or ""),
+            "correlation_id": correlation_id,
+            "predicted_success_milli": int(snapshot.get("predicted_success_milli") or 0),
+            "prediction_snapshot": deepcopy(dict(snapshot)),
+            "context_sha256": str(context_hashes[0] if context_hashes else ""),
+            "action_risk": "A1",
+            "opened_at_ms": int(getattr(episode, "created_at_ms", 0) or 0),
+        }
+        scope = self._scope_state(life_id)
+        if source == "autonomy":
+            task = (self._autonomy_state(life_id).get("tasks") or {}).get(ref_id)
+            if isinstance(task, Mapping):
+                entry["action_risk"] = str(task.get("risk_class") or "A0")
+        elif source == "capability":
+            capability_id = str(
+                getattr(episode, "selected_action_id", "")
+                or snapshot.get("artifact_id")
+                or ""
+            )
+            artifact = (scope.get("capabilities") or {}).get(capability_id)
+            artifact = artifact if isinstance(artifact, Mapping) else {}
+            entry.update({
+                "capability_id": capability_id,
+                "capability_version": str(artifact.get("version") or snapshot.get("version") or ""),
+                "capability_scope": str(artifact.get("title") or getattr(episode, "intention", "") or "能力学习"),
+                "action_risk": str(artifact.get("risk_level") or "A3"),
+            })
+            impact = store.find_action_impact_for_source_event(
+                life_id=life_id,
+                action_id=capability_id,
+                source_event_id=trigger_id,
+            )
+            if impact is not None:
+                entry["action_impact"] = impact.model_dump(mode="json")
+        return entry
+
+    def _resolve_runtime_episode_entry_locked(
+        self, *, life_id: str, source: str, ref_id: str
+    ) -> dict[str, Any] | None:
+        """Resolve OPEN episode from cache, then from the authoritative Store."""
+        scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+        registry = [
+            row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+        ]
+        for row in registry:
+            if (
+                str(row.get("source") or "") == source
+                and str(row.get("ref") or "") == ref_id
+            ):
+                return dict(row)
+        store = self._contract_store()
+        event_by_id = {str(event.event_id): event for event in store.load_events(life_id)}
+        offset = 0
+        while True:
+            batch = store.open_causal_episodes(life_id, limit=256, offset=offset)
+            if not batch:
+                return None
+            for episode in batch:
+                entry = self._reflection_registry_entry_from_episode_locked(
+                    life_id=life_id, episode=episode, event_by_id=event_by_id
+                )
+                if entry is None:
+                    continue
+                if (
+                    str(entry.get("source") or "") == source
+                    and str(entry.get("ref") or "") == ref_id
+                ):
+                    registry.append(entry)
+                    scheduler["open_episodes"] = registry[-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+                    return entry
+            if len(batch) < 256:
+                return None
+            offset += len(batch)
+
+    def _reconcile_open_reflection_episodes(self, life_id: str) -> int:
+        """Abort OPEN episodes orphaned by a previous process before scheduling."""
+        if not self._reflection_chain_enabled():
+            return 0
+        store = self._contract_store()
+        event_by_id = {str(event.event_id): event for event in store.load_events(life_id)}
+        episodes: list[Any] = []
+        offset = 0
+        while True:
+            batch = store.open_causal_episodes(life_id, limit=256, offset=offset)
+            episodes.extend(batch)
+            if len(batch) < 256:
+                break
+            offset += len(batch)
+        recovered = 0
+        for episode in episodes:
+            entry = self._reflection_registry_entry_from_episode_locked(
+                life_id=life_id, episode=episode, event_by_id=event_by_id
+            )
+            if entry is None:
+                self._reflection_journal_failure(life_id, "rehydrate_open", None)
+                continue
+            scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+            registry = [
+                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+            ]
+            registry.append(entry)
+            scheduler["open_episodes"] = registry[-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+            self._abort_runtime_episode_locked(
+                life_id=life_id,
+                source=str(entry["source"]),
+                ref_id=str(entry["ref"]),
+                reason="restart_recovery",
+            )
+            if not store.is_causal_episode_open(
+                life_id, str(getattr(episode, "episode_id", "") or "")
+            ):
+                recovered += 1
+        return recovered
+
     def _reflection_chain_enabled(self) -> bool:
         """熔断开关：TIANGONG_LIFE_REFLECTION_CHAIN=0 时整条反思链停摆。"""
         return str(os.environ.get("TIANGONG_LIFE_REFLECTION_CHAIN") or "1").strip() != "0"
@@ -2652,19 +2810,11 @@ class EmbeddedLifeRuntime:
             return
         try:
             scheduler = self._scope_state(life_id).setdefault("scheduler", {})
-            registry = [
-                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
-            ]
-            entry = next(
-                (
-                    row for row in registry
-                    if str(row.get("source") or "") == source
-                    and str(row.get("ref") or "") == ref_id
-                ),
-                None,
+            entry = self._resolve_runtime_episode_entry_locked(
+                life_id=life_id, source=source, ref_id=ref_id
             )
             if entry is None:
-                return  # 没有事前落账（链路关闭或 opening 失败），无从收尾
+                return  # Store 中没有事前 OPEN 证据，无法合法收尾
             outcome_event = self._runtime_life_event_locked(
                 life_id=life_id,
                 event_kind=event_kind,
@@ -2699,7 +2849,10 @@ class EmbeddedLifeRuntime:
                 outcome, now_ms=time.time_ns() // 1_000_000
             )
             scheduler["open_episodes"] = [
-                row for row in registry if row is not entry
+                row
+                for row in scheduler.get("open_episodes") or []
+                if isinstance(row, Mapping)
+                and str(row.get("episode_id") or "") != str(entry.get("episode_id") or "")
             ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
             try:
                 self.system.journal.append(
@@ -2825,16 +2978,8 @@ class EmbeddedLifeRuntime:
         try:
             store = self._contract_store()
             scheduler = self._scope_state(life_id).setdefault("scheduler", {})
-            registry = [
-                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
-            ]
-            entry = next(
-                (
-                    row for row in registry
-                    if str(row.get("source") or "") == "capability"
-                    and str(row.get("ref") or "") == execution_id
-                ),
-                None,
+            entry = self._resolve_runtime_episode_entry_locked(
+                life_id=life_id, source="capability", ref_id=execution_id
             )
             if entry is None:
                 return None
@@ -2930,7 +3075,10 @@ class EmbeddedLifeRuntime:
                 )
                 rollback_applied = True
             scheduler["open_episodes"] = [
-                row for row in registry if row is not entry
+                row
+                for row in scheduler.get("open_episodes") or []
+                if isinstance(row, Mapping)
+                and str(row.get("episode_id") or "") != str(entry.get("episode_id") or "")
             ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
             if learned is not None:
                 try:
@@ -3136,8 +3284,8 @@ class EmbeddedLifeRuntime:
         success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
         attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
         if (
-            (success_limit and int(scheduler.get("model_successes") or 0) >= success_limit)
-            or (attempt_limit and int(scheduler.get("model_attempts") or 0) >= attempt_limit)
+            int(scheduler.get("model_successes") or 0) >= success_limit
+            or int(scheduler.get("model_attempts") or 0) >= attempt_limit
         ):
             scheduler["model_skipped"] = int(scheduler.get("model_skipped") or 0) + 1
             scheduler["last_autonomy_decision_at_ms"] = now_ms
@@ -3990,10 +4138,10 @@ class EmbeddedLifeRuntime:
         proactive_success_limit = self._daily_limit_setting(settings, "proactive_llm_daily_budget", 6)
         proactive_attempt_limit = self._daily_limit_setting(settings, "proactive_llm_daily_attempt_budget", 8)
         exhausted = (
-            (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
-            or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
-            or (proactive_success_limit and int(scheduler.get("proactive_model_successes") or 0) >= proactive_success_limit)
-            or (proactive_attempt_limit and int(scheduler.get("proactive_model_attempts") or 0) >= proactive_attempt_limit)
+            int(scheduler.get("model_successes") or 0) >= global_success_limit
+            or int(scheduler.get("model_attempts") or 0) >= global_attempt_limit
+            or int(scheduler.get("proactive_model_successes") or 0) >= proactive_success_limit
+            or int(scheduler.get("proactive_model_attempts") or 0) >= proactive_attempt_limit
         )
         if exhausted:
             scheduler["model_skipped"] = int(scheduler.get("model_skipped") or 0) + 1
@@ -4069,10 +4217,10 @@ class EmbeddedLifeRuntime:
         sub_success_limit = self._daily_limit_setting(settings, str(config["success_key"]), int(config["success_default"]))
         sub_attempt_limit = self._daily_limit_setting(settings, str(config["attempt_key"]), int(config["attempt_default"]))
         return (
-            (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
-            or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
-            or (sub_success_limit and int(scheduler.get(f"{prefix}successes") or 0) >= sub_success_limit)
-            or (sub_attempt_limit and int(scheduler.get(f"{prefix}attempts") or 0) >= sub_attempt_limit)
+            int(scheduler.get("model_successes") or 0) >= global_success_limit
+            or int(scheduler.get("model_attempts") or 0) >= global_attempt_limit
+            or int(scheduler.get(f"{prefix}successes") or 0) >= sub_success_limit
+            or int(scheduler.get(f"{prefix}attempts") or 0) >= sub_attempt_limit
         )
 
     def _reserve_sub_model_call_locked(
@@ -7196,6 +7344,7 @@ class EmbeddedLifeRuntime:
         # （32 条截断即淘汰）。
         rows.sort(
             key=lambda item: (
+                int(bool(item.get("idle"))),
                 -int(item.get("composite_score_milli") or 0),
                 -int(item.get("last_outcome_at_ms") or 0),
                 str(item.get("kind")),
@@ -8046,11 +8195,12 @@ class EmbeddedLifeRuntime:
                     try:
                         decision = self._capability_patch_decider(material)
                         valid_decision = isinstance(decision, Mapping)
-                    except Exception:
+                    except Exception as exc:
                         with self._lock:
                             self._account_sub_model_failure_locked(
                                 self._scope_state(life_id).setdefault("scheduler", {}),
                                 pool="capability_patch",
+                                timeout=isinstance(exc, TimeoutError),
                             )
                         continue
                     if not valid_decision:
@@ -9443,6 +9593,12 @@ class EmbeddedLifeRuntime:
                     limits = {
                         "llm_daily_budget": (0, 1000),
                         "llm_daily_attempt_budget": (0, 2000),
+                        "learning_llm_daily_budget": (0, 1000),
+                        "learning_llm_daily_attempt_budget": (0, 2000),
+                        "self_iteration_llm_daily_budget": (0, 1000),
+                        "self_iteration_llm_daily_attempt_budget": (0, 2000),
+                        "capability_patch_llm_daily_budget": (0, 1000),
+                        "capability_patch_llm_daily_attempt_budget": (0, 2000),
                         "share_min_interval_seconds": (60, 604800),
                         "share_hourly_limit": (0, 60),
                         "share_daily_limit": (0, 1000),

--- a/app/life-service/runtime314/life_service/store.py
+++ b/app/life-service/runtime314/life_service/store.py
@@ -4095,13 +4095,15 @@ class LifeShadowStore:
         )
 
     def open_causal_episodes(
-        self, life_id: str, *, limit: int = 32
+        self, life_id: str, *, limit: int = 32, offset: int = 0
     ) -> tuple[CausalEpisode, ...]:
-        """Episodes whose LATEST revision is still OPEN, oldest first.
+        """Episodes whose latest revision is still OPEN, oldest first.
 
-        Closed episodes keep their OPEN revision-1 rows as history, so a plain
-        terminal_status filter would resurrect closed episodes as orphans.
+        Runtime registries are bounded caches, not authorities. ``offset``
+        allows recovery to page the complete authoritative OPEN set.
         """
+        bounded_limit = max(1, min(int(limit), 256))
+        bounded_offset = max(0, int(offset))
         rows = self._connection.execute(
             """
             SELECT e.payload FROM causal_episodes AS e
@@ -4115,14 +4117,46 @@ class LifeShadowStore:
              AND latest.max_revision = e.revision
             WHERE e.life_id = ? AND e.terminal_status = 'OPEN'
             ORDER BY e.created_at_ms, e.episode_id
-            LIMIT ?
+            LIMIT ? OFFSET ?
             """,
-            (life_id, life_id, max(1, min(int(limit), 256))),
+            (life_id, life_id, bounded_limit, bounded_offset),
         ).fetchall()
         return tuple(
             _parse_stored_contract(bytes(row["payload"]), CausalEpisode, "causal episode")
             for row in rows
         )
+
+    def is_causal_episode_open(self, life_id: str, episode_id: str) -> bool:
+        """Return whether the latest authoritative revision is still OPEN."""
+        row = self._connection.execute(
+            """
+            SELECT terminal_status FROM causal_episodes
+            WHERE life_id = ? AND episode_id = ?
+            ORDER BY revision DESC LIMIT 1
+            """,
+            (life_id, episode_id),
+        ).fetchone()
+        return row is not None and str(row["terminal_status"]) == "OPEN"
+
+    def find_action_impact_for_source_event(
+        self, *, life_id: str, action_id: str, source_event_id: str
+    ) -> ActionImpact | None:
+        """Read the immutable ActionImpact bound to one trigger event."""
+        rows = self._connection.execute(
+            """
+            SELECT payload FROM action_impacts
+            WHERE life_id = ? AND action_id = ?
+            ORDER BY created_at_ms, impact_id
+            """,
+            (life_id, action_id),
+        ).fetchall()
+        for row in rows:
+            impact = _parse_stored_contract(
+                bytes(row["payload"]), ActionImpact, "action impact"
+            )
+            if source_event_id in impact.source_event_ids:
+                return impact
+        return None
 
     def _verify_causal_memory_state(self) -> None:
         tombstones: dict[str, PrivacyDeletionTombstone] = {}

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -485,12 +485,20 @@ class EmbeddedLifeRuntime:
                 binding_factory=None,
             )
             self._state = self._load_state()
+            reflection_recovered = self._reconcile_open_reflection_episodes(active_life_id)
             heartbeat_recovered = self._reconcile_scheduler_heartbeat(active_life_id)
             recovered_inflight = recover_inflight_scheduler_flags(self._state)
             projection_changed = self._reconcile_authoritative_journal(active_life_id)
             classification_changed = self._ensure_memory_classification(active_life_id)
             memory_contract_changed = self._reconcile_memory_contract(active_life_id)
-            if projection_changed or classification_changed or memory_contract_changed or heartbeat_recovered or recovered_inflight:
+            if (
+                projection_changed
+                or classification_changed
+                or memory_contract_changed
+                or heartbeat_recovered
+                or recovered_inflight
+                or reflection_recovered
+            ):
                 self._persist(active_life_id)
             heartbeat_seconds = float(os.environ.get("TIANGONG_LIFE_HEARTBEAT_SECONDS") or 30.0)
             self.scheduler = start_embedded_scheduler(
@@ -2479,6 +2487,156 @@ class EmbeddedLifeRuntime:
 
     _REFLECTION_EPISODE_REGISTRY_CAP = 32
 
+    def _reflection_registry_entry_from_episode_locked(
+        self, *, life_id: str, episode: Any, event_by_id: Mapping[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        """Rehydrate one OPEN episode cache row from authoritative evidence."""
+        if str(getattr(episode, "life_id", "") or "") != life_id:
+            return None
+        if str(getattr(episode, "terminal_status", "") or "") != "OPEN":
+            return None
+        trigger_ids = tuple(getattr(episode, "trigger_event_ids", ()) or ())
+        if not trigger_ids:
+            return None
+        store = self._contract_store()
+        events = event_by_id or {
+            str(event.event_id): event for event in store.load_events(life_id)
+        }
+        trigger_id = str(trigger_ids[0])
+        trigger = events.get(trigger_id)
+        if trigger is None:
+            return None
+        correlation_id = str(getattr(trigger, "correlation_id", "") or "")
+        if ":" not in correlation_id:
+            return None
+        source, ref_id = correlation_id.split(":", 1)
+        source, ref_id = source.strip(), ref_id.strip()
+        if not source or not ref_id:
+            return None
+        try:
+            snapshot = json.loads(str(getattr(episode, "prior_prediction", "") or ""))
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(snapshot, Mapping):
+            return None
+        context_hashes = tuple(getattr(episode, "context_state_hashes", ()) or ())
+        entry: dict[str, Any] = {
+            "source": source,
+            "ref": ref_id,
+            "episode_id": str(getattr(episode, "episode_id", "") or ""),
+            "correlation_id": correlation_id,
+            "predicted_success_milli": int(snapshot.get("predicted_success_milli") or 0),
+            "prediction_snapshot": deepcopy(dict(snapshot)),
+            "context_sha256": str(context_hashes[0] if context_hashes else ""),
+            "action_risk": "A1",
+            "opened_at_ms": int(getattr(episode, "created_at_ms", 0) or 0),
+        }
+        scope = self._scope_state(life_id)
+        if source == "autonomy":
+            task = (self._autonomy_state(life_id).get("tasks") or {}).get(ref_id)
+            if isinstance(task, Mapping):
+                entry["action_risk"] = str(task.get("risk_class") or "A0")
+        elif source == "capability":
+            capability_id = str(
+                getattr(episode, "selected_action_id", "")
+                or snapshot.get("artifact_id")
+                or ""
+            )
+            artifact = (scope.get("capabilities") or {}).get(capability_id)
+            artifact = artifact if isinstance(artifact, Mapping) else {}
+            entry.update({
+                "capability_id": capability_id,
+                "capability_version": str(artifact.get("version") or snapshot.get("version") or ""),
+                "capability_scope": str(artifact.get("title") or getattr(episode, "intention", "") or "能力学习"),
+                "action_risk": str(artifact.get("risk_level") or "A3"),
+            })
+            impact = store.find_action_impact_for_source_event(
+                life_id=life_id,
+                action_id=capability_id,
+                source_event_id=trigger_id,
+            )
+            if impact is not None:
+                entry["action_impact"] = impact.model_dump(mode="json")
+        return entry
+
+    def _resolve_runtime_episode_entry_locked(
+        self, *, life_id: str, source: str, ref_id: str
+    ) -> dict[str, Any] | None:
+        """Resolve OPEN episode from cache, then from the authoritative Store."""
+        scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+        registry = [
+            row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+        ]
+        for row in registry:
+            if (
+                str(row.get("source") or "") == source
+                and str(row.get("ref") or "") == ref_id
+            ):
+                return dict(row)
+        store = self._contract_store()
+        event_by_id = {str(event.event_id): event for event in store.load_events(life_id)}
+        offset = 0
+        while True:
+            batch = store.open_causal_episodes(life_id, limit=256, offset=offset)
+            if not batch:
+                return None
+            for episode in batch:
+                entry = self._reflection_registry_entry_from_episode_locked(
+                    life_id=life_id, episode=episode, event_by_id=event_by_id
+                )
+                if entry is None:
+                    continue
+                if (
+                    str(entry.get("source") or "") == source
+                    and str(entry.get("ref") or "") == ref_id
+                ):
+                    registry.append(entry)
+                    scheduler["open_episodes"] = registry[-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+                    return entry
+            if len(batch) < 256:
+                return None
+            offset += len(batch)
+
+    def _reconcile_open_reflection_episodes(self, life_id: str) -> int:
+        """Abort OPEN episodes orphaned by a previous process before scheduling."""
+        if not self._reflection_chain_enabled():
+            return 0
+        store = self._contract_store()
+        event_by_id = {str(event.event_id): event for event in store.load_events(life_id)}
+        episodes: list[Any] = []
+        offset = 0
+        while True:
+            batch = store.open_causal_episodes(life_id, limit=256, offset=offset)
+            episodes.extend(batch)
+            if len(batch) < 256:
+                break
+            offset += len(batch)
+        recovered = 0
+        for episode in episodes:
+            entry = self._reflection_registry_entry_from_episode_locked(
+                life_id=life_id, episode=episode, event_by_id=event_by_id
+            )
+            if entry is None:
+                self._reflection_journal_failure(life_id, "rehydrate_open", None)
+                continue
+            scheduler = self._scope_state(life_id).setdefault("scheduler", {})
+            registry = [
+                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
+            ]
+            registry.append(entry)
+            scheduler["open_episodes"] = registry[-self._REFLECTION_EPISODE_REGISTRY_CAP:]
+            self._abort_runtime_episode_locked(
+                life_id=life_id,
+                source=str(entry["source"]),
+                ref_id=str(entry["ref"]),
+                reason="restart_recovery",
+            )
+            if not store.is_causal_episode_open(
+                life_id, str(getattr(episode, "episode_id", "") or "")
+            ):
+                recovered += 1
+        return recovered
+
     def _reflection_chain_enabled(self) -> bool:
         """熔断开关：TIANGONG_LIFE_REFLECTION_CHAIN=0 时整条反思链停摆。"""
         return str(os.environ.get("TIANGONG_LIFE_REFLECTION_CHAIN") or "1").strip() != "0"
@@ -2652,19 +2810,11 @@ class EmbeddedLifeRuntime:
             return
         try:
             scheduler = self._scope_state(life_id).setdefault("scheduler", {})
-            registry = [
-                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
-            ]
-            entry = next(
-                (
-                    row for row in registry
-                    if str(row.get("source") or "") == source
-                    and str(row.get("ref") or "") == ref_id
-                ),
-                None,
+            entry = self._resolve_runtime_episode_entry_locked(
+                life_id=life_id, source=source, ref_id=ref_id
             )
             if entry is None:
-                return  # 没有事前落账（链路关闭或 opening 失败），无从收尾
+                return  # Store 中没有事前 OPEN 证据，无法合法收尾
             outcome_event = self._runtime_life_event_locked(
                 life_id=life_id,
                 event_kind=event_kind,
@@ -2699,7 +2849,10 @@ class EmbeddedLifeRuntime:
                 outcome, now_ms=time.time_ns() // 1_000_000
             )
             scheduler["open_episodes"] = [
-                row for row in registry if row is not entry
+                row
+                for row in scheduler.get("open_episodes") or []
+                if isinstance(row, Mapping)
+                and str(row.get("episode_id") or "") != str(entry.get("episode_id") or "")
             ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
             try:
                 self.system.journal.append(
@@ -2825,16 +2978,8 @@ class EmbeddedLifeRuntime:
         try:
             store = self._contract_store()
             scheduler = self._scope_state(life_id).setdefault("scheduler", {})
-            registry = [
-                row for row in scheduler.get("open_episodes") or [] if isinstance(row, Mapping)
-            ]
-            entry = next(
-                (
-                    row for row in registry
-                    if str(row.get("source") or "") == "capability"
-                    and str(row.get("ref") or "") == execution_id
-                ),
-                None,
+            entry = self._resolve_runtime_episode_entry_locked(
+                life_id=life_id, source="capability", ref_id=execution_id
             )
             if entry is None:
                 return None
@@ -2930,7 +3075,10 @@ class EmbeddedLifeRuntime:
                 )
                 rollback_applied = True
             scheduler["open_episodes"] = [
-                row for row in registry if row is not entry
+                row
+                for row in scheduler.get("open_episodes") or []
+                if isinstance(row, Mapping)
+                and str(row.get("episode_id") or "") != str(entry.get("episode_id") or "")
             ][-self._REFLECTION_EPISODE_REGISTRY_CAP:]
             if learned is not None:
                 try:
@@ -3136,8 +3284,8 @@ class EmbeddedLifeRuntime:
         success_limit = self._daily_limit_setting(settings, "llm_daily_budget", 20)
         attempt_limit = self._daily_limit_setting(settings, "llm_daily_attempt_budget", 30)
         if (
-            (success_limit and int(scheduler.get("model_successes") or 0) >= success_limit)
-            or (attempt_limit and int(scheduler.get("model_attempts") or 0) >= attempt_limit)
+            int(scheduler.get("model_successes") or 0) >= success_limit
+            or int(scheduler.get("model_attempts") or 0) >= attempt_limit
         ):
             scheduler["model_skipped"] = int(scheduler.get("model_skipped") or 0) + 1
             scheduler["last_autonomy_decision_at_ms"] = now_ms
@@ -3990,10 +4138,10 @@ class EmbeddedLifeRuntime:
         proactive_success_limit = self._daily_limit_setting(settings, "proactive_llm_daily_budget", 6)
         proactive_attempt_limit = self._daily_limit_setting(settings, "proactive_llm_daily_attempt_budget", 8)
         exhausted = (
-            (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
-            or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
-            or (proactive_success_limit and int(scheduler.get("proactive_model_successes") or 0) >= proactive_success_limit)
-            or (proactive_attempt_limit and int(scheduler.get("proactive_model_attempts") or 0) >= proactive_attempt_limit)
+            int(scheduler.get("model_successes") or 0) >= global_success_limit
+            or int(scheduler.get("model_attempts") or 0) >= global_attempt_limit
+            or int(scheduler.get("proactive_model_successes") or 0) >= proactive_success_limit
+            or int(scheduler.get("proactive_model_attempts") or 0) >= proactive_attempt_limit
         )
         if exhausted:
             scheduler["model_skipped"] = int(scheduler.get("model_skipped") or 0) + 1
@@ -4069,10 +4217,10 @@ class EmbeddedLifeRuntime:
         sub_success_limit = self._daily_limit_setting(settings, str(config["success_key"]), int(config["success_default"]))
         sub_attempt_limit = self._daily_limit_setting(settings, str(config["attempt_key"]), int(config["attempt_default"]))
         return (
-            (global_success_limit and int(scheduler.get("model_successes") or 0) >= global_success_limit)
-            or (global_attempt_limit and int(scheduler.get("model_attempts") or 0) >= global_attempt_limit)
-            or (sub_success_limit and int(scheduler.get(f"{prefix}successes") or 0) >= sub_success_limit)
-            or (sub_attempt_limit and int(scheduler.get(f"{prefix}attempts") or 0) >= sub_attempt_limit)
+            int(scheduler.get("model_successes") or 0) >= global_success_limit
+            or int(scheduler.get("model_attempts") or 0) >= global_attempt_limit
+            or int(scheduler.get(f"{prefix}successes") or 0) >= sub_success_limit
+            or int(scheduler.get(f"{prefix}attempts") or 0) >= sub_attempt_limit
         )
 
     def _reserve_sub_model_call_locked(
@@ -7196,6 +7344,7 @@ class EmbeddedLifeRuntime:
         # （32 条截断即淘汰）。
         rows.sort(
             key=lambda item: (
+                int(bool(item.get("idle"))),
                 -int(item.get("composite_score_milli") or 0),
                 -int(item.get("last_outcome_at_ms") or 0),
                 str(item.get("kind")),
@@ -8046,11 +8195,12 @@ class EmbeddedLifeRuntime:
                     try:
                         decision = self._capability_patch_decider(material)
                         valid_decision = isinstance(decision, Mapping)
-                    except Exception:
+                    except Exception as exc:
                         with self._lock:
                             self._account_sub_model_failure_locked(
                                 self._scope_state(life_id).setdefault("scheduler", {}),
                                 pool="capability_patch",
+                                timeout=isinstance(exc, TimeoutError),
                             )
                         continue
                     if not valid_decision:
@@ -9443,6 +9593,12 @@ class EmbeddedLifeRuntime:
                     limits = {
                         "llm_daily_budget": (0, 1000),
                         "llm_daily_attempt_budget": (0, 2000),
+                        "learning_llm_daily_budget": (0, 1000),
+                        "learning_llm_daily_attempt_budget": (0, 2000),
+                        "self_iteration_llm_daily_budget": (0, 1000),
+                        "self_iteration_llm_daily_attempt_budget": (0, 2000),
+                        "capability_patch_llm_daily_budget": (0, 1000),
+                        "capability_patch_llm_daily_attempt_budget": (0, 2000),
                         "share_min_interval_seconds": (60, 604800),
                         "share_hourly_limit": (0, 60),
                         "share_daily_limit": (0, 1000),

--- a/src/life_service/store.py
+++ b/src/life_service/store.py
@@ -4095,13 +4095,15 @@ class LifeShadowStore:
         )
 
     def open_causal_episodes(
-        self, life_id: str, *, limit: int = 32
+        self, life_id: str, *, limit: int = 32, offset: int = 0
     ) -> tuple[CausalEpisode, ...]:
-        """Episodes whose LATEST revision is still OPEN, oldest first.
+        """Episodes whose latest revision is still OPEN, oldest first.
 
-        Closed episodes keep their OPEN revision-1 rows as history, so a plain
-        terminal_status filter would resurrect closed episodes as orphans.
+        Runtime registries are bounded caches, not authorities. ``offset``
+        allows recovery to page the complete authoritative OPEN set.
         """
+        bounded_limit = max(1, min(int(limit), 256))
+        bounded_offset = max(0, int(offset))
         rows = self._connection.execute(
             """
             SELECT e.payload FROM causal_episodes AS e
@@ -4115,14 +4117,46 @@ class LifeShadowStore:
              AND latest.max_revision = e.revision
             WHERE e.life_id = ? AND e.terminal_status = 'OPEN'
             ORDER BY e.created_at_ms, e.episode_id
-            LIMIT ?
+            LIMIT ? OFFSET ?
             """,
-            (life_id, life_id, max(1, min(int(limit), 256))),
+            (life_id, life_id, bounded_limit, bounded_offset),
         ).fetchall()
         return tuple(
             _parse_stored_contract(bytes(row["payload"]), CausalEpisode, "causal episode")
             for row in rows
         )
+
+    def is_causal_episode_open(self, life_id: str, episode_id: str) -> bool:
+        """Return whether the latest authoritative revision is still OPEN."""
+        row = self._connection.execute(
+            """
+            SELECT terminal_status FROM causal_episodes
+            WHERE life_id = ? AND episode_id = ?
+            ORDER BY revision DESC LIMIT 1
+            """,
+            (life_id, episode_id),
+        ).fetchone()
+        return row is not None and str(row["terminal_status"]) == "OPEN"
+
+    def find_action_impact_for_source_event(
+        self, *, life_id: str, action_id: str, source_event_id: str
+    ) -> ActionImpact | None:
+        """Read the immutable ActionImpact bound to one trigger event."""
+        rows = self._connection.execute(
+            """
+            SELECT payload FROM action_impacts
+            WHERE life_id = ? AND action_id = ?
+            ORDER BY created_at_ms, impact_id
+            """,
+            (life_id, action_id),
+        ).fetchall()
+        for row in rows:
+            impact = _parse_stored_contract(
+                bytes(row["payload"]), ActionImpact, "action impact"
+            )
+            if source_event_id in impact.source_event_ids:
+                return impact
+        return None
 
     def _verify_causal_memory_state(self) -> None:
         tombstones: dict[str, PrivacyDeletionTombstone] = {}

--- a/tests/test_life_qc_regressions_20260821.py
+++ b/tests/test_life_qc_regressions_20260821.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from life_service.embedded_runtime import EmbeddedLifeRuntime
+from life_service.episode_builder import build_prediction
+
+
+def runtime(root: Path) -> EmbeddedLifeRuntime:
+    life = EmbeddedLifeRuntime(
+        data_root=root / "life-data",
+        runtime_root=root / "runtime",
+        mode="embedded",
+    )
+    life.scheduler.stop(timeout_seconds=2)
+    return life
+
+
+def test_zero_sub_budget_is_exhausted_before_first_call() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            scope = life._scope_state()
+            scheduler = scope["scheduler"]
+            settings = scope["settings"]
+            settings["llm_daily_budget"] = 0
+            settings["llm_daily_attempt_budget"] = 0
+            settings["learning_llm_daily_budget"] = 0
+            settings["learning_llm_daily_attempt_budget"] = 0
+            assert life._sub_model_budget_exhausted(
+                scheduler, settings=settings, pool="learning"
+            ) is True
+            assert life._reserve_sub_model_call_locked(
+                scheduler=scheduler, settings=settings, pool="learning"
+            ) is False
+        finally:
+            life.close()
+
+
+def test_evicted_open_episode_closes_from_store_ssot() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            life_id = str(life._active()["life_id"])
+            with life._lock:
+                for index in range(33):
+                    life._open_runtime_episode_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=f"task_qc_{index:02d}",
+                        event_kind="autonomy.task.attempt.started",
+                        intention=f"QC task {index}",
+                        context_sha256=(f"{index + 1:064x}"[-64:]),
+                        prediction=build_prediction(
+                            basis_inputs={"source": "autonomy", "task_id": f"task_qc_{index:02d}"}
+                        ),
+                        action_risk="A0",
+                    )
+            registry = life._scope_state(life_id)["scheduler"]["open_episodes"]
+            assert len(registry) == 32
+            assert all(row["ref"] != "task_qc_00" for row in registry)
+            assert len(life._contract_store().open_causal_episodes(life_id, limit=64)) == 33
+            with life._lock:
+                life._abort_runtime_episode_locked(
+                    life_id=life_id,
+                    source="autonomy",
+                    ref_id="task_qc_00",
+                    reason="qc_eviction_recovery",
+                )
+            opens = life._contract_store().open_causal_episodes(life_id, limit=64)
+            assert len(opens) == 32
+            assert all(episode.episode_id for episode in opens)
+        finally:
+            life.close()
+
+
+def test_registry_loss_reconciles_all_open_episodes_from_store() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            life_id = str(life._active()["life_id"])
+            with life._lock:
+                for index in range(3):
+                    life._open_runtime_episode_locked(
+                        life_id=life_id,
+                        source="autonomy",
+                        ref_id=f"task_restart_{index}",
+                        event_kind="autonomy.task.attempt.started",
+                        intention=f"restart task {index}",
+                        context_sha256=(f"{index + 10:064x}"[-64:]),
+                        prediction=build_prediction(
+                            basis_inputs={"source": "autonomy", "task_id": f"task_restart_{index}"}
+                        ),
+                        action_risk="A0",
+                    )
+                life._scope_state(life_id)["scheduler"]["open_episodes"] = []
+                recovered = life._reconcile_open_reflection_episodes(life_id)
+            assert recovered == 3
+            assert life._contract_store().open_causal_episodes(life_id, limit=64) == ()
+            cards = life._contract_store().list_reflection_cards(life_id, limit=10)
+            assert len(cards) == 3
+            assert all("restart_recovery" in card.observed_outcome for card in cards)
+        finally:
+            life.close()
+
+
+def test_idle_sort_is_explicit_before_composite_score() -> None:
+    source = (Path(__file__).resolve().parents[1] / "src/life_service/embedded_runtime.py").read_text(encoding="utf-8")
+    sort_block = source[source.index("        rows.sort(\n            key=lambda item: (\n", source.index("def _capability_overlay_payload")):]
+    sort_block = sort_block[:800]
+    assert sort_block.index('int(bool(item.get("idle")))') < sort_block.index('composite_score_milli')
+
+
+def test_capability_patch_timeout_is_accounted_as_timeout() -> None:
+    source = (Path(__file__).resolve().parents[1] / "src/life_service/embedded_runtime.py").read_text(encoding="utf-8")
+    start = source.index("decision = self._capability_patch_decider(material)")
+    block = source[start:start + 900]
+    assert "except Exception as exc:" in block
+    assert "timeout=isinstance(exc, TimeoutError)" in block
+
+
+
+def test_reconcile_does_not_count_failed_abort_as_recovered() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        life = runtime(Path(temporary))
+        try:
+            life_id = str(life._active()["life_id"])
+            with life._lock:
+                life._open_runtime_episode_locked(
+                    life_id=life_id,
+                    source="autonomy",
+                    ref_id="task_failed_recovery_metric",
+                    event_kind="autonomy.task.attempt.started",
+                    intention="verify exact recovery accounting",
+                    context_sha256="a" * 64,
+                    prediction=build_prediction(
+                        basis_inputs={
+                            "source": "autonomy",
+                            "task_id": "task_failed_recovery_metric",
+                        }
+                    ),
+                    action_risk="A0",
+                )
+                life._scope_state(life_id)["scheduler"]["open_episodes"] = []
+                original_abort = life._abort_runtime_episode_locked
+                life._abort_runtime_episode_locked = lambda **_kwargs: None
+                try:
+                    recovered = life._reconcile_open_reflection_episodes(life_id)
+                finally:
+                    life._abort_runtime_episode_locked = original_abort
+            assert recovered == 0
+            opens = life._contract_store().open_causal_episodes(life_id, limit=8)
+            assert len(opens) == 1
+            assert life._contract_store().is_causal_episode_open(
+                life_id, opens[0].episode_id
+            ) is True
+        finally:
+            life.close()

--- a/tests/test_model_credential_identity_contract.py
+++ b/tests/test_model_credential_identity_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+V3_DIR = ROOT / "app" / "backend" / "tiangong-backend" / "v3"
+PACKAGE_NAME = "tiangong_backend_v3_credential_contract_test"
+
+
+def _load_peizhi(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    for name in tuple(sys.modules):
+        if name == PACKAGE_NAME or name.startswith(PACKAGE_NAME + "."):
+            sys.modules.pop(name, None)
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(V3_DIR)]
+    sys.modules[PACKAGE_NAME] = package
+    module = importlib.import_module(f"{PACKAGE_NAME}.peizhi")
+    monkeypatch.setattr(module, "API_PEIZHI_LUJING", tmp_path / "api_keys.json")
+    return module
+
+
+ALL_MODEL_ENV_KEYS = (
+    "TIANGONG_DEEPSEEK_API_KEY", "TIANGONG_DEEPSEEK_V4_API_KEY", "DEEPSEEK_API_KEY",
+    "TIANGONG_OPENAI_API_KEY", "TIANGONG_GPT_5_6_API_KEY", "OPENAI_API_KEY",
+    "TIANGONG_ZHIPU_API_KEY", "TIANGONG_GLM_5_2_API_KEY", "ZAI_API_KEY",
+    "ZHIPUAI_API_KEY", "ZHIPU_API_KEY", "TIANGONG_MINIMAX_API_KEY",
+    "TIANGONG_MINIMAX_M3_API_KEY", "MINIMAX_API_KEY", "TIANGONG_MIMO_API_KEY",
+    "MIMO_API_KEY", "TIANGONG_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY",
+    "TIANGONG_GOOGLE_API_KEY", "GOOGLE_API_KEY",
+)
+
+
+def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ALL_MODEL_ENV_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("identity", "base_url", "env_name"),
+    (
+        ("deepseek", "https://api.deepseek.com/v1", "TIANGONG_DEEPSEEK_API_KEY"),
+        ("openai", "https://api.openai.com/v1", "TIANGONG_OPENAI_API_KEY"),
+        ("zhipu", "https://open.bigmodel.cn/api/paas/v4", "TIANGONG_ZHIPU_API_KEY"),
+        ("minimax", "https://api.minimaxi.com/v1", "TIANGONG_MINIMAX_API_KEY"),
+        ("mimo", "https://api.xiaomimimo.com/v1", "TIANGONG_MIMO_API_KEY"),
+        ("anthropic", "https://api.anthropic.com", "TIANGONG_ANTHROPIC_API_KEY"),
+        ("google", "https://generativelanguage.googleapis.com/v1beta", "TIANGONG_GOOGLE_API_KEY"),
+    ),
+)
+def test_official_provider_identity_env_round_trips(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, identity: str, base_url: str, env_name: str
+) -> None:
+    peizhi = _load_peizhi(monkeypatch, tmp_path)
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv(env_name, f"identity-key:{identity}")
+    assert peizhi.duqu_endpoint_api_miyao(identity, base_url) == f"identity-key:{identity}"
+    assert peizhi.provider_identity_env_names(identity) == (env_name,)
+
+
+@pytest.mark.parametrize(
+    ("family", "identity_env"),
+    (
+        ("deepseek_v4", "TIANGONG_DEEPSEEK_API_KEY"),
+        ("gpt_5_6", "TIANGONG_OPENAI_API_KEY"),
+        ("glm_5_2", "TIANGONG_ZHIPU_API_KEY"),
+        ("minimax_m3", "TIANGONG_MINIMAX_API_KEY"),
+    ),
+)
+def test_legacy_family_callers_can_read_new_identity_slot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, family: str, identity_env: str
+) -> None:
+    peizhi = _load_peizhi(monkeypatch, tmp_path)
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv(identity_env, "new-identity-key")
+    assert peizhi.duqu_api_miyao(family) == "new-identity-key"
+
+
+def test_identity_slot_precedes_legacy_family_slot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    peizhi = _load_peizhi(monkeypatch, tmp_path)
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("TIANGONG_DEEPSEEK_API_KEY", "identity-key")
+    monkeypatch.setenv("TIANGONG_DEEPSEEK_V4_API_KEY", "legacy-family-key")
+    assert peizhi.duqu_endpoint_api_miyao("deepseek", "https://api.deepseek.com/v1") == "identity-key"
+
+
+def test_legacy_family_slot_still_reads_when_identity_slot_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    peizhi = _load_peizhi(monkeypatch, tmp_path)
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("TIANGONG_DEEPSEEK_V4_API_KEY", "legacy-family-key")
+    assert peizhi.duqu_endpoint_api_miyao("deepseek", "https://api.deepseek.com/v1") == "legacy-family-key"
+
+
+def test_custom_endpoint_never_inherits_official_provider_identity_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    peizhi = _load_peizhi(monkeypatch, tmp_path)
+    _clear_model_env(monkeypatch)
+    custom_url = "https://models.example.com/v1"
+    monkeypatch.setenv("TIANGONG_DEEPSEEK_API_KEY", "must-not-leak")
+    assert peizhi.duqu_endpoint_api_miyao("deepseek", custom_url) is None
+    scope = peizhi.custom_scope_id(custom_url)
+    endpoint_env = f"TIANGONG_{scope.upper().replace('-', '_')}_API_KEY"
+    monkeypatch.setenv(endpoint_env, "endpoint-only-key")
+    assert peizhi.duqu_endpoint_api_miyao("deepseek", custom_url) == "endpoint-only-key"
+
+
+def test_electron_writer_and_python_reader_share_identity_namespace() -> None:
+    electron = (ROOT / "app" / "main.js").read_text(encoding="utf-8")
+    assert 'function providerApiKeyEnvName(provider)' in electron
+    assert 'return `TIANGONG_${String(provider || "").toUpperCase().replace(/-/g, "_")}_API_KEY`;' in electron


### PR DESCRIPTION
## 修复范围

本 PR 已最终收口为 `main@9a667790...` 之上的单一干净提交 `b63bc005...`，不包含任何临时 CI/Runner/修复脚本历史。

- P1：`llm_daily_budget=0` / 子池 budget=0 真正按硬禁用处理，并补齐 learning/self_iteration/capability_patch 设置范围校验。
- P1：Reflection OPEN CausalEpisode 以现有 `LifeShadowStore` 为唯一 SSoT；`scheduler.open_episodes` 仅为 bounded cache。支持 cache miss、>32 OPEN、进程重启 orphan 的 Store 重建与 ABORTED 闭环；不新增 Store/Runtime/Gateway/schema。
- P2：Reflection recovery 成功计数改为以 Episode 最新权威 revision 为准，失败恢复不会误报成功。
- P2：capability patch `TimeoutError` 同时进入 failure + timeout 记账。
- P2：idle ability 成为 top-32 context 排序显式维度，避免高 proficiency 长期闲置能力永久占位。
- P1：P18.1 credential address 统一到 persisted `provider_identity` / endpoint scope；optimization family 不再决定新凭据寻址。旧 family/vendor env 保留只读兼容，custom endpoint 继续使用 origin-hash 独立槽位。

## 已完成验证

隔离验证 Runner 使用 CPython 3.14.7：
- Life / Reflection / Budget / Credential / P17 M4 / P17.1 联合专项：65 passed，0 failed。
- `scripts/sync-generated-sources.py --write` 已执行，权威源码与 runtime314 mirror 同步。
- 多角色代码审核发现的 recovery 计数问题已经追加修复并回归通过。

## 最终合入门槛

以当前最终 head `b63bc005...` 的正常 Architecture Gate 为准：Ubuntu + Windows full regression、source-authority、P14 validation 全绿后合入 main。