### PR TITLE
fix(P0): 安全批次一——读损坏 fail-closed、回调强制签名防重放、Endpoint 连接钉扎

### DIFF
--- a/app/backend/tiangong-backend/v3/duihua_qiaojie.py
+++ b/app/backend/tiangong-backend/v3/duihua_qiaojie.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 import json
+import shutil
 import hashlib
 import hmac
 import os
@@ -3636,12 +3637,34 @@ def _save_llm_settings(payload: dict) -> dict:
         reasoning_mode = "off" if capability.known_model else ""
 
     API_PEIZHI_LUJING.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        data = json.loads(API_PEIZHI_LUJING.read_text(encoding="utf-8-sig")) if API_PEIZHI_LUJING.exists() else {}
+    # P0 fail-closed：已存在的配置文件不可读/损坏时拒绝保存并隔离副本。
+    # 旧行为（读失败当 {} 继续整体重写）会把其他 provider 的凭证与端点
+    # 配置无声清空——一次磁盘抖动即造成不可逆数据丢失。
+    data: dict = {}
+    if API_PEIZHI_LUJING.exists():
+        try:
+            data = json.loads(API_PEIZHI_LUJING.read_text(encoding="utf-8-sig"))
+        except Exception:
+            stamp = time.strftime("%Y%m%d-%H%M%S")
+            quarantine = API_PEIZHI_LUJING.with_name(f"api_keys.corrupt-{stamp}.json")
+            try:
+                shutil.copyfile(API_PEIZHI_LUJING, quarantine)
+            except Exception:
+                quarantine = None
+            return {
+                "ok": False,
+                "error": "config_file_unreadable_refused_save",
+                "error_code": "config_file_unreadable",
+                "quarantine": str(quarantine) if quarantine else "",
+                "hint": "api_keys.json 已损坏，本次保存被拒绝（防止清空全部配置）；已保留隔离副本供修复。",
+            }
         if not isinstance(data, dict):
-            data = {}
-    except Exception:
-        data = {}
+            return {
+                "ok": False,
+                "error": "config_file_invalid_refused_save",
+                "error_code": "config_file_invalid",
+                "hint": "api_keys.json 结构异常（非 JSON 对象），本次保存被拒绝。",
+            }
 
     data["_default_provider"] = identity_provider
     data["_model_service"] = service_preset

--- a/app/backend/tiangong-backend/v3/gateway_links.py
+++ b/app/backend/tiangong-backend/v3/gateway_links.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import ipaddress
 import json
 import mimetypes
 import os
@@ -2258,6 +2259,45 @@ class _WechatHTTPServer(ThreadingHTTPServer):
     allow_reuse_address = True
 
 
+# P0 防重放：timestamp 新鲜性 + nonce 窗口内唯一（加密与明文消息共用）。
+_WECHAT_REPLAY_WINDOW_SECONDS = 600
+_wechat_nonce_seen: dict[str, float] = {}
+_wechat_nonce_lock = threading.Lock()
+
+
+def _wechat_replay_guard(timestamp: Any, nonce: Any) -> str | None:
+    """校验回调时间戳与 nonce；返回拒绝原因，None 表示通过。"""
+    try:
+        ts = int(str(timestamp or "").strip())
+    except (TypeError, ValueError):
+        return "invalid_timestamp"
+    now = time.time()
+    if abs(now - ts) > _WECHAT_REPLAY_WINDOW_SECONDS:
+        return "stale_timestamp"
+    nonce_value = str(nonce or "").strip()
+    if not nonce_value:
+        return "missing_nonce"
+    key = f"{ts}:{nonce_value}"
+    with _wechat_nonce_lock:
+        cutoff = now - _WECHAT_REPLAY_WINDOW_SECONDS * 2
+        for stale in [k for k, seen_at in _wechat_nonce_seen.items() if seen_at < cutoff]:
+            _wechat_nonce_seen.pop(stale, None)
+        if key in _wechat_nonce_seen:
+            return "replayed_nonce"
+        _wechat_nonce_seen[key] = now
+    return None
+
+
+def _is_loopback_host(host: str) -> bool:
+    value = str(host or "").strip().lower()
+    if value in {"localhost", "::1"} or value.startswith("127."):
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
 class _WeChatCallbackHandler(BaseHTTPRequestHandler):
     manager: "GatewayLinkManager"
 
@@ -2315,7 +2355,7 @@ class _WeChatCallbackHandler(BaseHTTPRequestHandler):
             self._send_text(echostr)
         except Exception as exc:
             self.manager._set_status("wechat_callback", "error", error=str(exc))
-            self._send_text(f"error:{exc}", 500)
+            self._send_text("internal_error", 500)
 
     def do_POST(self):
         parsed_url = urlparse(self.path)
@@ -2342,8 +2382,24 @@ class _WeChatCallbackHandler(BaseHTTPRequestHandler):
                     self._send_text("invalid_receive_id", 403)
                     return
                 xml_data = _xml_to_dict(xml_text)
-            elif query.get("signature") and _sha1_sorted(token, query.get("timestamp", ""), query.get("nonce", "")) != query.get("signature"):
-                self._send_text("invalid_signature", 403)
+            else:
+                # P0：明文回调与加密回调同一强度——签名必须存在且有效。
+                # 旧行为只在"签名存在但错误"时拒绝，无签名明文 POST 可
+                # 直接触发 AI 调度（无凭证外呼面）。
+                if not token:
+                    self._send_text("callback_token_unconfigured", 403)
+                    return
+                signature = str(query.get("signature") or "")
+                if not signature:
+                    self._send_text("missing_signature", 403)
+                    return
+                if _sha1_sorted(token, query.get("timestamp", ""), query.get("nonce", "")) != signature:
+                    self._send_text("invalid_signature", 403)
+                    return
+            # P0 防重放：签名有效 ≠ 本次投递新鲜；timestamp/nonce 双查。
+            replay_reason = _wechat_replay_guard(query.get("timestamp", ""), query.get("nonce", ""))
+            if replay_reason:
+                self._send_text(f"replay_rejected:{replay_reason}", 403)
                 return
 
             text = _extract_wechat_text(xml_data)
@@ -2400,8 +2456,9 @@ class _WeChatCallbackHandler(BaseHTTPRequestHandler):
                     )
             self._send_text("success")
         except Exception as exc:
+            # 细节只进内部状态，不回显给请求方（避免实现泄露）。
             self.manager._set_status("wechat_callback", "error", error=str(exc))
-            self._send_text(f"error:{exc}", 500)
+            self._send_text("internal_error", 500)
 
     def log_message(self, *args):
         pass
@@ -4003,9 +4060,27 @@ class GatewayLinkManager:
         }
 
     def _start_wechat_callback(self, callback: dict[str, Any]):
-        host = str(callback.get("host") or "127.0.0.1")
+        host = str(callback.get("host") or "127.0.0.1").strip() or "127.0.0.1"
         port = int(callback.get("port") or 7188)
         path = str(callback.get("path") or "/wechat/callback")
+
+        # P0 监听边界：默认仅回环。回调面有完整的签名+防重放，但把监听
+        # 暴露到外网仍是放大面——需要用户显式开启（allow_external_listener
+        # 或环境变量），拒绝静默扩大攻击面。
+        allow_external = bool(callback.get("allow_external_listener")) or str(
+            os.environ.get("TIANGONG_ALLOW_EXTERNAL_CALLBACK") or ""
+        ).lower() in {"1", "true", "yes", "on"}
+        if not _is_loopback_host(host) and not allow_external:
+            self._set_status(
+                "wechat_callback",
+                "error",
+                error="external_listener_forbidden",
+                host=host,
+                port=port,
+                path=path,
+                hint="非回环监听需在回调设置中显式 allow_external_listener=true（并确保 token/加密配置完整）",
+            )
+            return
 
         manager = self
 

--- a/app/backend/tiangong-backend/v3/jineng/model_transport_executor.py
+++ b/app/backend/tiangong-backend/v3/jineng/model_transport_executor.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import time
 from typing import Any, Callable, Mapping
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
-from ..endpoint_security import validate_model_endpoint
+from ..endpoint_security import EndpointBinding, validate_model_endpoint
 from ..model_endpoint import ModelEndpointConfig
 from ..model_protocol_contract import ProviderTurnEnvelope
 from .model_transport_contract import StreamState
@@ -52,6 +53,33 @@ def _response_preview(response: Any) -> str:
             return ""
 
 
+def _pinned_request(url: str, binding: EndpointBinding) -> tuple[str, dict[str, str], str]:
+    """把请求钉扎到已验证 IP：连接层用 IP，Host 头与 TLS SNI 仍用原域名。
+
+    安全性质：validate_model_endpoint 解析并拒绝过私网/回环地址，本次连接
+    固定到该已验证 IP——校验与真实连接成为同一事实，DNS rebinding 在
+    "校验解析"与"客户端二次解析"之间的 TOCTOU 窗口被消除。证书校验以
+    SNI 域名为准，不受 IP 直连影响。
+    """
+    ips = tuple(binding.resolved_ips or ())
+    if not ips:
+        raise TransportExecutionError("endpoint_pinning_no_validated_ip", str(url))
+    ip = str(ips[0]).strip()
+    parts = urlsplit(str(url))
+    hostname = (parts.hostname or "").lower()
+    if not hostname:
+        raise TransportExecutionError("endpoint_pinning_url_invalid", str(url))
+    scheme = parts.scheme.lower() or "https"
+    port = parts.port
+    default_port = (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
+    netloc = f"[{ip}]" if ":" in ip else ip
+    if port is not None and not default_port:
+        netloc = f"{netloc}:{port}"
+    pinned_url = urlunsplit((scheme, netloc, parts.path or "/", parts.query, ""))
+    host_header = hostname if port is None or default_port else f"{hostname}:{port}"
+    return pinned_url, {"Host": host_header}, hostname
+
+
 def execute_streaming_turn(
     *,
     client: httpx.Client,
@@ -83,10 +111,21 @@ def execute_streaming_turn(
             )
         started = time.perf_counter()
         try:
-            # Revalidate immediately before credential-bearing network release.
-            validate_model_endpoint(endpoint.provider_identity, endpoint.base_url, resolve_dns=True)
+            # Revalidate immediately before credential-bearing network release,
+            # then pin this attempt's connection to the validated IP.  Every
+            # retry re-resolves and re-pins; the credential and body only ever
+            # travel to an address that passed the private/loopback checks.
+            binding = validate_model_endpoint(endpoint.provider_identity, endpoint.base_url, resolve_dns=True)
+            pinned_url, host_headers, sni_hostname = _pinned_request(request.url, binding)
             state = StreamState()
-            with client.stream("POST", request.url, json=request.payload, headers=request.headers) as response:
+            pinned_http_request = client.build_request(
+                "POST",
+                pinned_url,
+                json=request.payload,
+                headers={**request.headers, **host_headers},
+                extensions={"sni_hostname": sni_hostname},
+            )
+            with client.send(pinned_http_request, stream=True) as response:
                 status = int(response.status_code)
                 if status in transient and attempt < retry_limit:
                     last_reason = f"HTTP {status}"

--- a/app/backend/tiangong-backend/v3/knowledge_store.py
+++ b/app/backend/tiangong-backend/v3/knowledge_store.py
@@ -210,20 +210,84 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+class KnowledgeIndexCorrupted(RuntimeError):
+    """index.json 已存在但不可读/不可解析——fail-closed，禁止当空索引使用。"""
+
+
+def _fresh_index() -> dict[str, Any]:
+    return {"schema": "tiangong.v3.knowledge.index.v1", "updated_at": "", "documents": {}, "last_document_id": ""}
+
+
 def _load_index(root: Path) -> dict[str, Any]:
     path = _index_path(root)
     if not path.exists():
-        return {"schema": "tiangong.v3.knowledge.index.v1", "updated_at": "", "documents": {}, "last_document_id": ""}
+        return _fresh_index()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            data.setdefault("schema", "tiangong.v3.knowledge.index.v1")
-            data.setdefault("documents", {})
-            data.setdefault("last_document_id", "")
-            return data
+    except Exception as exc:
+        raise KnowledgeIndexCorrupted(f"index_unreadable:{type(exc).__name__}") from exc
+    if not isinstance(data, dict):
+        raise KnowledgeIndexCorrupted("index_not_a_json_object")
+    data.setdefault("schema", "tiangong.v3.knowledge.index.v1")
+    data.setdefault("documents", {})
+    data.setdefault("last_document_id", "")
+    return data
+
+
+def _quarantine_corrupt_index(root: Path) -> Path | None:
+    """把损坏的索引移出原路径，保留诊断证据；原路径留给重建结果。"""
+    path = _index_path(root)
+    if not path.exists():
+        return None
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    target = root / f"index.corrupt-{stamp}.json"
+    try:
+        path.replace(target)
+        return target
     except Exception:
-        pass
-    return {"schema": "tiangong.v3.knowledge.index.v1", "updated_at": "", "documents": {}, "last_document_id": ""}
+        return None
+
+
+def _rebuild_index_from_contexts(root: Path) -> dict[str, Any]:
+    """显式重建：contexts/ 目录的每文档 JSON 才是权威，索引只是投影。"""
+    index = _fresh_index()
+    documents = index["documents"]
+    latest_id, latest_at = "", ""
+    for ctx_path in sorted(_contexts_dir(root).glob("*.json")):
+        try:
+            ctx = json.loads(ctx_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(ctx, dict) or not ctx.get("document_id"):
+            continue
+        document_id = str(ctx["document_id"])
+        documents[document_id] = _public_doc(ctx)
+        at = str(ctx.get("updated_at") or ctx.get("created_at") or "")
+        if at >= latest_at:
+            latest_at, latest_id = at, document_id
+    index["last_document_id"] = latest_id
+    return index
+
+
+def _load_index_recovered(root: Path) -> dict[str, Any]:
+    """所有入口的统一读索引路径：损坏即隔离 + 从 contexts 显式重建。
+
+    绝不把"已存在但读不出"静默降级为空索引——那会让下一次保存把全部
+    知识登记无声蒸发（P0 fail-closed 修复）。
+    """
+    try:
+        return _load_index(root)
+    except KnowledgeIndexCorrupted as exc:
+        quarantine = _quarantine_corrupt_index(root)
+        rebuilt = _rebuild_index_from_contexts(root)
+        _save_index(root, rebuilt)
+        try:
+            recovery_log = root / "index.recovery.log"
+            with recovery_log.open("a", encoding="utf-8") as fh:
+                fh.write(f"{_now_iso()} recovered from {exc}; quarantine={quarantine}; documents={len(rebuilt['documents'])}\n")
+        except Exception:
+            pass
+        return rebuilt
 
 
 def _save_index(root: Path, index: dict[str, Any]) -> None:
@@ -618,7 +682,7 @@ def _import_one(root: Path, path: Path, payload: dict[str, Any] | None = None, *
     if previous and previous.get("created_at"):
         ctx["created_at"] = previous["created_at"]
     _save_context(root, ctx)
-    index = _load_index(root)
+    index = _load_index_recovered(root)
     documents = index.setdefault("documents", {})
     documents[document_id] = _public_doc(ctx)
     index["last_document_id"] = document_id
@@ -664,7 +728,7 @@ def _inline_paths(root: Path, payload: dict[str, Any], *, handoff: bool = False)
 
 def knowledge_list(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     root = knowledge_root(payload)
-    index = _load_index(root)
+    index = _load_index_recovered(root)
     docs: list[dict[str, Any]] = []
     for document_id, entry in (index.get("documents") or {}).items():
         ctx = _load_context(root, str(document_id))
@@ -810,7 +874,7 @@ def search_knowledge(payload: dict[str, Any] | None = None) -> dict[str, Any]:
         return {"ok": False, "error": "missing_query", "cards": []}
     limit = max(1, min(int(payload.get("top_k") or payload.get("limit") or 8), 30))
     per_doc = max(1, min(int(payload.get("per_doc") or 3), 10))
-    index = _load_index(root)
+    index = _load_index_recovered(root)
     cards: list[dict[str, Any]] = []
     for document_id in (index.get("documents") or {}).keys():
         ctx = _load_context(root, str(document_id))
@@ -957,7 +1021,7 @@ def remove_knowledge(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     document_id = _safe_text(payload.get("document_id") or payload.get("documentId"), 120)
     if not document_id:
         return {"ok": False, "error": "missing_document_id"}
-    index = _load_index(root)
+    index = _load_index_recovered(root)
     docs = dict(index.get("documents") or {})
     entry = docs.get(document_id) if isinstance(docs.get(document_id), dict) else {}
     stored_path = Path(str(entry.get("stored_path") or "")).resolve(strict=False) if entry.get("stored_path") else None

--- a/tests/test_p0_safety_batch1.py
+++ b/tests/test_p0_safety_batch1.py
@@ -1,0 +1,351 @@
+"""P0 安全批次一（2026-08-22）故障注入测试。
+
+覆盖三项修复：
+1. knowledge index 读损坏 → fail-closed 隔离 + 从 contexts 显式重建
+2. api_keys.json 读损坏 → 拒绝保存（不再空对象覆盖）
+3. 微信 callback 无签名直通 → 强制签名 + 防重放 + 监听边界
+4. Endpoint DNS 连接钉扎 → 校验与连接同一事实
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from v3 import knowledge_store as ks
+from v3 import peizhi
+from v3.duihua_qiaojie import _save_llm_settings
+from v3.endpoint_security import EndpointBinding
+from v3.gateway_links import (
+    _WechatHTTPServer,
+    _WeChatCallbackHandler,
+    _is_loopback_host,
+    _sha1_sorted,
+    _wechat_replay_guard,
+)
+from v3.jineng.model_transport_executor import (
+    TransportExecutionError,
+    _pinned_request,
+    execute_streaming_turn,
+)
+
+
+# ---------- 1. knowledge index fail-closed ----------
+
+
+def _seed_knowledge(root: Path, document_id: str, text: str) -> None:
+    ctx = {
+        "document_id": document_id,
+        "created_at": "2026-08-22T10:00:00",
+        "updated_at": "2026-08-22T10:00:00",
+        "card": {"title": document_id, "summary": text[:40]},
+        "text": text,
+    }
+    (root / "contexts").mkdir(parents=True, exist_ok=True)
+    (root / "contexts" / f"{document_id}.json").write_text(
+        json.dumps(ctx, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def test_corrupt_index_is_quarantined_and_rebuilt_from_contexts(tmp_path: Path) -> None:
+    root = tmp_path / "knowledge"
+    root.mkdir(parents=True)
+    _seed_knowledge(root, "doc_alpha", "知识库正文 alpha：" + "长" * 100)
+    # 故障注入：已有的 index.json 被写成半截 JSON（模拟磁盘抖动/掉电半写）。
+    (root / "index.json").write_text('{"schema": "tiangong.v3.knowledge.index.v1", "docu', encoding="utf-8")
+    # 旧行为：这里静默返回空索引，下一次保存把登记无声蒸发。
+    recovered = ks.knowledge_list({"knowledgeRoot": str(root)})
+    assert recovered["count"] == 1
+    assert recovered["documents"][0]["document_id"] == "doc_alpha"
+    # 损坏件被隔离保留，索引被重建为合法 JSON。
+    quarantines = list(root.glob("index.corrupt-*.json"))
+    assert len(quarantines) == 1
+    assert "docu" in quarantines[0].read_text(encoding="utf-8")
+    rebuilt = json.loads((root / "index.json").read_text(encoding="utf-8"))
+    assert "doc_alpha" in rebuilt["documents"]
+    assert (root / "index.recovery.log").exists()
+
+
+def test_load_index_raises_on_corruption_instead_of_empty(tmp_path: Path) -> None:
+    root = tmp_path / "knowledge"
+    root.mkdir(parents=True)
+    (root / "index.json").write_text("not json at all", encoding="utf-8")
+    with pytest.raises(ks.KnowledgeIndexCorrupted):
+        ks._load_index(root)
+    # 非 JSON 对象同样拒绝。
+    (root / "index.json").write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ks.KnowledgeIndexCorrupted):
+        ks._load_index(root)
+
+
+# ---------- 2. api_keys.json 读损坏拒绝保存 ----------
+
+
+def _valid_model_payload() -> dict:
+    return {
+        "provider_identity": "custom",
+        "service_preset": "custom",
+        "protocol_family": "openai_chat_completions",
+        "base_url": "https://api.example.test/v1",
+        "model_name": "test-model",
+    }
+
+
+def test_save_llm_settings_refuses_when_config_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = tmp_path / "api_keys.json"
+    config.write_text('{"_default_provider": "openai", "_custom_endp', encoding="utf-8")
+    monkeypatch.setattr(peizhi, "API_PEIZHI_LUJING", config)
+    result = _save_llm_settings(_valid_model_payload())
+    assert result["ok"] is False
+    assert result["error"] == "config_file_unreadable_refused_save"
+    # 原文件保持原样（未被覆盖、未被清空），隔离副本保留证据。
+    assert "openai" in config.read_text(encoding="utf-8")
+    assert len(list(tmp_path.glob("api_keys.corrupt-*.json"))) == 1
+
+
+def test_save_llm_settings_refuses_when_config_not_object(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = tmp_path / "api_keys.json"
+    config.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setattr(peizhi, "API_PEIZHI_LUJING", config)
+    result = _save_llm_settings(_valid_model_payload())
+    assert result["ok"] is False
+    assert result["error"] == "config_file_invalid_refused_save"
+    assert config.read_text(encoding="utf-8") == "[1, 2, 3]"
+
+
+# ---------- 3. 微信 callback 强制签名 + 防重放 + 监听边界 ----------
+
+
+class _FakeManager:
+    """最小回调管理器：记录 dispatch 与状态，不触网。"""
+
+    def __init__(self, settings: dict):
+        self.settings = {"wechat": {"callback": settings}}
+        self.dispatched: list[dict] = []
+        self.statuses: list[tuple] = []
+
+    def dispatch_inbound(self, **kwargs) -> dict:
+        self.dispatched.append(kwargs)
+        return {"ok": True, "reply": "ok"}
+
+    def _set_status(self, channel: str, status: str, **extra) -> None:
+        self.statuses.append((channel, status, extra))
+
+
+def _plain_message_xml(content: str = "你好", from_user: str = "tester") -> str:
+    return (
+        f"<xml><ToUserName><![CDATA[gh_test]]></ToUserName>"
+        f"<FromUserName><![CDATA[{from_user}]]></FromUserName>"
+        f"<Content><![CDATA[{content}]]></Content></xml>"
+    )
+
+
+@pytest.fixture()
+def callback_server(tmp_path: Path):
+    manager = _FakeManager(
+        {
+            "path": "/wechat/callback",
+            "token": "unit-test-token",
+            "sync_reply": True,
+            "auto_reply": False,
+        }
+    )
+
+    class Handler(_WeChatCallbackHandler):
+        pass
+
+    Handler.manager = manager
+    server = _WechatHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}/wechat/callback"
+    try:
+        yield base, manager
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _signed_query(token: str, timestamp: int, nonce: str) -> str:
+    signature = _sha1_sorted(token, str(timestamp), nonce)
+    return f"signature={signature}&timestamp={timestamp}&nonce={nonce}"
+
+
+def test_unsigned_plaintext_post_is_rejected(callback_server) -> None:
+    base, manager = callback_server
+    # 故障注入：无任何签名的明文 POST（旧行为直接进入 dispatch 触发 AI）。
+    response = httpx.post(base, content=_plain_message_xml().encode("utf-8"), timeout=5)
+    assert response.status_code == 403
+    assert "missing_signature" in response.text
+    assert manager.dispatched == []
+
+
+def test_wrong_signature_is_rejected(callback_server) -> None:
+    base, manager = callback_server
+    response = httpx.post(
+        base + "?signature=deadbeef&timestamp=1&nonce=n1",
+        content=_plain_message_xml().encode("utf-8"),
+        timeout=5,
+    )
+    assert response.status_code == 403
+    assert manager.dispatched == []
+
+
+def test_signed_fresh_message_dispatches_then_replay_rejected(callback_server) -> None:
+    base, manager = callback_server
+    now = int(time.time())
+    query = _signed_query("unit-test-token", now, "nonce-once")
+    response = httpx.post(f"{base}?{query}", content=_plain_message_xml().encode("utf-8"), timeout=5)
+    assert response.status_code == 200
+    assert len(manager.dispatched) == 1
+    assert manager.dispatched[0]["text"]
+    # 同一 timestamp+nonce 重放 → 拒绝，不二次触发 AI。
+    replay = httpx.post(f"{base}?{query}", content=_plain_message_xml().encode("utf-8"), timeout=5)
+    assert replay.status_code == 403
+    assert "replayed_nonce" in replay.text
+    assert len(manager.dispatched) == 1
+
+
+def test_stale_timestamp_is_rejected(callback_server) -> None:
+    base, manager = callback_server
+    stale = int(time.time()) - 3600
+    query = _signed_query("unit-test-token", stale, "nonce-stale")
+    response = httpx.post(f"{base}?{query}", content=_plain_message_xml().encode("utf-8"), timeout=5)
+    assert response.status_code == 403
+    assert "stale_timestamp" in response.text
+    assert manager.dispatched == []
+
+
+def test_replay_guard_units() -> None:
+    now = int(time.time())
+    assert _wechat_replay_guard("not-a-number", "n") == "invalid_timestamp"
+    assert _wechat_replay_guard(str(now - 7200), "n") == "stale_timestamp"
+    assert _wechat_replay_guard(str(now), "") == "missing_nonce"
+    assert _wechat_replay_guard(str(now), f"unit-{now}-a") is None
+    assert _wechat_replay_guard(str(now), f"unit-{now}-a") == "replayed_nonce"
+
+
+def test_loopback_boundary_units() -> None:
+    assert _is_loopback_host("127.0.0.1") is True
+    assert _is_loopback_host("localhost") is True
+    assert _is_loopback_host("::1") is True
+    assert _is_loopback_host("0.0.0.0") is False
+    assert _is_loopback_host("192.168.1.10") is False
+    assert _is_loopback_host("example.com") is False
+
+
+# ---------- 4. Endpoint DNS 连接钉扎 ----------
+
+
+def _binding(ips: tuple[str, ...]) -> EndpointBinding:
+    return EndpointBinding(
+        provider_id="custom",
+        base_url="https://api.example.test/v1",
+        origin="https://api.example.test",
+        host="api.example.test",
+        port=443,
+        official=False,
+        custom_scope="endpoint_test",
+        resolved_ips=ips,
+    )
+
+
+def test_pinned_request_pins_connection_keeps_domain_identity() -> None:
+    pinned_url, headers, sni = _pinned_request("https://api.example.test/v1/chat", _binding(("93.184.216.34",)))
+    assert pinned_url == "https://93.184.216.34/v1/chat"
+    assert headers == {"Host": "api.example.test"}
+    assert sni == "api.example.test"
+
+
+def test_pinned_request_handles_ipv6_and_custom_port() -> None:
+    pinned_url, headers, sni = _pinned_request(
+        "https://api.example.test:8443/v1/chat", _binding(("2606:4700::6810:85e5",))
+    )
+    assert pinned_url == "https://[2606:4700::6810:85e5]:8443/v1/chat"
+    assert headers == {"Host": "api.example.test:8443"}
+    assert sni == "api.example.test"
+
+
+def test_pinned_request_fails_closed_without_validated_ip() -> None:
+    with pytest.raises(TransportExecutionError):
+        _pinned_request("https://api.example.test/v1/chat", _binding(()))
+
+
+def test_execute_streaming_turn_sends_to_pinned_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    from v3.jineng import model_transport_executor as executor
+
+    captured: dict = {}
+
+    class _StubResponse:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_lines(self):
+            return iter([])
+
+    class _StubClient:
+        def build_request(self, method, url, **kwargs):
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers")
+            captured["extensions"] = kwargs.get("extensions")
+            captured["payload"] = kwargs.get("json")
+            return object()
+
+        def send(self, request, stream: bool = False):
+            captured["stream"] = stream
+            return _StubResponse()
+
+    class _StubTransport:
+        protocol_family = "stub"
+
+        def build_request(self, endpoint, api_key, payload):
+            from v3.jineng.model_transport_contract import TransportRequest
+
+            return TransportRequest(
+                url="https://api.example.test/v1/chat",
+                headers={"Authorization": "Bearer test-key"},
+                payload=dict(payload),
+                protocol_family="stub",
+            )
+
+        def consume_stream_event(self, state, event):
+            return "", ""
+
+        def finalize_turn(self, endpoint, state):
+            return {"finish_reason": "stop"}
+
+    monkeypatch.setattr(executor, "get_model_transport", lambda family: _StubTransport())
+    monkeypatch.setattr(
+        executor,
+        "validate_model_endpoint",
+        lambda provider, base_url, resolve_dns=True: _binding(("203.0.113.10", "203.0.113.11")),
+    )
+    endpoint = type("E", (), {"provider_identity": "custom", "base_url": "https://api.example.test/v1", "protocol_family": "stub"})()
+    result = executor.execute_streaming_turn(
+        client=_StubClient(),
+        endpoint=endpoint,
+        api_key="test-key",
+        canonical_payload={"model": "m", "messages": []},
+        max_wall_clock_seconds=10,
+    )
+    assert result.http_status == 200
+    # 连接目标是被验证过的 IP，Host/SNI 保持原域名——校验与连接同一事实。
+    assert captured["url"] == "https://203.0.113.10/v1/chat"
+    assert captured["headers"]["Host"] == "api.example.test"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["extensions"] == {"sni_hostname": "api.example.test"}
+    assert captured["stream"] is True

--- a/tests/test_simple_chain_loop_budget.py
+++ b/tests/test_simple_chain_loop_budget.py
@@ -158,7 +158,10 @@ class SimpleChainLoopBudgetTests(unittest.TestCase):
                 yield 'data: {"choices":[{"delta":{"content":"keepalive"}}]}'
 
         class _FakeClient:
-            def stream(self, method, url, **kwargs):
+            def build_request(self, method, url, **kwargs):
+                return object()
+
+            def send(self, request, stream: bool = False):
                 return _FakeResponse()
 
         endpoint = ModelEndpointConfig(
@@ -173,9 +176,22 @@ class SimpleChainLoopBudgetTests(unittest.TestCase):
             optimization_family="deepseek_v4",
             config_fingerprint="deadline-test",
         )
+        from v3.endpoint_security import EndpointBinding
+
+        pinned_binding = EndpointBinding(
+            provider_id="deepseek_v4",
+            base_url="https://api.deepseek.com/v1",
+            origin="https://api.deepseek.com",
+            host="api.deepseek.com",
+            port=443,
+            official=True,
+            custom_scope=None,
+            resolved_ips=("203.0.113.99",),
+        )
         with (
             mock.patch(
-                "v3.jineng.model_transport_executor.validate_model_endpoint"
+                "v3.jineng.model_transport_executor.validate_model_endpoint",
+                return_value=pinned_binding,
             ),
             mock.patch(
                 "v3.jineng.model_transport_executor.time.perf_counter",


### PR DESCRIPTION
按《多视角质检与辩论终审报告 v2》（源码复核修正版）第 0 周第一批 + 硬约束 H1 实施，三项均经源码复核确认：

## 1. 两处"读失败→空白覆盖"fail-closed（不可逆数据丢失）
- `knowledge_store._load_index`：损坏的 index.json 不再静默当空索引；统一入口 `_load_index_recovered` —— 隔离损坏件（`index.corrupt-*.json`）、从 contexts/ 权威文件显式重建、写 `index.recovery.log`
- `duihua_qiaojie._save_llm_settings`：api_keys.json 已存在但不可读/非 JSON 对象时**拒绝保存**并保留隔离副本——杜绝一次磁盘抖动清空全部 provider 凭证与端点配置

## 2. 微信 callback 鉴权闭合（无凭证外呼面）
- 明文 POST 与加密回调同一强度：签名必须存在且有效（旧行为：无签名明文 POST 直接进入 dispatch 触发 AI 调度）；token 未配置一律拒绝
- 防重放：timestamp 新鲜性（±600s）+ nonce 窗口内唯一，加密/明文共用
- 监听边界：默认仅回环；非回环监听需显式 `allow_external_listener` 或 `TIANGONG_ALLOW_EXTERNAL_CALLBACK`
- 异常响应不再回显内部错误文本

## 3. Endpoint DNS 连接钉扎（TOCTOU · 硬约束 H1）
`model_transport_executor`：每次 attempt 先 validate（解析 + 拒绝私网/回环）→ 本次连接**钉扎到已验证 IP**——连接层用 IP、Host 头与 TLS SNI 保持原域名，证书校验以域名为准。校验与真实连接成为同一事实，DNS rebinding 在"校验解析"与"客户端二次解析"之间的窗口被消除；retry 重新验证重新钉扎。

## 测试
- `test_p0_safety_batch1.py`：14 项故障注入（半截 JSON 索引→隔离重建、无签名直通拒绝、签名有效后重放拒绝、陈旧时间戳、钉扎 IPv6/自定义端口/无 IP fail-closed、executor 级钉扎断言）
- `test_simple_chain_loop_budget` 桩随新客户端接口更新（测试目的不变，真实回测通过）
- 受影响模块回归 194 项全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)