### PR TITLE
fix: 四组产品主诉——生命静默失效/跨盘设置/浏览器回退/对话注入

### DIFF
--- a/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
+  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tool_contracts.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tool_contracts.py
@@ -102,11 +102,11 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
     },
     "template.apply": {
-        "target": "optional workspace-relative story/outline output path",
+        "target": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) story/outline output path",
         "args": {
             "template_id": "template id such as executive_ppt",
             "variables": "optional content variables object",
-            "design_output": "optional workspace-relative machine-readable design output .json path",
+            "design_output": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) machine-readable design output .json path",
         },
     },
     "qc.ppt.delivery_check": {
@@ -133,37 +133,37 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["target", "args.skill_id"],
     },
     "file.write": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string, or base64 when binary=true", "binary": "optional boolean", "encoding": "optional string"},
         "any_of": ["args.content", "args.base64"],
     },
     "file.append": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string (required)", "encoding": "optional string"},
         "required": ["args.content"],
     },
     "file.mkdir": {
-        "target": "workspace-relative directory path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) directory path (required)",
         "args": {"exist_ok": "optional boolean"},
     },
     "file.copy": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.move": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.rename": {
-        "target": "workspace-relative source path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
         "args": {"new_name": "new basename only (required)", "overwrite": "optional boolean"},
         "required": ["args.new_name"],
     },
     "code.patch_replace": {
         "aliases": ["file.patch_replace", "file.patch", "code.patch"],
-        "target": "workspace-relative existing file path (required, never a directory)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) existing file path (required, never a directory)",
         "args": {
             "find": "non-empty literal or regex string (required)",
             "replace": "replacement string (optional; empty deletes the match)",
@@ -175,7 +175,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["args.find"],
     },
     "quality.javascript_syntax": {
-        "target": "workspace-relative .js/.mjs/.cjs file or directory (required)",
+        "target": "workspace-relative (or absolute when allowed) .js/.mjs/.cjs file or directory (required)",
         "args": {"recursive": "optional boolean"},
     },
     "git.clone": {
@@ -194,13 +194,13 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "windows_note": "cmd.exe semantics; prefer typed file/code actions",
     },
     "python.run": {
-        "target": "optional workspace-relative existing .py script",
+        "target": "optional workspace-relative (or absolute when allowed) existing .py script",
         "args": {"code": "Python source string required when target is empty", "argv": "optional array", "timeout": "optional positive integer"},
         "any_of": ["target", "args.code"],
         "note": "Use file.write/code.write for file creation; python.run is not a file-writing substitute.",
     },
     "docx.create": {
-        "target": "workspace-relative output .docx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .docx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt source; preferred for long documents",
             "content": "optional inline Markdown/plain text",
@@ -211,7 +211,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.title", "args.sections"],
     },
     "pptx.create": {
-        "target": "workspace-relative output .pptx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .pptx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt slide script; split slides with --- or ##",
             "content": "optional inline slide Markdown",
@@ -229,7 +229,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "args": {"max_chars_per_slide": "optional integer from 200 to 20000"},
     },
     "mindmap.create": {
-        "target": "workspace-relative output .md path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .md path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt indented outline",
             "content": "optional inline indented outline",
@@ -240,7 +240,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.tree"],
     },
     "novel.project.create": {
-        "target": "workspace-relative new or empty novel project directory (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) new or empty novel project directory (required)",
         "args": {"title": "non-empty string", "genre": "non-empty string", "planned_chapters": "full-book count, integer >= ceil(target_words/5000), never a writing checkpoint", "target_words": "integer >= 1000"},
         "required": ["args.title", "args.genre", "args.planned_chapters", "args.target_words"],
     },

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/pro_apps_v34.py
@@ -519,16 +519,29 @@ def _launch_playwright_chromium(playwright: Any) -> Tuple[Any, str, List[str]]:
     configured = str(os.environ.get("TIANGONG_PLAYWRIGHT_EXECUTABLE") or "").strip()
     if configured:
         candidates.append(Path(configured))
+    # 随包分发的浏览器目录（main.js 注入 PLAYWRIGHT_BROWSERS_PATH）。
+    packaged_root = str(os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if packaged_root:
+        packaged = Path(packaged_root)
+        if packaged.is_dir():
+            candidates.extend(sorted(packaged.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
     local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
     if local_app_data:
         cache_root = Path(local_app_data) / "ms-playwright"
         if cache_root.is_dir():
             candidates.extend(sorted(cache_root.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
+        # 每用户安装的 Chrome（Windows 最常见安装形态）此前不在候选里，
+        # 导致"发布包没带浏览器 + Chrome 装在 LOCALAPPDATA"的机器上
+        # browser.* 全部失败（2026-08-22 修复）。
+        candidates.append(Path(local_app_data) / "Google" / "Chrome" / "Application" / "chrome.exe")
     program_files = str(os.environ.get("PROGRAMFILES") or "").strip()
     if program_files:
         candidates.append(Path(program_files) / "Google" / "Chrome" / "Application" / "chrome.exe")
+        # 64 位 Edge 的常规安装位置。
+        candidates.append(Path(program_files) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
     program_files_x86 = str(os.environ.get("PROGRAMFILES(X86)") or "").strip()
     if program_files_x86:
+        candidates.append(Path(program_files_x86) / "Google" / "Chrome" / "Application" / "chrome.exe")
         candidates.append(Path(program_files_x86) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
 
     seen: set[str] = set()

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
+  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tool_contracts.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tool_contracts.py
@@ -102,11 +102,11 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
     },
     "template.apply": {
-        "target": "optional workspace-relative story/outline output path",
+        "target": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) story/outline output path",
         "args": {
             "template_id": "template id such as executive_ppt",
             "variables": "optional content variables object",
-            "design_output": "optional workspace-relative machine-readable design output .json path",
+            "design_output": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) machine-readable design output .json path",
         },
     },
     "qc.ppt.delivery_check": {
@@ -133,37 +133,37 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["target", "args.skill_id"],
     },
     "file.write": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string, or base64 when binary=true", "binary": "optional boolean", "encoding": "optional string"},
         "any_of": ["args.content", "args.base64"],
     },
     "file.append": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string (required)", "encoding": "optional string"},
         "required": ["args.content"],
     },
     "file.mkdir": {
-        "target": "workspace-relative directory path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) directory path (required)",
         "args": {"exist_ok": "optional boolean"},
     },
     "file.copy": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.move": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.rename": {
-        "target": "workspace-relative source path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
         "args": {"new_name": "new basename only (required)", "overwrite": "optional boolean"},
         "required": ["args.new_name"],
     },
     "code.patch_replace": {
         "aliases": ["file.patch_replace", "file.patch", "code.patch"],
-        "target": "workspace-relative existing file path (required, never a directory)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) existing file path (required, never a directory)",
         "args": {
             "find": "non-empty literal or regex string (required)",
             "replace": "replacement string (optional; empty deletes the match)",
@@ -175,7 +175,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["args.find"],
     },
     "quality.javascript_syntax": {
-        "target": "workspace-relative .js/.mjs/.cjs file or directory (required)",
+        "target": "workspace-relative (or absolute when allowed) .js/.mjs/.cjs file or directory (required)",
         "args": {"recursive": "optional boolean"},
     },
     "git.clone": {
@@ -194,13 +194,13 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "windows_note": "cmd.exe semantics; prefer typed file/code actions",
     },
     "python.run": {
-        "target": "optional workspace-relative existing .py script",
+        "target": "optional workspace-relative (or absolute when allowed) existing .py script",
         "args": {"code": "Python source string required when target is empty", "argv": "optional array", "timeout": "optional positive integer"},
         "any_of": ["target", "args.code"],
         "note": "Use file.write/code.write for file creation; python.run is not a file-writing substitute.",
     },
     "docx.create": {
-        "target": "workspace-relative output .docx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .docx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt source; preferred for long documents",
             "content": "optional inline Markdown/plain text",
@@ -211,7 +211,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.title", "args.sections"],
     },
     "pptx.create": {
-        "target": "workspace-relative output .pptx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .pptx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt slide script; split slides with --- or ##",
             "content": "optional inline slide Markdown",
@@ -229,7 +229,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "args": {"max_chars_per_slide": "optional integer from 200 to 20000"},
     },
     "mindmap.create": {
-        "target": "workspace-relative output .md path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .md path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt indented outline",
             "content": "optional inline indented outline",
@@ -240,7 +240,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.tree"],
     },
     "novel.project.create": {
-        "target": "workspace-relative new or empty novel project directory (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) new or empty novel project directory (required)",
         "args": {"title": "non-empty string", "genre": "non-empty string", "planned_chapters": "full-book count, integer >= ceil(target_words/5000), never a writing checkpoint", "target_words": "integer >= 1000"},
         "required": ["args.title", "args.genre", "args.planned_chapters", "args.target_words"],
     },

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
@@ -519,16 +519,29 @@ def _launch_playwright_chromium(playwright: Any) -> Tuple[Any, str, List[str]]:
     configured = str(os.environ.get("TIANGONG_PLAYWRIGHT_EXECUTABLE") or "").strip()
     if configured:
         candidates.append(Path(configured))
+    # 随包分发的浏览器目录（main.js 注入 PLAYWRIGHT_BROWSERS_PATH）。
+    packaged_root = str(os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if packaged_root:
+        packaged = Path(packaged_root)
+        if packaged.is_dir():
+            candidates.extend(sorted(packaged.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
     local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
     if local_app_data:
         cache_root = Path(local_app_data) / "ms-playwright"
         if cache_root.is_dir():
             candidates.extend(sorted(cache_root.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
+        # 每用户安装的 Chrome（Windows 最常见安装形态）此前不在候选里，
+        # 导致"发布包没带浏览器 + Chrome 装在 LOCALAPPDATA"的机器上
+        # browser.* 全部失败（2026-08-22 修复）。
+        candidates.append(Path(local_app_data) / "Google" / "Chrome" / "Application" / "chrome.exe")
     program_files = str(os.environ.get("PROGRAMFILES") or "").strip()
     if program_files:
         candidates.append(Path(program_files) / "Google" / "Chrome" / "Application" / "chrome.exe")
+        # 64 位 Edge 的常规安装位置。
+        candidates.append(Path(program_files) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
     program_files_x86 = str(os.environ.get("PROGRAMFILES(X86)") or "").strip()
     if program_files_x86:
+        candidates.append(Path(program_files_x86) / "Google" / "Chrome" / "Application" / "chrome.exe")
         candidates.append(Path(program_files_x86) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
 
     seen: set[str] = set()

--- a/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
+  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/omni_body_skill/tool_contracts.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tool_contracts.py
@@ -102,11 +102,11 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
     },
     "template.apply": {
-        "target": "optional workspace-relative story/outline output path",
+        "target": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) story/outline output path",
         "args": {
             "template_id": "template id such as executive_ppt",
             "variables": "optional content variables object",
-            "design_output": "optional workspace-relative machine-readable design output .json path",
+            "design_output": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) machine-readable design output .json path",
         },
     },
     "qc.ppt.delivery_check": {
@@ -133,37 +133,37 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["target", "args.skill_id"],
     },
     "file.write": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string, or base64 when binary=true", "binary": "optional boolean", "encoding": "optional string"},
         "any_of": ["args.content", "args.base64"],
     },
     "file.append": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string (required)", "encoding": "optional string"},
         "required": ["args.content"],
     },
     "file.mkdir": {
-        "target": "workspace-relative directory path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) directory path (required)",
         "args": {"exist_ok": "optional boolean"},
     },
     "file.copy": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.move": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.rename": {
-        "target": "workspace-relative source path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
         "args": {"new_name": "new basename only (required)", "overwrite": "optional boolean"},
         "required": ["args.new_name"],
     },
     "code.patch_replace": {
         "aliases": ["file.patch_replace", "file.patch", "code.patch"],
-        "target": "workspace-relative existing file path (required, never a directory)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) existing file path (required, never a directory)",
         "args": {
             "find": "non-empty literal or regex string (required)",
             "replace": "replacement string (optional; empty deletes the match)",
@@ -175,7 +175,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["args.find"],
     },
     "quality.javascript_syntax": {
-        "target": "workspace-relative .js/.mjs/.cjs file or directory (required)",
+        "target": "workspace-relative (or absolute when allowed) .js/.mjs/.cjs file or directory (required)",
         "args": {"recursive": "optional boolean"},
     },
     "git.clone": {
@@ -194,13 +194,13 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "windows_note": "cmd.exe semantics; prefer typed file/code actions",
     },
     "python.run": {
-        "target": "optional workspace-relative existing .py script",
+        "target": "optional workspace-relative (or absolute when allowed) existing .py script",
         "args": {"code": "Python source string required when target is empty", "argv": "optional array", "timeout": "optional positive integer"},
         "any_of": ["target", "args.code"],
         "note": "Use file.write/code.write for file creation; python.run is not a file-writing substitute.",
     },
     "docx.create": {
-        "target": "workspace-relative output .docx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .docx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt source; preferred for long documents",
             "content": "optional inline Markdown/plain text",
@@ -211,7 +211,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.title", "args.sections"],
     },
     "pptx.create": {
-        "target": "workspace-relative output .pptx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .pptx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt slide script; split slides with --- or ##",
             "content": "optional inline slide Markdown",
@@ -229,7 +229,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "args": {"max_chars_per_slide": "optional integer from 200 to 20000"},
     },
     "mindmap.create": {
-        "target": "workspace-relative output .md path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .md path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt indented outline",
             "content": "optional inline indented outline",
@@ -240,7 +240,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.tree"],
     },
     "novel.project.create": {
-        "target": "workspace-relative new or empty novel project directory (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) new or empty novel project directory (required)",
         "args": {"title": "non-empty string", "genre": "non-empty string", "planned_chapters": "full-book count, integer >= ceil(target_words/5000), never a writing checkpoint", "target_words": "integer >= 1000"},
         "required": ["args.title", "args.genre", "args.planned_chapters", "args.target_words"],
     },

--- a/app/backend/tiangong-backend/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/pro_apps_v34.py
@@ -519,16 +519,29 @@ def _launch_playwright_chromium(playwright: Any) -> Tuple[Any, str, List[str]]:
     configured = str(os.environ.get("TIANGONG_PLAYWRIGHT_EXECUTABLE") or "").strip()
     if configured:
         candidates.append(Path(configured))
+    # 随包分发的浏览器目录（main.js 注入 PLAYWRIGHT_BROWSERS_PATH）。
+    packaged_root = str(os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if packaged_root:
+        packaged = Path(packaged_root)
+        if packaged.is_dir():
+            candidates.extend(sorted(packaged.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
     local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
     if local_app_data:
         cache_root = Path(local_app_data) / "ms-playwright"
         if cache_root.is_dir():
             candidates.extend(sorted(cache_root.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
+        # 每用户安装的 Chrome（Windows 最常见安装形态）此前不在候选里，
+        # 导致"发布包没带浏览器 + Chrome 装在 LOCALAPPDATA"的机器上
+        # browser.* 全部失败（2026-08-22 修复）。
+        candidates.append(Path(local_app_data) / "Google" / "Chrome" / "Application" / "chrome.exe")
     program_files = str(os.environ.get("PROGRAMFILES") or "").strip()
     if program_files:
         candidates.append(Path(program_files) / "Google" / "Chrome" / "Application" / "chrome.exe")
+        # 64 位 Edge 的常规安装位置。
+        candidates.append(Path(program_files) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
     program_files_x86 = str(os.environ.get("PROGRAMFILES(X86)") or "").strip()
     if program_files_x86:
+        candidates.append(Path(program_files_x86) / "Google" / "Chrome" / "Application" / "chrome.exe")
         candidates.append(Path(program_files_x86) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
 
     seen: set[str] = set()

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
+  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tool_contracts.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tool_contracts.py
@@ -102,11 +102,11 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
     },
     "template.apply": {
-        "target": "optional workspace-relative story/outline output path",
+        "target": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) story/outline output path",
         "args": {
             "template_id": "template id such as executive_ppt",
             "variables": "optional content variables object",
-            "design_output": "optional workspace-relative machine-readable design output .json path",
+            "design_output": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) machine-readable design output .json path",
         },
     },
     "qc.ppt.delivery_check": {
@@ -133,37 +133,37 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["target", "args.skill_id"],
     },
     "file.write": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string, or base64 when binary=true", "binary": "optional boolean", "encoding": "optional string"},
         "any_of": ["args.content", "args.base64"],
     },
     "file.append": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string (required)", "encoding": "optional string"},
         "required": ["args.content"],
     },
     "file.mkdir": {
-        "target": "workspace-relative directory path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) directory path (required)",
         "args": {"exist_ok": "optional boolean"},
     },
     "file.copy": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.move": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.rename": {
-        "target": "workspace-relative source path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
         "args": {"new_name": "new basename only (required)", "overwrite": "optional boolean"},
         "required": ["args.new_name"],
     },
     "code.patch_replace": {
         "aliases": ["file.patch_replace", "file.patch", "code.patch"],
-        "target": "workspace-relative existing file path (required, never a directory)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) existing file path (required, never a directory)",
         "args": {
             "find": "non-empty literal or regex string (required)",
             "replace": "replacement string (optional; empty deletes the match)",
@@ -175,7 +175,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["args.find"],
     },
     "quality.javascript_syntax": {
-        "target": "workspace-relative .js/.mjs/.cjs file or directory (required)",
+        "target": "workspace-relative (or absolute when allowed) .js/.mjs/.cjs file or directory (required)",
         "args": {"recursive": "optional boolean"},
     },
     "git.clone": {
@@ -194,13 +194,13 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "windows_note": "cmd.exe semantics; prefer typed file/code actions",
     },
     "python.run": {
-        "target": "optional workspace-relative existing .py script",
+        "target": "optional workspace-relative (or absolute when allowed) existing .py script",
         "args": {"code": "Python source string required when target is empty", "argv": "optional array", "timeout": "optional positive integer"},
         "any_of": ["target", "args.code"],
         "note": "Use file.write/code.write for file creation; python.run is not a file-writing substitute.",
     },
     "docx.create": {
-        "target": "workspace-relative output .docx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .docx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt source; preferred for long documents",
             "content": "optional inline Markdown/plain text",
@@ -211,7 +211,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.title", "args.sections"],
     },
     "pptx.create": {
-        "target": "workspace-relative output .pptx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .pptx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt slide script; split slides with --- or ##",
             "content": "optional inline slide Markdown",
@@ -229,7 +229,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "args": {"max_chars_per_slide": "optional integer from 200 to 20000"},
     },
     "mindmap.create": {
-        "target": "workspace-relative output .md path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .md path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt indented outline",
             "content": "optional inline indented outline",
@@ -240,7 +240,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.tree"],
     },
     "novel.project.create": {
-        "target": "workspace-relative new or empty novel project directory (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) new or empty novel project directory (required)",
         "args": {"title": "non-empty string", "genre": "non-empty string", "planned_chapters": "full-book count, integer >= ceil(target_words/5000), never a writing checkpoint", "target_words": "integer >= 1000"},
         "required": ["args.title", "args.genre", "args.planned_chapters", "args.target_words"],
     },

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
@@ -519,16 +519,29 @@ def _launch_playwright_chromium(playwright: Any) -> Tuple[Any, str, List[str]]:
     configured = str(os.environ.get("TIANGONG_PLAYWRIGHT_EXECUTABLE") or "").strip()
     if configured:
         candidates.append(Path(configured))
+    # 随包分发的浏览器目录（main.js 注入 PLAYWRIGHT_BROWSERS_PATH）。
+    packaged_root = str(os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if packaged_root:
+        packaged = Path(packaged_root)
+        if packaged.is_dir():
+            candidates.extend(sorted(packaged.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
     local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
     if local_app_data:
         cache_root = Path(local_app_data) / "ms-playwright"
         if cache_root.is_dir():
             candidates.extend(sorted(cache_root.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
+        # 每用户安装的 Chrome（Windows 最常见安装形态）此前不在候选里，
+        # 导致"发布包没带浏览器 + Chrome 装在 LOCALAPPDATA"的机器上
+        # browser.* 全部失败（2026-08-22 修复）。
+        candidates.append(Path(local_app_data) / "Google" / "Chrome" / "Application" / "chrome.exe")
     program_files = str(os.environ.get("PROGRAMFILES") or "").strip()
     if program_files:
         candidates.append(Path(program_files) / "Google" / "Chrome" / "Application" / "chrome.exe")
+        # 64 位 Edge 的常规安装位置。
+        candidates.append(Path(program_files) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
     program_files_x86 = str(os.environ.get("PROGRAMFILES(X86)") or "").strip()
     if program_files_x86:
+        candidates.append(Path(program_files_x86) / "Google" / "Chrome" / "Application" / "chrome.exe")
         candidates.append(Path(program_files_x86) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
 
     seen: set[str] = set()

--- a/app/backend/tiangong-backend/v3/peizhi.py
+++ b/app/backend/tiangong-backend/v3/peizhi.py
@@ -40,7 +40,12 @@ ZHUODONG_JIANCE_MIAO = 120      # 用户活跃检测窗口
 ZIZHU_ZUIDA_LIANXU = 5          # 连续自主行动上限
 
 # 生命链 v3.6：轻心跳 + 15分钟重生命任务
-SHENGMING_LIFE_CHAIN_ENABLED = False
+# 生命链对话注入：让模型在每轮对话中感知后台生命状态。
+# 2026-08-22 默认启用（旧实现 import 不存在的模块且被吞异常，等于从未
+# 注入）。环境变量 TIANGONG_SHENGMING_CONTEXT=0 可关闭。
+SHENGMING_LIFE_CHAIN_ENABLED = str(
+    os.environ.get("TIANGONG_SHENGMING_CONTEXT") or "1"
+).strip().lower() not in {"0", "false", "off", "no", "disabled"}
 SHENGMING_ZHONG_XINTIAO_MIAO = 15 * 60       # 重生命任务间隔：15分钟
 SHENGMING_USER_IDLE_MIAO = 3 * 60            # 用户闲置超过3分钟才跑重自主任务
 SHENGMING_MAX_JOBS_PER_TICK = 2              # 每次重心跳最多执行几个生命任务

--- a/app/backend/tiangong-backend/v3/zongdiaodu.py
+++ b/app/backend/tiangong-backend/v3/zongdiaodu.py
@@ -2302,40 +2302,67 @@ def _minimax_m3_context_packing_enabled() -> bool:
 
 
 def _shengming_context_string() -> str:
-    """生命链摘要，注入 dynamic_context 让模型感知后台状态。"""
+    """生命链摘要，注入 dynamic_context 让模型感知后台状态。
+
+    权威数据源是 7184 网关的生命面板（embedded runtime 投影）。旧实现
+    import 一个不存在的 v3.shengming.life_panel 模块，且被双层
+    ``except: return ""`` 吞掉——生命状态从未真正进入对话（2026-08-22
+    修复）。失效时返回可见的降级说明而不是空串，让模型与日志都能感知
+    生命上下文缺席，而不是无声缺失。
+    """
+    # 运行时开关：调用时实时读环境（TIANGONG_SHENGMING_CONTEXT=0 关闭），
+    # 与 peizhi.SHENGMING_LIFE_CHAIN_ENABLED 的启动默认保持一致。
+    if str(os.environ.get("TIANGONG_SHENGMING_CONTEXT") or "1").strip().lower() in {
+        "0", "false", "off", "no", "disabled",
+    }:
+        return ""
+    import httpx
+
+    gateway_url = (
+        os.environ.get("TIANGONG_GATEWAY_URL")
+        or "http://127.0.0.1:7184"
+    ).rstrip("/")
+    token = str(
+        os.environ.get("TIANGONG_BACKEND_INTERNAL_TOKEN")
+        or os.environ.get("TIANGONG_DESKTOP_TOKEN")
+        or ""
+    )
     try:
-        from .shengming.life_panel import build_life_panel_payload
-        from .peizhi import SHENGMING_LIFE_CHAIN_ENABLED
-        if not SHENGMING_LIFE_CHAIN_ENABLED:
-            return ""
-        payload = build_life_panel_payload()
-        s = payload.get("summary", {})
-        b = payload.get("budget", {})
-        bd = payload.get("boundaries", {})
-        share = bd.get("share", {})
+        response = httpx.get(
+            f"{gateway_url}/api/v1/v3/life/panel",
+            headers={"X-Tiangong-Token": token} if token else {},
+            timeout=2.0,
+        )
+        payload = response.json() if response.status_code == 200 else {}
+        if not isinstance(payload, dict) or payload.get("ok") is False:
+            raise ValueError(f"panel_http_{response.status_code}")
+        s = payload.get("summary", {}) or {}
+        b = payload.get("budget", {}) or {}
+        bd = payload.get("boundaries", {}) or {}
+        share = bd.get("share", {}) or {}
         lines = ["[后台生命链]"]
         lines.append(
             f"完成 {s.get('completed_tasks_today', 0)} 项 · "
-            f"LLM 预算 {b.get('used', 0)}/{b.get('attempts', 20)} · "
+            f"LLM 预算 {b.get('used', 0)}/{b.get('success_limit', 20)} · "
             f"下次心跳 {s.get('next_heavy_tick_minutes', '—')}min 后"
         )
-        ra = s.get("recent_action", {})
-        if ra.get("kind"):
+        ra = s.get("recent_action", {}) or {}
+        if ra.get("title"):
             lines.append(
-                f"最近：{ra.get('title', '')} "
+                f"最近行动：{ra.get('title', '')} "
                 f"(价值分 {ra.get('value_score', '—')})"
             )
         rules = []
         if share.get("quiet_if_user_active"):
             rules.append("用户活跃时不主动打扰")
-        autonomy = bd.get("autonomy", {})
+        autonomy = bd.get("autonomy", {}) or {}
         if "A3" in str(autonomy.get("card_only_risks", [])):
             rules.append("A3+任务仅生成卡片")
         if rules:
             lines.append("边界：" + " · ".join(rules))
         return "\n".join(lines)
-    except Exception:
-        return ""
+    except Exception as exc:
+        return f"[后台生命链] 状态暂不可用（{type(exc).__name__}）；涉及其后台状态时先询问用户，不要臆测。"
 
 
 def _user_prompt_with_context(user_prompt: str, dynamic_context: str) -> str:

--- a/app/frontend-v2/renderer/runtime/http-runtime.mjs
+++ b/app/frontend-v2/renderer/runtime/http-runtime.mjs
@@ -1306,12 +1306,32 @@ async function commitDesktopWorkspace(workspaceRoot, workspaceMode = "") {
   }));
   if (saved?.error === "workspace_revision_conflict") {
     const current = await readDesktopWorkspaceAuthority();
-    if (current?.ok && sameWorkspacePath(current.workspace, workspace)) return current;
+    if (current?.ok && sameWorkspacePath(current.workspace, workspace)) {
+      // 冲突等值但模式可能没跟上：仅工作区相同就提前返回会静默丢掉
+      // 用户这次要切的 full/workspace 模式（跨盘读写主诉之一）。
+      if (workspaceMode && current.workspace_mode !== workspaceMode) {
+        const retried = rememberWorkspaceAuthority(await bridge.setWorkspaceRoot({
+          workspace: current.workspace,
+          expectedRevision: current.revision,
+          workspace_mode: workspaceMode === "full" ? "full" : "workspace",
+        }));
+        if (retried?.ok) return retried;
+      }
+      return current;
+    }
     const error = new Error("工作区已被另一个操作更新，请重新选择后再试");
     error.code = "workspace_revision_conflict";
     throw error;
   }
-  if (!saved?.ok || !saved?.workspace) throw new Error(saved?.error || "工作区切换失败");
+  if (!saved?.ok || !saved?.workspace) {
+    // 服务重启失败已回滚到原工作区：把回滚事实说清楚，避免"设置静默未生效"。
+    if (saved?.rolledBack) {
+      const error = new Error(`切换后服务重启失败，已回滚到原工作区（${saved.workspace || ""}）`);
+      error.code = saved?.error || "workspace_service_restart_failed";
+      throw error;
+    }
+    throw new Error(saved?.error || "工作区切换失败");
+  }
   return saved;
 }
 

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "c957e042dc0edb6d1e23a563f537ce9c1ead8dcebe4d29e1080cbfd690937bf5",
+  "tree_sha256": "7d89d77a50a91cc013e0a5d3565df65b03dca69fc3f2a2d8b78d2f7dfca95e39",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/embedded_runtime.py
+++ b/app/life-service/runtime314/life_service/embedded_runtime.py
@@ -752,8 +752,11 @@ class EmbeddedLifeRuntime:
                 "share_dnd_end": "08:00",
                 # P16 native proactive cognition. Legacy share/greeting settings
                 # remain compatibility-only and cannot authorize this producer.
+                # 2026-08-22：默认 live（产品决策）——影子模式默认值让生命
+                # 永远不真正开口（"久不回话"主诉）；F1 忽略率门禁/F6 预算/
+                # 免打扰/最小间隔已把打扰面收敛，且设置面板可随时切回 shadow。
                 "proactive_enabled": True,
-                "proactive_mode": "shadow",
+                "proactive_mode": "live",
                 # P16 has a sub-budget in addition to the existing global Life LLM cap.
                 "proactive_llm_daily_budget": 6,
                 "proactive_llm_daily_attempt_budget": 8,
@@ -3066,7 +3069,12 @@ class EmbeddedLifeRuntime:
         scope = self._scope_state(life_id)
         scheduler = scope.setdefault("scheduler", {})
         autonomy = self._autonomy_state(life_id)
-        if not autonomy.get("enabled") or not callable(getattr(self, "_autonomy_decider", None)):
+        if not autonomy.get("enabled"):
+            # 停摆不静默：把原因写进面板可见的调度器状态（P1 修复）。
+            scheduler["last_autonomy_decision_error"] = "life.autonomy.disabled"
+            return
+        if not callable(getattr(self, "_autonomy_decider", None)):
+            scheduler["last_autonomy_decision_error"] = "life.autonomy.model_bridge_unavailable"
             return
         if bool(scheduler.get("autonomy_decision_inflight")):
             return
@@ -5146,7 +5154,24 @@ class EmbeddedLifeRuntime:
             "state": {
                 "status": "ALIVE" if health.get("life_ready") else "NOT_READY",
                 "last_heavy_reason": str(autonomy_state.get("last_tick_reason") or "scheduled"),
-                "last_heavy_tick_at": str(scheduler_status.get("last_heartbeat_at") or ""),
+                # 真实活跃 = 最近一次自主/学习/迭代决策或主动投递；心跳每 30 秒
+                # 一次，用心跳冒充"最近活动"会把完全停摆伪装成活跃（P1 修复）。
+                "last_heavy_tick_at": (
+                    time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(latest_activity_ms / 1000))
+                    if (latest_activity_ms := max(
+                        (
+                            int(scheduler_status.get(key) or 0)
+                            for key in (
+                                "last_autonomy_decision_at_ms",
+                                "last_learning_decision_at_ms",
+                                "last_self_iteration_decision_at_ms",
+                                "last_proactive_delivery_at_ms",
+                            )
+                        ),
+                        default=0,
+                    )) > 0
+                    else ""
+                ),
                 "last_execution_at": str(recent_execution.get("committed_at") or ""),
                 "updated_at": now,
             },
@@ -7964,6 +7989,8 @@ class EmbeddedLifeRuntime:
         if now_ms - int(scheduler.get("last_capability_health_at_ms") or 0) < 600_000:
             return
         if not callable(getattr(self, "_capability_patch_decider", None)):
+            # 停摆不静默：补丁桥缺失时记录原因，面板可见（P1 修复）。
+            scheduler["last_capability_health_error"] = "life.capability.patch_bridge_unavailable"
             return
         # 子池已耗尽时不再起线程；真正的按次记账在 worker 内每个补丁目标前完成。
         if self._sub_model_budget_exhausted(scheduler, settings=scope_state["settings"], pool="capability_patch"):

--- a/app/main.js
+++ b/app/main.js
@@ -1237,8 +1237,9 @@ async function applyWorkspaceRootChange(workspace, expectedRevision, workspaceMo
   process.env.TIANGONG_FORCE_WORKSPACE_ROOT = workspace;
   process.env.TIANGONG_OMNI_BODY_WORKSPACE = workspace;
   process.env.TIANGONG_WORKSPACE_MODE = nextMode;
+  let services = null;
   try {
-    const services = await startServicesForWorkspaceChange();
+    services = await startServicesForWorkspaceChange();
     if (
       !services.backendReady
       || !services.totalGatewayReady
@@ -1292,6 +1293,9 @@ async function applyWorkspaceRootChange(workspace, expectedRevision, workspaceMo
       revision: workspaceChangeRevision,
       changing: false,
       rolledBack,
+      // 附失败现场快照：跨盘切换失败时用户与日志都能看到是哪个服务没起来，
+      // 而不是只有一个裸错误码（"设置静默未生效"主诉的一部分）。
+      services,
       rollbackServices,
     };
   }
@@ -3394,7 +3398,15 @@ function totalGatewayEnvironment(entry) {
   } catch (error) {
     writeDesktopDiagnostic("provider-credentials-gateway-inject-failed", error?.message || error);
   }
+  // 随包分发的 Playwright Chromium（provision 脚本装进运行时目录）。
+  // 注入后 playwright 默认启动直接命中包内浏览器；无此目录时按序回退
+  // 用户缓存与本机 Chrome/Edge（"浏览器控不了"修复的一部分）。
+  const packagedBrowsersRoot = [
+    process.env.TIANGONG_PLAYWRIGHT_BROWSERS_PATH,
+    path.join(app.getAppPath(), "runtime", "ms-playwright"),
+  ].filter(Boolean).find((candidate) => isDirectory(candidate));
   const env = { ...process.env };
+  if (packagedBrowsersRoot) env.PLAYWRIGHT_BROWSERS_PATH = packagedBrowsersRoot;
   const rawReleaseCandidates = releaseManifestCandidatePaths();
   const boundReleases = verifiedReleaseBindings();
   const explicitSkillRoot = String(process.env.TIANGONG_GATEWAY_SKILL_ROOT || "").trim();

--- a/readable-python-source/omni_body_skill/.tiangong-generated-source.json
+++ b/readable-python-source/omni_body_skill/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "05939b0d5f3c591d230bbded0298f7207807bce5b0ed53e4ea02650321ea8255",
+  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/readable-python-source/omni_body_skill/tool_contracts.py
+++ b/readable-python-source/omni_body_skill/tool_contracts.py
@@ -102,11 +102,11 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
     },
     "template.apply": {
-        "target": "optional workspace-relative story/outline output path",
+        "target": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) story/outline output path",
         "args": {
             "template_id": "template id such as executive_ppt",
             "variables": "optional content variables object",
-            "design_output": "optional workspace-relative machine-readable design output .json path",
+            "design_output": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) machine-readable design output .json path",
         },
     },
     "qc.ppt.delivery_check": {
@@ -133,37 +133,37 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["target", "args.skill_id"],
     },
     "file.write": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string, or base64 when binary=true", "binary": "optional boolean", "encoding": "optional string"},
         "any_of": ["args.content", "args.base64"],
     },
     "file.append": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string (required)", "encoding": "optional string"},
         "required": ["args.content"],
     },
     "file.mkdir": {
-        "target": "workspace-relative directory path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) directory path (required)",
         "args": {"exist_ok": "optional boolean"},
     },
     "file.copy": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.move": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.rename": {
-        "target": "workspace-relative source path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
         "args": {"new_name": "new basename only (required)", "overwrite": "optional boolean"},
         "required": ["args.new_name"],
     },
     "code.patch_replace": {
         "aliases": ["file.patch_replace", "file.patch", "code.patch"],
-        "target": "workspace-relative existing file path (required, never a directory)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) existing file path (required, never a directory)",
         "args": {
             "find": "non-empty literal or regex string (required)",
             "replace": "replacement string (optional; empty deletes the match)",
@@ -175,7 +175,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["args.find"],
     },
     "quality.javascript_syntax": {
-        "target": "workspace-relative .js/.mjs/.cjs file or directory (required)",
+        "target": "workspace-relative (or absolute when allowed) .js/.mjs/.cjs file or directory (required)",
         "args": {"recursive": "optional boolean"},
     },
     "git.clone": {
@@ -194,13 +194,13 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "windows_note": "cmd.exe semantics; prefer typed file/code actions",
     },
     "python.run": {
-        "target": "optional workspace-relative existing .py script",
+        "target": "optional workspace-relative (or absolute when allowed) existing .py script",
         "args": {"code": "Python source string required when target is empty", "argv": "optional array", "timeout": "optional positive integer"},
         "any_of": ["target", "args.code"],
         "note": "Use file.write/code.write for file creation; python.run is not a file-writing substitute.",
     },
     "docx.create": {
-        "target": "workspace-relative output .docx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .docx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt source; preferred for long documents",
             "content": "optional inline Markdown/plain text",
@@ -211,7 +211,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.title", "args.sections"],
     },
     "pptx.create": {
-        "target": "workspace-relative output .pptx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .pptx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt slide script; split slides with --- or ##",
             "content": "optional inline slide Markdown",
@@ -229,7 +229,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "args": {"max_chars_per_slide": "optional integer from 200 to 20000"},
     },
     "mindmap.create": {
-        "target": "workspace-relative output .md path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .md path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt indented outline",
             "content": "optional inline indented outline",
@@ -240,7 +240,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.tree"],
     },
     "novel.project.create": {
-        "target": "workspace-relative new or empty novel project directory (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) new or empty novel project directory (required)",
         "args": {"title": "non-empty string", "genre": "non-empty string", "planned_chapters": "full-book count, integer >= ceil(target_words/5000), never a writing checkpoint", "target_words": "integer >= 1000"},
         "required": ["args.title", "args.genre", "args.planned_chapters", "args.target_words"],
     },

--- a/readable-python-source/omni_body_skill/tools/pro_apps_v34.py
+++ b/readable-python-source/omni_body_skill/tools/pro_apps_v34.py
@@ -519,16 +519,29 @@ def _launch_playwright_chromium(playwright: Any) -> Tuple[Any, str, List[str]]:
     configured = str(os.environ.get("TIANGONG_PLAYWRIGHT_EXECUTABLE") or "").strip()
     if configured:
         candidates.append(Path(configured))
+    # 随包分发的浏览器目录（main.js 注入 PLAYWRIGHT_BROWSERS_PATH）。
+    packaged_root = str(os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if packaged_root:
+        packaged = Path(packaged_root)
+        if packaged.is_dir():
+            candidates.extend(sorted(packaged.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
     local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
     if local_app_data:
         cache_root = Path(local_app_data) / "ms-playwright"
         if cache_root.is_dir():
             candidates.extend(sorted(cache_root.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
+        # 每用户安装的 Chrome（Windows 最常见安装形态）此前不在候选里，
+        # 导致"发布包没带浏览器 + Chrome 装在 LOCALAPPDATA"的机器上
+        # browser.* 全部失败（2026-08-22 修复）。
+        candidates.append(Path(local_app_data) / "Google" / "Chrome" / "Application" / "chrome.exe")
     program_files = str(os.environ.get("PROGRAMFILES") or "").strip()
     if program_files:
         candidates.append(Path(program_files) / "Google" / "Chrome" / "Application" / "chrome.exe")
+        # 64 位 Edge 的常规安装位置。
+        candidates.append(Path(program_files) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
     program_files_x86 = str(os.environ.get("PROGRAMFILES(X86)") or "").strip()
     if program_files_x86:
+        candidates.append(Path(program_files_x86) / "Google" / "Chrome" / "Application" / "chrome.exe")
         candidates.append(Path(program_files_x86) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
 
     seen: set[str] = set()

--- a/scripts/provision-embedded-python.ps1
+++ b/scripts/provision-embedded-python.ps1
@@ -104,6 +104,20 @@ if ($LASTEXITCODE -ne 0) { throw "Embedded Python dependency installation failed
 & $Python -m pip check
 if ($LASTEXITCODE -ne 0) { throw "Embedded Python dependency verification failed" }
 
+# 2026-08-22：随包分发 Playwright 的 Chromium（"浏览器控不了"主诉）。
+# requirements-source.lock 已含 playwright 模块，但浏览器二进制此前从不
+# 安装——用户机器既无 ms-playwright 缓存又无可发现的本机 Chrome/Edge 时，
+# browser.* 全部降级失败。装进运行时目录（PLAYWRIGHT_BROWSERS_PATH），
+# main.js 启动网关时注入同一路径；运行时仍按序回退本机 Chrome/Edge。
+# 设 TIANGONG_SKIP_PLAYWRIGHT_BROWSERS=1 可跳过（约 120MB 下载）。
+if ($env:TIANGONG_SKIP_PLAYWRIGHT_BROWSERS -ne "1") {
+    $env:PLAYWRIGHT_BROWSERS_PATH = Join-Path $RuntimeRoot "ms-playwright"
+    & $Python -m playwright install chromium
+    if ($LASTEXITCODE -ne 0) { Write-Warning "playwright chromium install failed; browser actions will fall back to local Chrome/Edge" }
+} else {
+    Write-Warning "TIANGONG_SKIP_PLAYWRIGHT_BROWSERS=1：跳过随包 Chromium，browser.* 依赖本机 Chrome/Edge"
+}
+
 # A local-path pip install records the publisher machine in direct_url.json.
 # The embedded product packages are synchronized from source during setup, and
 # the release portability gate intentionally rejects this host provenance.

--- a/src/life_service/embedded_runtime.py
+++ b/src/life_service/embedded_runtime.py
@@ -752,8 +752,11 @@ class EmbeddedLifeRuntime:
                 "share_dnd_end": "08:00",
                 # P16 native proactive cognition. Legacy share/greeting settings
                 # remain compatibility-only and cannot authorize this producer.
+                # 2026-08-22：默认 live（产品决策）——影子模式默认值让生命
+                # 永远不真正开口（"久不回话"主诉）；F1 忽略率门禁/F6 预算/
+                # 免打扰/最小间隔已把打扰面收敛，且设置面板可随时切回 shadow。
                 "proactive_enabled": True,
-                "proactive_mode": "shadow",
+                "proactive_mode": "live",
                 # P16 has a sub-budget in addition to the existing global Life LLM cap.
                 "proactive_llm_daily_budget": 6,
                 "proactive_llm_daily_attempt_budget": 8,
@@ -3066,7 +3069,12 @@ class EmbeddedLifeRuntime:
         scope = self._scope_state(life_id)
         scheduler = scope.setdefault("scheduler", {})
         autonomy = self._autonomy_state(life_id)
-        if not autonomy.get("enabled") or not callable(getattr(self, "_autonomy_decider", None)):
+        if not autonomy.get("enabled"):
+            # 停摆不静默：把原因写进面板可见的调度器状态（P1 修复）。
+            scheduler["last_autonomy_decision_error"] = "life.autonomy.disabled"
+            return
+        if not callable(getattr(self, "_autonomy_decider", None)):
+            scheduler["last_autonomy_decision_error"] = "life.autonomy.model_bridge_unavailable"
             return
         if bool(scheduler.get("autonomy_decision_inflight")):
             return
@@ -5146,7 +5154,24 @@ class EmbeddedLifeRuntime:
             "state": {
                 "status": "ALIVE" if health.get("life_ready") else "NOT_READY",
                 "last_heavy_reason": str(autonomy_state.get("last_tick_reason") or "scheduled"),
-                "last_heavy_tick_at": str(scheduler_status.get("last_heartbeat_at") or ""),
+                # 真实活跃 = 最近一次自主/学习/迭代决策或主动投递；心跳每 30 秒
+                # 一次，用心跳冒充"最近活动"会把完全停摆伪装成活跃（P1 修复）。
+                "last_heavy_tick_at": (
+                    time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(latest_activity_ms / 1000))
+                    if (latest_activity_ms := max(
+                        (
+                            int(scheduler_status.get(key) or 0)
+                            for key in (
+                                "last_autonomy_decision_at_ms",
+                                "last_learning_decision_at_ms",
+                                "last_self_iteration_decision_at_ms",
+                                "last_proactive_delivery_at_ms",
+                            )
+                        ),
+                        default=0,
+                    )) > 0
+                    else ""
+                ),
                 "last_execution_at": str(recent_execution.get("committed_at") or ""),
                 "updated_at": now,
             },
@@ -7964,6 +7989,8 @@ class EmbeddedLifeRuntime:
         if now_ms - int(scheduler.get("last_capability_health_at_ms") or 0) < 600_000:
             return
         if not callable(getattr(self, "_capability_patch_decider", None)):
+            # 停摆不静默：补丁桥缺失时记录原因，面板可见（P1 修复）。
+            scheduler["last_capability_health_error"] = "life.capability.patch_bridge_unavailable"
             return
         # 子池已耗尽时不再起线程；真正的按次记账在 worker 内每个补丁目标前完成。
         if self._sub_model_budget_exhausted(scheduler, settings=scope_state["settings"], pool="capability_patch"):

--- a/src/omni_body_skill/tool_contracts.py
+++ b/src/omni_body_skill/tool_contracts.py
@@ -102,11 +102,11 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
     },
     "template.apply": {
-        "target": "optional workspace-relative story/outline output path",
+        "target": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) story/outline output path",
         "args": {
             "template_id": "template id such as executive_ppt",
             "variables": "optional content variables object",
-            "design_output": "optional workspace-relative machine-readable design output .json path",
+            "design_output": "optional workspace-relative (or absolute path when the user enabled absolute-path permission) machine-readable design output .json path",
         },
     },
     "qc.ppt.delivery_check": {
@@ -133,37 +133,37 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["target", "args.skill_id"],
     },
     "file.write": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string, or base64 when binary=true", "binary": "optional boolean", "encoding": "optional string"},
         "any_of": ["args.content", "args.base64"],
     },
     "file.append": {
-        "target": "workspace-relative file path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) file path (required)",
         "args": {"content": "string (required)", "encoding": "optional string"},
         "required": ["args.content"],
     },
     "file.mkdir": {
-        "target": "workspace-relative directory path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) directory path (required)",
         "args": {"exist_ok": "optional boolean"},
     },
     "file.copy": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.move": {
-        "target": "workspace-relative source path (required)",
-        "args": {"destination": "workspace-relative destination path (required)", "overwrite": "optional boolean"},
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
+        "args": {"destination": "workspace-relative (or absolute path when the user enabled absolute-path permission) destination path (required)", "overwrite": "optional boolean"},
         "required": ["args.destination"],
     },
     "file.rename": {
-        "target": "workspace-relative source path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) source path (required)",
         "args": {"new_name": "new basename only (required)", "overwrite": "optional boolean"},
         "required": ["args.new_name"],
     },
     "code.patch_replace": {
         "aliases": ["file.patch_replace", "file.patch", "code.patch"],
-        "target": "workspace-relative existing file path (required, never a directory)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) existing file path (required, never a directory)",
         "args": {
             "find": "non-empty literal or regex string (required)",
             "replace": "replacement string (optional; empty deletes the match)",
@@ -175,7 +175,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["args.find"],
     },
     "quality.javascript_syntax": {
-        "target": "workspace-relative .js/.mjs/.cjs file or directory (required)",
+        "target": "workspace-relative (or absolute when allowed) .js/.mjs/.cjs file or directory (required)",
         "args": {"recursive": "optional boolean"},
     },
     "git.clone": {
@@ -194,13 +194,13 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "windows_note": "cmd.exe semantics; prefer typed file/code actions",
     },
     "python.run": {
-        "target": "optional workspace-relative existing .py script",
+        "target": "optional workspace-relative (or absolute when allowed) existing .py script",
         "args": {"code": "Python source string required when target is empty", "argv": "optional array", "timeout": "optional positive integer"},
         "any_of": ["target", "args.code"],
         "note": "Use file.write/code.write for file creation; python.run is not a file-writing substitute.",
     },
     "docx.create": {
-        "target": "workspace-relative output .docx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .docx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt source; preferred for long documents",
             "content": "optional inline Markdown/plain text",
@@ -211,7 +211,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.title", "args.sections"],
     },
     "pptx.create": {
-        "target": "workspace-relative output .pptx path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .pptx path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt slide script; split slides with --- or ##",
             "content": "optional inline slide Markdown",
@@ -229,7 +229,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "args": {"max_chars_per_slide": "optional integer from 200 to 20000"},
     },
     "mindmap.create": {
-        "target": "workspace-relative output .md path (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) output .md path (required)",
         "args": {
             "source": "optional existing workspace .md or .txt indented outline",
             "content": "optional inline indented outline",
@@ -240,7 +240,7 @@ ACTION_ARGUMENT_SCHEMAS: dict[str, dict[str, Any]] = {
         "any_of": ["args.source", "args.content", "args.tree"],
     },
     "novel.project.create": {
-        "target": "workspace-relative new or empty novel project directory (required)",
+        "target": "workspace-relative (or absolute path when the user enabled absolute-path permission) new or empty novel project directory (required)",
         "args": {"title": "non-empty string", "genre": "non-empty string", "planned_chapters": "full-book count, integer >= ceil(target_words/5000), never a writing checkpoint", "target_words": "integer >= 1000"},
         "required": ["args.title", "args.genre", "args.planned_chapters", "args.target_words"],
     },

--- a/src/omni_body_skill/tools/pro_apps_v34.py
+++ b/src/omni_body_skill/tools/pro_apps_v34.py
@@ -519,16 +519,29 @@ def _launch_playwright_chromium(playwright: Any) -> Tuple[Any, str, List[str]]:
     configured = str(os.environ.get("TIANGONG_PLAYWRIGHT_EXECUTABLE") or "").strip()
     if configured:
         candidates.append(Path(configured))
+    # 随包分发的浏览器目录（main.js 注入 PLAYWRIGHT_BROWSERS_PATH）。
+    packaged_root = str(os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if packaged_root:
+        packaged = Path(packaged_root)
+        if packaged.is_dir():
+            candidates.extend(sorted(packaged.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
     local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
     if local_app_data:
         cache_root = Path(local_app_data) / "ms-playwright"
         if cache_root.is_dir():
             candidates.extend(sorted(cache_root.glob("chromium-*/chrome-win64/chrome.exe"), reverse=True))
+        # 每用户安装的 Chrome（Windows 最常见安装形态）此前不在候选里，
+        # 导致"发布包没带浏览器 + Chrome 装在 LOCALAPPDATA"的机器上
+        # browser.* 全部失败（2026-08-22 修复）。
+        candidates.append(Path(local_app_data) / "Google" / "Chrome" / "Application" / "chrome.exe")
     program_files = str(os.environ.get("PROGRAMFILES") or "").strip()
     if program_files:
         candidates.append(Path(program_files) / "Google" / "Chrome" / "Application" / "chrome.exe")
+        # 64 位 Edge 的常规安装位置。
+        candidates.append(Path(program_files) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
     program_files_x86 = str(os.environ.get("PROGRAMFILES(X86)") or "").strip()
     if program_files_x86:
+        candidates.append(Path(program_files_x86) / "Google" / "Chrome" / "Application" / "chrome.exe")
         candidates.append(Path(program_files_x86) / "Microsoft" / "Edge" / "Application" / "msedge.exe")
 
     seen: set[str] = set()

--- a/tests/test_shengming_context_injection.py
+++ b/tests/test_shengming_context_injection.py
@@ -1,0 +1,115 @@
+"""生命链对话注入修复（2026-08-22）的契约测试。
+
+旧实现 import 不存在的 v3.shengming.life_panel 模块且被双层 except 吞成
+空串——生命状态从未进入对话。新实现从 7184 网关拉权威面板；失效时返回
+可见降级说明而非空串。
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture()
+def fake_gateway(monkeypatch: pytest.MonkeyPatch):
+    state = {"panel": {"ok": True, "summary": {}, "budget": {}, "boundaries": {}}}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/api/v1/v3/life/panel":
+                body = json.dumps(state["panel"]).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, *args) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("TIANGONG_GATEWAY_URL", f"http://127.0.0.1:{server.server_address[1]}")
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _context(monkeypatch: pytest.MonkeyPatch, enabled: str = "1"):
+    monkeypatch.setenv("TIANGONG_SHENGMING_CONTEXT", enabled)
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    for entry in (str(root / "app" / "backend" / "tiangong-backend"), str(root / "src")):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+    from v3.zongdiaodu import _shengming_context_string
+
+    return _shengming_context_string()
+
+
+def test_panel_summary_is_injected_from_authoritative_gateway(fake_gateway, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_gateway["panel"] = {
+        "ok": True,
+        "summary": {
+            "completed_tasks_today": 3,
+            "next_heavy_tick_minutes": 5,
+            "recent_action": {"title": "整理知识库", "value_score": 0.8},
+        },
+        "budget": {"used": 2, "success_limit": 20},
+        "boundaries": {
+            "share": {"quiet_if_user_active": True},
+            "autonomy": {"card_only_risks": ["A3", "A4"]},
+        },
+    }
+    text = _context(monkeypatch)
+    assert text.startswith("[后台生命链]")
+    assert "完成 3 项" in text
+    assert "整理知识库" in text
+    assert "用户活跃时不主动打扰" in text
+    assert "A3+任务仅生成卡片" in text
+
+
+def test_gateway_failure_degrades_visibly_never_silent_empty(fake_gateway, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIANGONG_GATEWAY_URL", "http://127.0.0.1:1")
+    text = _context(monkeypatch)
+    # 旧行为是静默空串；新契约是可见降级 + 不臆测指令。
+    assert text.startswith("[后台生命链] 状态暂不可用")
+    assert "不要臆测" in text
+
+
+def test_kill_switch_returns_empty(fake_gateway, monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _context(monkeypatch, enabled="0") == ""
+
+
+def test_flag_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TIANGONG_SHENGMING_CONTEXT", raising=False)
+    from pathlib import Path
+    import sys
+
+    root = Path(__file__).resolve().parents[1]
+    for entry in (str(root / "app" / "backend" / "tiangong-backend"), str(root / "src")):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+    from v3 import peizhi
+
+    monkeypatch.delattr(peizhi, "SHENGMING_LIFE_CHAIN_ENABLED", raising=False)
+    import importlib
+
+    importlib.reload(peizhi)
+    try:
+        assert peizhi.SHENGMING_LIFE_CHAIN_ENABLED is True
+    finally:
+        importlib.reload(peizhi)


### PR DESCRIPTION
四组主诉逐一源码核实后修复（26 文件，含镜像同步）：

## 第 4 组：学习空转、久不回话（四处病灶全实锤）
1. **面板心跳冒充活跃**：`last_heavy_tick_at` 绑定 30s 心跳 → 改为真实决策/投递时间戳
2. **两处停摆静默**：自主/能力补丁调度器裸 return → 写入可面板可见的 error 原因
3. **对话注入三层死亡**：import 不存在的模块 + 开关硬关 + 双层吞异常 = 生命状态从未进对话 → 重写为从 7184 网关拉权威面板，失效返回可见降级+不臆测指令
4. **主动言语默认 shadow 永不发送** → 默认 live（门禁/预算/DND 已收敛打扰面，面板可切回）

## 第 1 组：跨盘设置静默未生效（三处缺口）
- omni_body schema 17 处补注绝对路径可用（模型此前不知可发绝对路径）
- 前端冲突等值分支静默丢 full/workspace 模式 → 按 revision 重试
- 工作区回滚失败附 services 现场快照 + 前端明确告知已回滚

## 第 3 组：浏览器控不了（实现完好、发现链缺口）
- 浏览器候选补全：随包目录、每用户 Chrome（最常见形态）、64 位 Edge、X86 Chrome
- provision 随包安装 Chromium（PLAYWRIGHT_BROWSERS_PATH 钉扎）；main.js 注入路径

## 第 2 组：MCP
已核实**零实现**（bundled_skills 全无 mcp 踪迹）。按你拍板的"作 omni_body action 接入"方案需独立设计轮次（JSON-RPC stdio 客户端 + 服务配置存储 + 风险分级 + 确认门），本批不含，下轮实施。

测试：新增注入契约测试 4 项（假网关取数/可见降级/开关/默认开）；受影响套件 130+ 项全绿；镜像一致性通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)