### PR TITLE
fix: 全仓审计三批修复——生命 P0、MCP 死锁、更新器四连环、便携版、通信崩溃恢复链

### DIFF
--- a/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/.tiangong-generated-source.json
@@ -1,8 +1,8 @@
 {
-  "file_count": 148,
+  "file_count": 149,
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
+  "tree_sha256": "825c485d88dd541e593eb1532e6ee57c07f7a75f459a7a8cbd3dde0ee0d96d9d",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/model_adapters/core.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/model_adapters/core.py
@@ -129,7 +129,7 @@ def _omni_parameters_schema(strict: bool = False) -> Dict[str, Any]:
     schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search。优先直接调用生产 action。"},
+            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search/mcp.servers.list/mcp.tools.list/mcp.tool.call。优先直接调用生产 action。"},
             "target": {"type": "string", "description": "主目标：文件路径、URL、对象ID、输出路径或空字符串。"},
             "args": {
                 "type": "object",
@@ -223,6 +223,7 @@ def _tool_description() -> str:
         "搜索: browser.search_web(网页搜索)/web.search/http.get(读URL)/browser.open.\n"
         "质检交付: qc.*(质量检查)/deliverable.package(交付打包).\n"
         "系统: life.body.state.query/life.activity.query/system.capabilities/system.health/rollback.list/rollback.apply.\n"
+        "扩展: mcp.servers.list(列出用户配置的 MCP 服务器)/mcp.tools.list(列出某服务器的工具)/mcp.tool.call(调用 MCP 工具，A3 需用户确认；服务器只能引用用户已配置的名字，不可自造命令)。\n"
         "受托管小说能力采用最小暴露：通用工具说明不公布其动作名。只有用户明确要求全书/长期多章工程或续作已有托管项目，并且模型实际读取对应受托管 Skill 后，才按该 Skill 公布的动作执行。单章、少量章节、一次性协作资料包不得升级为整书项目。\n"
         "技能选择有双通道：系统已提供 active/related Skill 时直接读取该 Skill；没有匹配且任务需要专用流程时，模型可调用 skill.route 再 skill.get/skill.read。选定后以具体 Skill 的作用域和工作流为准，通用动作说明不得覆盖它。\n"
     )

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/mcp_client.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/mcp_client.py
@@ -1,0 +1,443 @@
+"""MCP (Model Context Protocol) client for omni_body actions.
+
+v1 设计（2026-08-22，"作 omni_body action 接入"方案）：
+
+- **安全边界**：服务器进程只能来自用户管理的
+  ``~/.tiangong/v3/mcp_servers.json``——模型只能引用已配置的服务器名，
+  绝不能自造命令行。配置文件是唯一的 spawn 授权面。
+- **权限链全复用**：mcp.tool.call 注册为 A3，走网关既有确认链；
+  mcp.servers.list / mcp.tools.list 为 A0 只读。
+- **进程生命周期**：每次调用独立 spawn → initialize → 请求 → close。
+  无僵尸进程、无陈旧会话、无并发争用；代价是每次约百毫秒启动，
+  桌面场景可接受。持久会话留作后续。stdout/stderr 各有独立读线程
+  （stderr 持续消费防止服务器日志撑爆管道缓冲导致死锁，只保留尾部
+  用于诊断）；超时/失败清理时按进程树收割（Windows npx/uvx 的 .cmd
+  shim 之下还有真实孙进程）。
+- **传输**：JSON-RPC 2.0 over stdio，按行分隔（MCP stdio 传输）。
+- **资源上限**：默认 30s 超时 / 256KB 输出上限 / 512 行读取上限，
+  均可被 args 有限度覆盖；子进程环境做白名单最小化继承。
+
+配置格式（用户手写，带 ``mcp.servers.list`` 可视化校验）::
+
+    {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/root"],
+          "env": {"NODE_OPTIONS": "--enable-source-maps"},
+          "enabled": true
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROTOCOL_VERSION = "2024-11-05"
+CLIENT_INFO = {"name": "tiangong-omni-body", "version": "3.5"}
+
+CONFIG_PATH = Path.home() / ".tiangong" / "v3" / "mcp_servers.json"
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 120_000
+MAX_OUTPUT_BYTES = 256 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+# stderr 尾部诊断缓冲与 stdout 读线程的生产侧上限（防失控服务器把
+# _lines 队列灌成无界内存）。
+_STDERR_TAIL_BYTES = 4096
+_MAX_QUEUED_LINES = 100_000
+
+# 子进程环境白名单：Windows 进程启动所需的最小集合 + PATH（npx/node/
+# uvx 常见发行方式需要）。绝不整份继承宿主环境（防泄漏宿主凭据变量）。
+_INHERIT_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "ComSpec", "PATHEXT", "windir", "OS",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+    "PATH", "TEMP", "TMP", "USERPROFILE", "HOME",
+    "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "PROGRAMDATA", "HOMEDRIVE", "HOMEPATH",
+)
+
+
+class McpClientError(RuntimeError):
+    """MCP 调用失败（配置缺失/进程失败/协议错误/超时）。"""
+
+    def __init__(self, code: str, detail: str = ""):
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def load_server_config(config_path: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """读取并校验服务器配置；文件缺失返回空表（未配置≠错误）。"""
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        raise McpClientError("mcp.config.invalid", str(exc)) from exc
+    servers = data.get("servers") if isinstance(data, dict) else None
+    if servers is None:
+        return {}
+    if not isinstance(servers, dict):
+        raise McpClientError("mcp.config.invalid", "servers must be an object")
+    clean: Dict[str, Dict[str, Any]] = {}
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or "").strip()
+        if not command:
+            continue
+        args = [str(item) for item in raw.get("args") or [] if str(item).strip()]
+        env = {
+            str(key): str(value)
+            for key, value in (raw.get("env") or {}).items()
+            if str(key).strip()
+        } if isinstance(raw.get("env"), dict) else {}
+        clean[str(name).strip()] = {
+            "command": command,
+            "args": args,
+            "env": env,
+            "enabled": raw.get("enabled") is not False,
+        }
+    return clean
+
+
+def list_servers() -> List[Dict[str, Any]]:
+    """已配置服务器的只读清单（不含 env 值，防凭据泄漏给模型）。"""
+    rows = []
+    for name, cfg in sorted(load_server_config().items()):
+        rows.append({
+            "server": name,
+            "enabled": bool(cfg["enabled"]),
+            "command": cfg["command"],
+            "args": cfg["args"],
+            "env_keys": sorted(cfg["env"].keys()),
+            "config_path": str(CONFIG_PATH),
+        })
+    return rows
+
+
+def _resolve_server(server: str) -> Dict[str, Any]:
+    name = str(server or "").strip()
+    if not name:
+        raise McpClientError("mcp.server.required", "target or args.server is required")
+    config = load_server_config()
+    cfg = config.get(name)
+    if cfg is None:
+        raise McpClientError(
+            "mcp.server.unknown",
+            f"'{name}' is not configured; known: {sorted(config.keys())}",
+        )
+    if not cfg["enabled"]:
+        raise McpClientError("mcp.server.disabled", name)
+    return cfg
+
+
+def _safe_env(extra: Dict[str, str]) -> Dict[str, str]:
+    env = {key: os.environ[key] for key in _INHERIT_ENV_KEYS if os.environ.get(key)}
+    env.update(extra)
+    return env
+
+
+class _ServerProcess:
+    """一个 MCP 服务器子进程的完整生命周期（行分隔 JSON-RPC）。"""
+
+    def __init__(self, cfg: Dict[str, Any], timeout_ms: int):
+        self.timeout_ms = max(1_000, min(int(timeout_ms), MAX_TIMEOUT_MS))
+        # Windows 下 npx/uvx 实为 .cmd  shim，CreateProcess 只认可执行
+        # 本体——先经 PATHEXT 解析成真实路径，否则配置里的 "npx" 会
+        # 直接 FileNotFoundError。解析失败即干净报错，不落到进程层。
+        command = shutil.which(cfg["command"])
+        if command is None:
+            raise McpClientError(
+                "mcp.server.command_not_found",
+                f"'{cfg['command']}' is not on PATH",
+            )
+        # POSIX 下放进独立进程组，超时清理才能整组收割（与 Windows 的
+        # taskkill /T 对应）。
+        try:
+            self._proc = subprocess.Popen(
+                [command, *cfg["args"]],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_safe_env(cfg["env"]),
+                cwd=str(Path.home()),
+                # 桌面冻结应用内 spawn 控制台进程必须隐窗，否则每次调用
+                # 都会闪一个黑色控制台（与本仓 sandbox_runtime 同款约定）。
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+        except OSError as exc:
+            raise McpClientError("mcp.server.spawn_failed", str(exc)) from exc
+        self._lines: "queue.Queue[bytes | None]" = queue.Queue()
+        self._stderr_tail = b""
+        self._stdout_flood = False
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # stderr 必须有独立消费者：stdio MCP 服务器（npx 安装日志、node
+        # 警告）普遍往 stderr 打日志，PIPE 无人读时写满管道缓冲（Windows
+        # 约 64KB）即阻塞服务器进程，表现为首次调用就超时。
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+        self._next_id = 0
+
+    def _read_loop(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for raw in self._proc.stdout:
+                if self._lines.qsize() >= _MAX_QUEUED_LINES:
+                    # 消费侧上限（512 行无响应即 flood）远小于此；到这里的
+                    # 只可能是失控服务器，停止排队防止内存无界增长。
+                    self._stdout_flood = True
+                    break
+                self._lines.put(raw)
+                if len(raw) > MAX_LINE_BYTES:
+                    break
+        except Exception:
+            pass
+        finally:
+            self._lines.put(None)
+
+    def _stderr_loop(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while True:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except Exception:
+            pass
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if len(data) > MAX_LINE_BYTES:
+            raise McpClientError("mcp.request.too_large", str(len(data)))
+        try:
+            self._proc.stdin.write(data + b"\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # 服务器已退出（stdin 断裂）时转成结构化错误，避免裸
+            # BrokenPipeError 逃出 mcp.* 错误码体系。
+            raise McpClientError("mcp.server.exited", f"stdin broken: {exc}") from None
+
+    def _recv_response(self, request_id: int) -> Dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_ms / 1000
+        received = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms")
+            try:
+                raw = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms") from None
+            if raw is None:
+                # stdout EOF：诊断信息直接取 stderr 读线程的尾部缓冲。
+                # 此处绝不能同步 read() stderr——服务器已死但其孙进程
+                # （npx shim 的 worker）仍持有写端时该读永不返回，
+                # timeout_ms 保护会被整个架空。
+                if self._stdout_flood:
+                    raise McpClientError(
+                        "mcp.protocol.flood",
+                        f"server produced >{_MAX_QUEUED_LINES} queued stdout lines",
+                    )
+                detail = self._stderr_tail.decode("utf-8", errors="replace").strip()[-400:]
+                raise McpClientError("mcp.server.exited", detail)
+            received += 1
+            if received > 512:
+                raise McpClientError("mcp.protocol.flood", ">512 lines without response")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except Exception:
+                continue  # 服务器 banner/日志行，跳过
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def request(self, method: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        response = self._recv_response(request_id)
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            raise McpClientError("mcp.rpc.error", f"{err.get('code')}: {err.get('message')}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise McpClientError("mcp.protocol.invalid", "result is not an object")
+        return result
+
+    def notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def handshake(self) -> Dict[str, Any]:
+        info = self.request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": CLIENT_INFO,
+        })
+        self.notify("notifications/initialized")
+        return info
+
+    def _kill_tree(self) -> None:
+        """按进程树收割：Windows 的 .cmd shim 之下还有真实孙进程。"""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(self._proc.pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+                return
+            except Exception:
+                pass
+        else:
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin is not None and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=3)
+            return
+        except Exception:
+            pass
+        self._kill_tree()
+        # kill 后仍要 wait 收尸，避免句柄/僵尸泄漏。
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _connect(server: str, timeout_ms: int) -> tuple[Dict[str, Any], _ServerProcess]:
+    cfg = _resolve_server(server)
+    proc: _ServerProcess | None = None
+    try:
+        proc = _ServerProcess(cfg, timeout_ms)
+        info = proc.handshake()
+        return info, proc
+    except Exception:
+        if proc is not None:
+            proc.close()
+        raise
+
+
+def list_tools(server: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dict[str, Any]:
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/list", {})
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise McpClientError("mcp.protocol.invalid", "tools is not a list")
+        # 输出上限：整体序列化超预算即留名占位并停止——放不下就丢，
+        # 绝不把超预算的完整工具（大 inputSchema 可达数 MB）放大进
+        # 模型上下文与审计记录。
+        trimmed: List[Dict[str, Any]] = []
+        budget = MAX_OUTPUT_BYTES
+        truncated = False
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            row = dict(tool)
+            desc = str(row.get("description") or "")
+            if len(desc.encode("utf-8")) > 4096:
+                row["description"] = desc[:2048] + "…"
+            size = len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
+            if size > budget:
+                trimmed.append({"name": str(row.get("name") or ""), "_truncated": True})
+                truncated = True
+                break
+            budget -= size
+            trimmed.append(row)
+        return {
+            "server": server,
+            "server_info": info.get("serverInfo") or {},
+            "tools": trimmed,
+            "truncated": truncated,
+        }
+    finally:
+        proc.close()
+
+
+def call_tool(
+    server: str,
+    tool: str,
+    arguments: Dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    tool_name = str(tool or "").strip()
+    if not tool_name:
+        raise McpClientError("mcp.tool.required", "args.tool is required")
+    if not isinstance(arguments or {}, dict):
+        raise McpClientError("mcp.arguments.invalid", "args.arguments must be an object")
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/call", {"name": tool_name, "arguments": dict(arguments or {})})
+        content = result.get("content")
+        texts: List[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+        joined = "\n".join(texts)
+        encoded = joined.encode("utf-8")
+        truncated = len(encoded) > MAX_OUTPUT_BYTES
+        if truncated:
+            joined = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
+        return {
+            "server": server,
+            "tool": tool_name,
+            "is_error": bool(result.get("isError")),
+            "text": joined,
+            "truncated": truncated,
+            "structured": result.get("structuredContent")
+            if isinstance(result.get("structuredContent"), dict)
+            else None,
+        }
+    finally:
+        proc.close()
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DEFAULT_TIMEOUT_MS",
+    "McpClientError",
+    "call_tool",
+    "list_servers",
+    "list_tools",
+    "load_server_config",
+]

--- a/app/backend/tiangong-backend/_internal/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/_internal/omni_body_skill/tools/pro_apps_v34.py
@@ -70,6 +70,10 @@ PRO_APP_ACTIONS: Dict[str, Dict[str, Any]] = {
     "docker.compose.config": {"risk": "A0", "implemented": True, "summary": "Validate/print docker compose config for a compose file."},
 
     "sqlite.query": {"risk": "A2", "implemented": True, "summary": "Run a SQLite query against a workspace database; SELECT by default, writes require confirmed=true."},
+
+    "mcp.servers.list": {"risk": "A0", "implemented": True, "summary": "List user-configured MCP servers from ~/.tiangong/v3/mcp_servers.json (read-only, no env values)."},
+    "mcp.tools.list": {"risk": "A0", "implemented": True, "summary": "Connect to a configured MCP server and list its tools with input schemas."},
+    "mcp.tool.call": {"risk": "A3", "implemented": True, "summary": "Call one tool on a configured MCP server; A3 confirmation chain applies because MCP tools can have arbitrary side effects."},
 }
 
 APP_PROFILES: Dict[str, Dict[str, Any]] = {
@@ -190,6 +194,15 @@ APP_PROFILES: Dict[str, Dict[str, Any]] = {
         "bridge_actions": [],
         "official_path": "stdlib sqlite3 local database query/limited update executor.",
     },
+    "mcp": {
+        "label": "Model Context Protocol",
+        "modules": [],
+        "executables": [],
+        "env": [],
+        "native_actions": ["mcp.servers.list", "mcp.tools.list", "mcp.tool.call"],
+        "bridge_actions": [],
+        "official_path": "MCP stdio servers declared by the user in ~/.tiangong/v3/mcp_servers.json; the model can only reference configured server names and can never invent spawn commands.",
+    },
 }
 
 
@@ -208,6 +221,8 @@ def handle_pro_app_action(runtime: Any, op_id: str, action: str, target: str | N
         return _bridge_pack_create(runtime, target, args)
     if action.startswith("browser.playwright."):
         return _browser_playwright(runtime, action, target, args)
+    if action.startswith("mcp."):
+        return _mcp_action(runtime, action, target, args)
     if action == "microsoft.graph.request_pack.create":
         return _request_pack(runtime, target, args, provider="microsoft_graph")
     if action == "microsoft.office.com.script.create":
@@ -926,6 +941,59 @@ def _docker_action(runtime: Any, action: str, target: str | None, args: Dict[str
         return {"success": False, "message": f"unsupported docker action: {action}"}
     res = subprocess.run(cmd, cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 60)))
     return {"success": res.returncode == 0, "result": {"cmd": cmd[1:], "returncode": res.returncode, "stdout": res.stdout, "stderr": res.stderr}, "evidence": {"path": "docker", "exists": True, "bytes": len(res.stdout)}}
+
+
+def _mcp_action(runtime: Any, action: str, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:
+    """MCP 接入（v1）：服务器只能来自用户配置文件，模型不可自造命令。
+
+    权限链全复用：mcp.tool.call 注册为 A3，由网关确认链把关——任何
+    MCP 工具都可能有任意副作用，宁可多确认一次。
+    """
+    from .mcp_client import (
+        DEFAULT_TIMEOUT_MS,
+        McpClientError,
+        call_tool,
+        list_servers,
+        list_tools,
+    )
+
+    def _timeout_ms() -> int:
+        try:
+            return int(args.get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        except (TypeError, ValueError):
+            return DEFAULT_TIMEOUT_MS
+
+    try:
+        if action == "mcp.servers.list":
+            servers = list_servers()
+            return {
+                "success": True,
+                "result": {
+                    "servers": servers,
+                    "count": len(servers),
+                    "hint": "服务器在 ~/.tiangong/v3/mcp_servers.json 中由用户配置；模型只能引用 server 名。",
+                },
+            }
+        if action == "mcp.tools.list":
+            server = str(target or args.get("server") or "").strip()
+            result = list_tools(server, timeout_ms=_timeout_ms())
+            return {"success": True, "result": result}
+        if action == "mcp.tool.call":
+            server = str(target or args.get("server") or "").strip()
+            tool = str(args.get("tool") or args.get("name") or "").strip()
+            arguments = args.get("arguments") or {}
+            result = call_tool(server, tool, arguments, timeout_ms=_timeout_ms())
+            return {
+                "success": not result.get("is_error"),
+                # 两种失败（isError / McpClientError）保持同一形状：
+                # error + message + result 三键齐全，下游按 error 分类。
+                "error": "" if not result.get("is_error") else "mcp.tool.is_error",
+                "result": result,
+                "message": "MCP tool reported isError" if result.get("is_error") else "",
+            }
+    except McpClientError as exc:
+        return {"success": False, "error": exc.code, "result": None, "message": str(exc)}
+    return {"success": False, "error": "mcp.action.unknown", "result": None, "message": f"unknown mcp action: {action}"}
 
 
 def _sqlite_query(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -1,8 +1,8 @@
 {
-  "file_count": 148,
+  "file_count": 149,
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
+  "tree_sha256": "825c485d88dd541e593eb1532e6ee57c07f7a75f459a7a8cbd3dde0ee0d96d9d",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/model_adapters/core.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/model_adapters/core.py
@@ -129,7 +129,7 @@ def _omni_parameters_schema(strict: bool = False) -> Dict[str, Any]:
     schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search。优先直接调用生产 action。"},
+            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search/mcp.servers.list/mcp.tools.list/mcp.tool.call。优先直接调用生产 action。"},
             "target": {"type": "string", "description": "主目标：文件路径、URL、对象ID、输出路径或空字符串。"},
             "args": {
                 "type": "object",
@@ -223,6 +223,7 @@ def _tool_description() -> str:
         "搜索: browser.search_web(网页搜索)/web.search/http.get(读URL)/browser.open.\n"
         "质检交付: qc.*(质量检查)/deliverable.package(交付打包).\n"
         "系统: life.body.state.query/life.activity.query/system.capabilities/system.health/rollback.list/rollback.apply.\n"
+        "扩展: mcp.servers.list(列出用户配置的 MCP 服务器)/mcp.tools.list(列出某服务器的工具)/mcp.tool.call(调用 MCP 工具，A3 需用户确认；服务器只能引用用户已配置的名字，不可自造命令)。\n"
         "受托管小说能力采用最小暴露：通用工具说明不公布其动作名。只有用户明确要求全书/长期多章工程或续作已有托管项目，并且模型实际读取对应受托管 Skill 后，才按该 Skill 公布的动作执行。单章、少量章节、一次性协作资料包不得升级为整书项目。\n"
         "技能选择有双通道：系统已提供 active/related Skill 时直接读取该 Skill；没有匹配且任务需要专用流程时，模型可调用 skill.route 再 skill.get/skill.read。选定后以具体 Skill 的作用域和工作流为准，通用动作说明不得覆盖它。\n"
     )

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/mcp_client.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/mcp_client.py
@@ -1,0 +1,443 @@
+"""MCP (Model Context Protocol) client for omni_body actions.
+
+v1 设计（2026-08-22，"作 omni_body action 接入"方案）：
+
+- **安全边界**：服务器进程只能来自用户管理的
+  ``~/.tiangong/v3/mcp_servers.json``——模型只能引用已配置的服务器名，
+  绝不能自造命令行。配置文件是唯一的 spawn 授权面。
+- **权限链全复用**：mcp.tool.call 注册为 A3，走网关既有确认链；
+  mcp.servers.list / mcp.tools.list 为 A0 只读。
+- **进程生命周期**：每次调用独立 spawn → initialize → 请求 → close。
+  无僵尸进程、无陈旧会话、无并发争用；代价是每次约百毫秒启动，
+  桌面场景可接受。持久会话留作后续。stdout/stderr 各有独立读线程
+  （stderr 持续消费防止服务器日志撑爆管道缓冲导致死锁，只保留尾部
+  用于诊断）；超时/失败清理时按进程树收割（Windows npx/uvx 的 .cmd
+  shim 之下还有真实孙进程）。
+- **传输**：JSON-RPC 2.0 over stdio，按行分隔（MCP stdio 传输）。
+- **资源上限**：默认 30s 超时 / 256KB 输出上限 / 512 行读取上限，
+  均可被 args 有限度覆盖；子进程环境做白名单最小化继承。
+
+配置格式（用户手写，带 ``mcp.servers.list`` 可视化校验）::
+
+    {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/root"],
+          "env": {"NODE_OPTIONS": "--enable-source-maps"},
+          "enabled": true
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROTOCOL_VERSION = "2024-11-05"
+CLIENT_INFO = {"name": "tiangong-omni-body", "version": "3.5"}
+
+CONFIG_PATH = Path.home() / ".tiangong" / "v3" / "mcp_servers.json"
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 120_000
+MAX_OUTPUT_BYTES = 256 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+# stderr 尾部诊断缓冲与 stdout 读线程的生产侧上限（防失控服务器把
+# _lines 队列灌成无界内存）。
+_STDERR_TAIL_BYTES = 4096
+_MAX_QUEUED_LINES = 100_000
+
+# 子进程环境白名单：Windows 进程启动所需的最小集合 + PATH（npx/node/
+# uvx 常见发行方式需要）。绝不整份继承宿主环境（防泄漏宿主凭据变量）。
+_INHERIT_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "ComSpec", "PATHEXT", "windir", "OS",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+    "PATH", "TEMP", "TMP", "USERPROFILE", "HOME",
+    "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "PROGRAMDATA", "HOMEDRIVE", "HOMEPATH",
+)
+
+
+class McpClientError(RuntimeError):
+    """MCP 调用失败（配置缺失/进程失败/协议错误/超时）。"""
+
+    def __init__(self, code: str, detail: str = ""):
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def load_server_config(config_path: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """读取并校验服务器配置；文件缺失返回空表（未配置≠错误）。"""
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        raise McpClientError("mcp.config.invalid", str(exc)) from exc
+    servers = data.get("servers") if isinstance(data, dict) else None
+    if servers is None:
+        return {}
+    if not isinstance(servers, dict):
+        raise McpClientError("mcp.config.invalid", "servers must be an object")
+    clean: Dict[str, Dict[str, Any]] = {}
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or "").strip()
+        if not command:
+            continue
+        args = [str(item) for item in raw.get("args") or [] if str(item).strip()]
+        env = {
+            str(key): str(value)
+            for key, value in (raw.get("env") or {}).items()
+            if str(key).strip()
+        } if isinstance(raw.get("env"), dict) else {}
+        clean[str(name).strip()] = {
+            "command": command,
+            "args": args,
+            "env": env,
+            "enabled": raw.get("enabled") is not False,
+        }
+    return clean
+
+
+def list_servers() -> List[Dict[str, Any]]:
+    """已配置服务器的只读清单（不含 env 值，防凭据泄漏给模型）。"""
+    rows = []
+    for name, cfg in sorted(load_server_config().items()):
+        rows.append({
+            "server": name,
+            "enabled": bool(cfg["enabled"]),
+            "command": cfg["command"],
+            "args": cfg["args"],
+            "env_keys": sorted(cfg["env"].keys()),
+            "config_path": str(CONFIG_PATH),
+        })
+    return rows
+
+
+def _resolve_server(server: str) -> Dict[str, Any]:
+    name = str(server or "").strip()
+    if not name:
+        raise McpClientError("mcp.server.required", "target or args.server is required")
+    config = load_server_config()
+    cfg = config.get(name)
+    if cfg is None:
+        raise McpClientError(
+            "mcp.server.unknown",
+            f"'{name}' is not configured; known: {sorted(config.keys())}",
+        )
+    if not cfg["enabled"]:
+        raise McpClientError("mcp.server.disabled", name)
+    return cfg
+
+
+def _safe_env(extra: Dict[str, str]) -> Dict[str, str]:
+    env = {key: os.environ[key] for key in _INHERIT_ENV_KEYS if os.environ.get(key)}
+    env.update(extra)
+    return env
+
+
+class _ServerProcess:
+    """一个 MCP 服务器子进程的完整生命周期（行分隔 JSON-RPC）。"""
+
+    def __init__(self, cfg: Dict[str, Any], timeout_ms: int):
+        self.timeout_ms = max(1_000, min(int(timeout_ms), MAX_TIMEOUT_MS))
+        # Windows 下 npx/uvx 实为 .cmd  shim，CreateProcess 只认可执行
+        # 本体——先经 PATHEXT 解析成真实路径，否则配置里的 "npx" 会
+        # 直接 FileNotFoundError。解析失败即干净报错，不落到进程层。
+        command = shutil.which(cfg["command"])
+        if command is None:
+            raise McpClientError(
+                "mcp.server.command_not_found",
+                f"'{cfg['command']}' is not on PATH",
+            )
+        # POSIX 下放进独立进程组，超时清理才能整组收割（与 Windows 的
+        # taskkill /T 对应）。
+        try:
+            self._proc = subprocess.Popen(
+                [command, *cfg["args"]],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_safe_env(cfg["env"]),
+                cwd=str(Path.home()),
+                # 桌面冻结应用内 spawn 控制台进程必须隐窗，否则每次调用
+                # 都会闪一个黑色控制台（与本仓 sandbox_runtime 同款约定）。
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+        except OSError as exc:
+            raise McpClientError("mcp.server.spawn_failed", str(exc)) from exc
+        self._lines: "queue.Queue[bytes | None]" = queue.Queue()
+        self._stderr_tail = b""
+        self._stdout_flood = False
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # stderr 必须有独立消费者：stdio MCP 服务器（npx 安装日志、node
+        # 警告）普遍往 stderr 打日志，PIPE 无人读时写满管道缓冲（Windows
+        # 约 64KB）即阻塞服务器进程，表现为首次调用就超时。
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+        self._next_id = 0
+
+    def _read_loop(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for raw in self._proc.stdout:
+                if self._lines.qsize() >= _MAX_QUEUED_LINES:
+                    # 消费侧上限（512 行无响应即 flood）远小于此；到这里的
+                    # 只可能是失控服务器，停止排队防止内存无界增长。
+                    self._stdout_flood = True
+                    break
+                self._lines.put(raw)
+                if len(raw) > MAX_LINE_BYTES:
+                    break
+        except Exception:
+            pass
+        finally:
+            self._lines.put(None)
+
+    def _stderr_loop(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while True:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except Exception:
+            pass
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if len(data) > MAX_LINE_BYTES:
+            raise McpClientError("mcp.request.too_large", str(len(data)))
+        try:
+            self._proc.stdin.write(data + b"\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # 服务器已退出（stdin 断裂）时转成结构化错误，避免裸
+            # BrokenPipeError 逃出 mcp.* 错误码体系。
+            raise McpClientError("mcp.server.exited", f"stdin broken: {exc}") from None
+
+    def _recv_response(self, request_id: int) -> Dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_ms / 1000
+        received = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms")
+            try:
+                raw = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms") from None
+            if raw is None:
+                # stdout EOF：诊断信息直接取 stderr 读线程的尾部缓冲。
+                # 此处绝不能同步 read() stderr——服务器已死但其孙进程
+                # （npx shim 的 worker）仍持有写端时该读永不返回，
+                # timeout_ms 保护会被整个架空。
+                if self._stdout_flood:
+                    raise McpClientError(
+                        "mcp.protocol.flood",
+                        f"server produced >{_MAX_QUEUED_LINES} queued stdout lines",
+                    )
+                detail = self._stderr_tail.decode("utf-8", errors="replace").strip()[-400:]
+                raise McpClientError("mcp.server.exited", detail)
+            received += 1
+            if received > 512:
+                raise McpClientError("mcp.protocol.flood", ">512 lines without response")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except Exception:
+                continue  # 服务器 banner/日志行，跳过
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def request(self, method: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        response = self._recv_response(request_id)
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            raise McpClientError("mcp.rpc.error", f"{err.get('code')}: {err.get('message')}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise McpClientError("mcp.protocol.invalid", "result is not an object")
+        return result
+
+    def notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def handshake(self) -> Dict[str, Any]:
+        info = self.request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": CLIENT_INFO,
+        })
+        self.notify("notifications/initialized")
+        return info
+
+    def _kill_tree(self) -> None:
+        """按进程树收割：Windows 的 .cmd shim 之下还有真实孙进程。"""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(self._proc.pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+                return
+            except Exception:
+                pass
+        else:
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin is not None and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=3)
+            return
+        except Exception:
+            pass
+        self._kill_tree()
+        # kill 后仍要 wait 收尸，避免句柄/僵尸泄漏。
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _connect(server: str, timeout_ms: int) -> tuple[Dict[str, Any], _ServerProcess]:
+    cfg = _resolve_server(server)
+    proc: _ServerProcess | None = None
+    try:
+        proc = _ServerProcess(cfg, timeout_ms)
+        info = proc.handshake()
+        return info, proc
+    except Exception:
+        if proc is not None:
+            proc.close()
+        raise
+
+
+def list_tools(server: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dict[str, Any]:
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/list", {})
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise McpClientError("mcp.protocol.invalid", "tools is not a list")
+        # 输出上限：整体序列化超预算即留名占位并停止——放不下就丢，
+        # 绝不把超预算的完整工具（大 inputSchema 可达数 MB）放大进
+        # 模型上下文与审计记录。
+        trimmed: List[Dict[str, Any]] = []
+        budget = MAX_OUTPUT_BYTES
+        truncated = False
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            row = dict(tool)
+            desc = str(row.get("description") or "")
+            if len(desc.encode("utf-8")) > 4096:
+                row["description"] = desc[:2048] + "…"
+            size = len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
+            if size > budget:
+                trimmed.append({"name": str(row.get("name") or ""), "_truncated": True})
+                truncated = True
+                break
+            budget -= size
+            trimmed.append(row)
+        return {
+            "server": server,
+            "server_info": info.get("serverInfo") or {},
+            "tools": trimmed,
+            "truncated": truncated,
+        }
+    finally:
+        proc.close()
+
+
+def call_tool(
+    server: str,
+    tool: str,
+    arguments: Dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    tool_name = str(tool or "").strip()
+    if not tool_name:
+        raise McpClientError("mcp.tool.required", "args.tool is required")
+    if not isinstance(arguments or {}, dict):
+        raise McpClientError("mcp.arguments.invalid", "args.arguments must be an object")
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/call", {"name": tool_name, "arguments": dict(arguments or {})})
+        content = result.get("content")
+        texts: List[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+        joined = "\n".join(texts)
+        encoded = joined.encode("utf-8")
+        truncated = len(encoded) > MAX_OUTPUT_BYTES
+        if truncated:
+            joined = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
+        return {
+            "server": server,
+            "tool": tool_name,
+            "is_error": bool(result.get("isError")),
+            "text": joined,
+            "truncated": truncated,
+            "structured": result.get("structuredContent")
+            if isinstance(result.get("structuredContent"), dict)
+            else None,
+        }
+    finally:
+        proc.close()
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DEFAULT_TIMEOUT_MS",
+    "McpClientError",
+    "call_tool",
+    "list_servers",
+    "list_tools",
+    "load_server_config",
+]

--- a/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/_internal/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
@@ -70,6 +70,10 @@ PRO_APP_ACTIONS: Dict[str, Dict[str, Any]] = {
     "docker.compose.config": {"risk": "A0", "implemented": True, "summary": "Validate/print docker compose config for a compose file."},
 
     "sqlite.query": {"risk": "A2", "implemented": True, "summary": "Run a SQLite query against a workspace database; SELECT by default, writes require confirmed=true."},
+
+    "mcp.servers.list": {"risk": "A0", "implemented": True, "summary": "List user-configured MCP servers from ~/.tiangong/v3/mcp_servers.json (read-only, no env values)."},
+    "mcp.tools.list": {"risk": "A0", "implemented": True, "summary": "Connect to a configured MCP server and list its tools with input schemas."},
+    "mcp.tool.call": {"risk": "A3", "implemented": True, "summary": "Call one tool on a configured MCP server; A3 confirmation chain applies because MCP tools can have arbitrary side effects."},
 }
 
 APP_PROFILES: Dict[str, Dict[str, Any]] = {
@@ -190,6 +194,15 @@ APP_PROFILES: Dict[str, Dict[str, Any]] = {
         "bridge_actions": [],
         "official_path": "stdlib sqlite3 local database query/limited update executor.",
     },
+    "mcp": {
+        "label": "Model Context Protocol",
+        "modules": [],
+        "executables": [],
+        "env": [],
+        "native_actions": ["mcp.servers.list", "mcp.tools.list", "mcp.tool.call"],
+        "bridge_actions": [],
+        "official_path": "MCP stdio servers declared by the user in ~/.tiangong/v3/mcp_servers.json; the model can only reference configured server names and can never invent spawn commands.",
+    },
 }
 
 
@@ -208,6 +221,8 @@ def handle_pro_app_action(runtime: Any, op_id: str, action: str, target: str | N
         return _bridge_pack_create(runtime, target, args)
     if action.startswith("browser.playwright."):
         return _browser_playwright(runtime, action, target, args)
+    if action.startswith("mcp."):
+        return _mcp_action(runtime, action, target, args)
     if action == "microsoft.graph.request_pack.create":
         return _request_pack(runtime, target, args, provider="microsoft_graph")
     if action == "microsoft.office.com.script.create":
@@ -926,6 +941,59 @@ def _docker_action(runtime: Any, action: str, target: str | None, args: Dict[str
         return {"success": False, "message": f"unsupported docker action: {action}"}
     res = subprocess.run(cmd, cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 60)))
     return {"success": res.returncode == 0, "result": {"cmd": cmd[1:], "returncode": res.returncode, "stdout": res.stdout, "stderr": res.stderr}, "evidence": {"path": "docker", "exists": True, "bytes": len(res.stdout)}}
+
+
+def _mcp_action(runtime: Any, action: str, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:
+    """MCP 接入（v1）：服务器只能来自用户配置文件，模型不可自造命令。
+
+    权限链全复用：mcp.tool.call 注册为 A3，由网关确认链把关——任何
+    MCP 工具都可能有任意副作用，宁可多确认一次。
+    """
+    from .mcp_client import (
+        DEFAULT_TIMEOUT_MS,
+        McpClientError,
+        call_tool,
+        list_servers,
+        list_tools,
+    )
+
+    def _timeout_ms() -> int:
+        try:
+            return int(args.get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        except (TypeError, ValueError):
+            return DEFAULT_TIMEOUT_MS
+
+    try:
+        if action == "mcp.servers.list":
+            servers = list_servers()
+            return {
+                "success": True,
+                "result": {
+                    "servers": servers,
+                    "count": len(servers),
+                    "hint": "服务器在 ~/.tiangong/v3/mcp_servers.json 中由用户配置；模型只能引用 server 名。",
+                },
+            }
+        if action == "mcp.tools.list":
+            server = str(target or args.get("server") or "").strip()
+            result = list_tools(server, timeout_ms=_timeout_ms())
+            return {"success": True, "result": result}
+        if action == "mcp.tool.call":
+            server = str(target or args.get("server") or "").strip()
+            tool = str(args.get("tool") or args.get("name") or "").strip()
+            arguments = args.get("arguments") or {}
+            result = call_tool(server, tool, arguments, timeout_ms=_timeout_ms())
+            return {
+                "success": not result.get("is_error"),
+                # 两种失败（isError / McpClientError）保持同一形状：
+                # error + message + result 三键齐全，下游按 error 分类。
+                "error": "" if not result.get("is_error") else "mcp.tool.is_error",
+                "result": result,
+                "message": "MCP tool reported isError" if result.get("is_error") else "",
+            }
+    except McpClientError as exc:
+        return {"success": False, "error": exc.code, "result": None, "message": str(exc)}
+    return {"success": False, "error": "mcp.action.unknown", "result": None, "message": f"unknown mcp action: {action}"}
 
 
 def _sqlite_query(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/omni_body_skill/.tiangong-generated-source.json
@@ -1,8 +1,8 @@
 {
-  "file_count": 148,
+  "file_count": 149,
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
+  "tree_sha256": "825c485d88dd541e593eb1532e6ee57c07f7a75f459a7a8cbd3dde0ee0d96d9d",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/omni_body_skill/model_adapters/core.py
+++ b/app/backend/tiangong-backend/omni_body_skill/model_adapters/core.py
@@ -129,7 +129,7 @@ def _omni_parameters_schema(strict: bool = False) -> Dict[str, Any]:
     schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search。优先直接调用生产 action。"},
+            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search/mcp.servers.list/mcp.tools.list/mcp.tool.call。优先直接调用生产 action。"},
             "target": {"type": "string", "description": "主目标：文件路径、URL、对象ID、输出路径或空字符串。"},
             "args": {
                 "type": "object",
@@ -223,6 +223,7 @@ def _tool_description() -> str:
         "搜索: browser.search_web(网页搜索)/web.search/http.get(读URL)/browser.open.\n"
         "质检交付: qc.*(质量检查)/deliverable.package(交付打包).\n"
         "系统: life.body.state.query/life.activity.query/system.capabilities/system.health/rollback.list/rollback.apply.\n"
+        "扩展: mcp.servers.list(列出用户配置的 MCP 服务器)/mcp.tools.list(列出某服务器的工具)/mcp.tool.call(调用 MCP 工具，A3 需用户确认；服务器只能引用用户已配置的名字，不可自造命令)。\n"
         "受托管小说能力采用最小暴露：通用工具说明不公布其动作名。只有用户明确要求全书/长期多章工程或续作已有托管项目，并且模型实际读取对应受托管 Skill 后，才按该 Skill 公布的动作执行。单章、少量章节、一次性协作资料包不得升级为整书项目。\n"
         "技能选择有双通道：系统已提供 active/related Skill 时直接读取该 Skill；没有匹配且任务需要专用流程时，模型可调用 skill.route 再 skill.get/skill.read。选定后以具体 Skill 的作用域和工作流为准，通用动作说明不得覆盖它。\n"
     )

--- a/app/backend/tiangong-backend/omni_body_skill/tools/mcp_client.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/mcp_client.py
@@ -1,0 +1,443 @@
+"""MCP (Model Context Protocol) client for omni_body actions.
+
+v1 设计（2026-08-22，"作 omni_body action 接入"方案）：
+
+- **安全边界**：服务器进程只能来自用户管理的
+  ``~/.tiangong/v3/mcp_servers.json``——模型只能引用已配置的服务器名，
+  绝不能自造命令行。配置文件是唯一的 spawn 授权面。
+- **权限链全复用**：mcp.tool.call 注册为 A3，走网关既有确认链；
+  mcp.servers.list / mcp.tools.list 为 A0 只读。
+- **进程生命周期**：每次调用独立 spawn → initialize → 请求 → close。
+  无僵尸进程、无陈旧会话、无并发争用；代价是每次约百毫秒启动，
+  桌面场景可接受。持久会话留作后续。stdout/stderr 各有独立读线程
+  （stderr 持续消费防止服务器日志撑爆管道缓冲导致死锁，只保留尾部
+  用于诊断）；超时/失败清理时按进程树收割（Windows npx/uvx 的 .cmd
+  shim 之下还有真实孙进程）。
+- **传输**：JSON-RPC 2.0 over stdio，按行分隔（MCP stdio 传输）。
+- **资源上限**：默认 30s 超时 / 256KB 输出上限 / 512 行读取上限，
+  均可被 args 有限度覆盖；子进程环境做白名单最小化继承。
+
+配置格式（用户手写，带 ``mcp.servers.list`` 可视化校验）::
+
+    {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/root"],
+          "env": {"NODE_OPTIONS": "--enable-source-maps"},
+          "enabled": true
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROTOCOL_VERSION = "2024-11-05"
+CLIENT_INFO = {"name": "tiangong-omni-body", "version": "3.5"}
+
+CONFIG_PATH = Path.home() / ".tiangong" / "v3" / "mcp_servers.json"
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 120_000
+MAX_OUTPUT_BYTES = 256 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+# stderr 尾部诊断缓冲与 stdout 读线程的生产侧上限（防失控服务器把
+# _lines 队列灌成无界内存）。
+_STDERR_TAIL_BYTES = 4096
+_MAX_QUEUED_LINES = 100_000
+
+# 子进程环境白名单：Windows 进程启动所需的最小集合 + PATH（npx/node/
+# uvx 常见发行方式需要）。绝不整份继承宿主环境（防泄漏宿主凭据变量）。
+_INHERIT_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "ComSpec", "PATHEXT", "windir", "OS",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+    "PATH", "TEMP", "TMP", "USERPROFILE", "HOME",
+    "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "PROGRAMDATA", "HOMEDRIVE", "HOMEPATH",
+)
+
+
+class McpClientError(RuntimeError):
+    """MCP 调用失败（配置缺失/进程失败/协议错误/超时）。"""
+
+    def __init__(self, code: str, detail: str = ""):
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def load_server_config(config_path: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """读取并校验服务器配置；文件缺失返回空表（未配置≠错误）。"""
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        raise McpClientError("mcp.config.invalid", str(exc)) from exc
+    servers = data.get("servers") if isinstance(data, dict) else None
+    if servers is None:
+        return {}
+    if not isinstance(servers, dict):
+        raise McpClientError("mcp.config.invalid", "servers must be an object")
+    clean: Dict[str, Dict[str, Any]] = {}
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or "").strip()
+        if not command:
+            continue
+        args = [str(item) for item in raw.get("args") or [] if str(item).strip()]
+        env = {
+            str(key): str(value)
+            for key, value in (raw.get("env") or {}).items()
+            if str(key).strip()
+        } if isinstance(raw.get("env"), dict) else {}
+        clean[str(name).strip()] = {
+            "command": command,
+            "args": args,
+            "env": env,
+            "enabled": raw.get("enabled") is not False,
+        }
+    return clean
+
+
+def list_servers() -> List[Dict[str, Any]]:
+    """已配置服务器的只读清单（不含 env 值，防凭据泄漏给模型）。"""
+    rows = []
+    for name, cfg in sorted(load_server_config().items()):
+        rows.append({
+            "server": name,
+            "enabled": bool(cfg["enabled"]),
+            "command": cfg["command"],
+            "args": cfg["args"],
+            "env_keys": sorted(cfg["env"].keys()),
+            "config_path": str(CONFIG_PATH),
+        })
+    return rows
+
+
+def _resolve_server(server: str) -> Dict[str, Any]:
+    name = str(server or "").strip()
+    if not name:
+        raise McpClientError("mcp.server.required", "target or args.server is required")
+    config = load_server_config()
+    cfg = config.get(name)
+    if cfg is None:
+        raise McpClientError(
+            "mcp.server.unknown",
+            f"'{name}' is not configured; known: {sorted(config.keys())}",
+        )
+    if not cfg["enabled"]:
+        raise McpClientError("mcp.server.disabled", name)
+    return cfg
+
+
+def _safe_env(extra: Dict[str, str]) -> Dict[str, str]:
+    env = {key: os.environ[key] for key in _INHERIT_ENV_KEYS if os.environ.get(key)}
+    env.update(extra)
+    return env
+
+
+class _ServerProcess:
+    """一个 MCP 服务器子进程的完整生命周期（行分隔 JSON-RPC）。"""
+
+    def __init__(self, cfg: Dict[str, Any], timeout_ms: int):
+        self.timeout_ms = max(1_000, min(int(timeout_ms), MAX_TIMEOUT_MS))
+        # Windows 下 npx/uvx 实为 .cmd  shim，CreateProcess 只认可执行
+        # 本体——先经 PATHEXT 解析成真实路径，否则配置里的 "npx" 会
+        # 直接 FileNotFoundError。解析失败即干净报错，不落到进程层。
+        command = shutil.which(cfg["command"])
+        if command is None:
+            raise McpClientError(
+                "mcp.server.command_not_found",
+                f"'{cfg['command']}' is not on PATH",
+            )
+        # POSIX 下放进独立进程组，超时清理才能整组收割（与 Windows 的
+        # taskkill /T 对应）。
+        try:
+            self._proc = subprocess.Popen(
+                [command, *cfg["args"]],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_safe_env(cfg["env"]),
+                cwd=str(Path.home()),
+                # 桌面冻结应用内 spawn 控制台进程必须隐窗，否则每次调用
+                # 都会闪一个黑色控制台（与本仓 sandbox_runtime 同款约定）。
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+        except OSError as exc:
+            raise McpClientError("mcp.server.spawn_failed", str(exc)) from exc
+        self._lines: "queue.Queue[bytes | None]" = queue.Queue()
+        self._stderr_tail = b""
+        self._stdout_flood = False
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # stderr 必须有独立消费者：stdio MCP 服务器（npx 安装日志、node
+        # 警告）普遍往 stderr 打日志，PIPE 无人读时写满管道缓冲（Windows
+        # 约 64KB）即阻塞服务器进程，表现为首次调用就超时。
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+        self._next_id = 0
+
+    def _read_loop(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for raw in self._proc.stdout:
+                if self._lines.qsize() >= _MAX_QUEUED_LINES:
+                    # 消费侧上限（512 行无响应即 flood）远小于此；到这里的
+                    # 只可能是失控服务器，停止排队防止内存无界增长。
+                    self._stdout_flood = True
+                    break
+                self._lines.put(raw)
+                if len(raw) > MAX_LINE_BYTES:
+                    break
+        except Exception:
+            pass
+        finally:
+            self._lines.put(None)
+
+    def _stderr_loop(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while True:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except Exception:
+            pass
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if len(data) > MAX_LINE_BYTES:
+            raise McpClientError("mcp.request.too_large", str(len(data)))
+        try:
+            self._proc.stdin.write(data + b"\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # 服务器已退出（stdin 断裂）时转成结构化错误，避免裸
+            # BrokenPipeError 逃出 mcp.* 错误码体系。
+            raise McpClientError("mcp.server.exited", f"stdin broken: {exc}") from None
+
+    def _recv_response(self, request_id: int) -> Dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_ms / 1000
+        received = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms")
+            try:
+                raw = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms") from None
+            if raw is None:
+                # stdout EOF：诊断信息直接取 stderr 读线程的尾部缓冲。
+                # 此处绝不能同步 read() stderr——服务器已死但其孙进程
+                # （npx shim 的 worker）仍持有写端时该读永不返回，
+                # timeout_ms 保护会被整个架空。
+                if self._stdout_flood:
+                    raise McpClientError(
+                        "mcp.protocol.flood",
+                        f"server produced >{_MAX_QUEUED_LINES} queued stdout lines",
+                    )
+                detail = self._stderr_tail.decode("utf-8", errors="replace").strip()[-400:]
+                raise McpClientError("mcp.server.exited", detail)
+            received += 1
+            if received > 512:
+                raise McpClientError("mcp.protocol.flood", ">512 lines without response")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except Exception:
+                continue  # 服务器 banner/日志行，跳过
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def request(self, method: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        response = self._recv_response(request_id)
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            raise McpClientError("mcp.rpc.error", f"{err.get('code')}: {err.get('message')}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise McpClientError("mcp.protocol.invalid", "result is not an object")
+        return result
+
+    def notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def handshake(self) -> Dict[str, Any]:
+        info = self.request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": CLIENT_INFO,
+        })
+        self.notify("notifications/initialized")
+        return info
+
+    def _kill_tree(self) -> None:
+        """按进程树收割：Windows 的 .cmd shim 之下还有真实孙进程。"""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(self._proc.pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+                return
+            except Exception:
+                pass
+        else:
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin is not None and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=3)
+            return
+        except Exception:
+            pass
+        self._kill_tree()
+        # kill 后仍要 wait 收尸，避免句柄/僵尸泄漏。
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _connect(server: str, timeout_ms: int) -> tuple[Dict[str, Any], _ServerProcess]:
+    cfg = _resolve_server(server)
+    proc: _ServerProcess | None = None
+    try:
+        proc = _ServerProcess(cfg, timeout_ms)
+        info = proc.handshake()
+        return info, proc
+    except Exception:
+        if proc is not None:
+            proc.close()
+        raise
+
+
+def list_tools(server: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dict[str, Any]:
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/list", {})
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise McpClientError("mcp.protocol.invalid", "tools is not a list")
+        # 输出上限：整体序列化超预算即留名占位并停止——放不下就丢，
+        # 绝不把超预算的完整工具（大 inputSchema 可达数 MB）放大进
+        # 模型上下文与审计记录。
+        trimmed: List[Dict[str, Any]] = []
+        budget = MAX_OUTPUT_BYTES
+        truncated = False
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            row = dict(tool)
+            desc = str(row.get("description") or "")
+            if len(desc.encode("utf-8")) > 4096:
+                row["description"] = desc[:2048] + "…"
+            size = len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
+            if size > budget:
+                trimmed.append({"name": str(row.get("name") or ""), "_truncated": True})
+                truncated = True
+                break
+            budget -= size
+            trimmed.append(row)
+        return {
+            "server": server,
+            "server_info": info.get("serverInfo") or {},
+            "tools": trimmed,
+            "truncated": truncated,
+        }
+    finally:
+        proc.close()
+
+
+def call_tool(
+    server: str,
+    tool: str,
+    arguments: Dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    tool_name = str(tool or "").strip()
+    if not tool_name:
+        raise McpClientError("mcp.tool.required", "args.tool is required")
+    if not isinstance(arguments or {}, dict):
+        raise McpClientError("mcp.arguments.invalid", "args.arguments must be an object")
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/call", {"name": tool_name, "arguments": dict(arguments or {})})
+        content = result.get("content")
+        texts: List[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+        joined = "\n".join(texts)
+        encoded = joined.encode("utf-8")
+        truncated = len(encoded) > MAX_OUTPUT_BYTES
+        if truncated:
+            joined = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
+        return {
+            "server": server,
+            "tool": tool_name,
+            "is_error": bool(result.get("isError")),
+            "text": joined,
+            "truncated": truncated,
+            "structured": result.get("structuredContent")
+            if isinstance(result.get("structuredContent"), dict)
+            else None,
+        }
+    finally:
+        proc.close()
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DEFAULT_TIMEOUT_MS",
+    "McpClientError",
+    "call_tool",
+    "list_servers",
+    "list_tools",
+    "load_server_config",
+]

--- a/app/backend/tiangong-backend/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/omni_body_skill/tools/pro_apps_v34.py
@@ -70,6 +70,10 @@ PRO_APP_ACTIONS: Dict[str, Dict[str, Any]] = {
     "docker.compose.config": {"risk": "A0", "implemented": True, "summary": "Validate/print docker compose config for a compose file."},
 
     "sqlite.query": {"risk": "A2", "implemented": True, "summary": "Run a SQLite query against a workspace database; SELECT by default, writes require confirmed=true."},
+
+    "mcp.servers.list": {"risk": "A0", "implemented": True, "summary": "List user-configured MCP servers from ~/.tiangong/v3/mcp_servers.json (read-only, no env values)."},
+    "mcp.tools.list": {"risk": "A0", "implemented": True, "summary": "Connect to a configured MCP server and list its tools with input schemas."},
+    "mcp.tool.call": {"risk": "A3", "implemented": True, "summary": "Call one tool on a configured MCP server; A3 confirmation chain applies because MCP tools can have arbitrary side effects."},
 }
 
 APP_PROFILES: Dict[str, Dict[str, Any]] = {
@@ -190,6 +194,15 @@ APP_PROFILES: Dict[str, Dict[str, Any]] = {
         "bridge_actions": [],
         "official_path": "stdlib sqlite3 local database query/limited update executor.",
     },
+    "mcp": {
+        "label": "Model Context Protocol",
+        "modules": [],
+        "executables": [],
+        "env": [],
+        "native_actions": ["mcp.servers.list", "mcp.tools.list", "mcp.tool.call"],
+        "bridge_actions": [],
+        "official_path": "MCP stdio servers declared by the user in ~/.tiangong/v3/mcp_servers.json; the model can only reference configured server names and can never invent spawn commands.",
+    },
 }
 
 
@@ -208,6 +221,8 @@ def handle_pro_app_action(runtime: Any, op_id: str, action: str, target: str | N
         return _bridge_pack_create(runtime, target, args)
     if action.startswith("browser.playwright."):
         return _browser_playwright(runtime, action, target, args)
+    if action.startswith("mcp."):
+        return _mcp_action(runtime, action, target, args)
     if action == "microsoft.graph.request_pack.create":
         return _request_pack(runtime, target, args, provider="microsoft_graph")
     if action == "microsoft.office.com.script.create":
@@ -926,6 +941,59 @@ def _docker_action(runtime: Any, action: str, target: str | None, args: Dict[str
         return {"success": False, "message": f"unsupported docker action: {action}"}
     res = subprocess.run(cmd, cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 60)))
     return {"success": res.returncode == 0, "result": {"cmd": cmd[1:], "returncode": res.returncode, "stdout": res.stdout, "stderr": res.stderr}, "evidence": {"path": "docker", "exists": True, "bytes": len(res.stdout)}}
+
+
+def _mcp_action(runtime: Any, action: str, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:
+    """MCP 接入（v1）：服务器只能来自用户配置文件，模型不可自造命令。
+
+    权限链全复用：mcp.tool.call 注册为 A3，由网关确认链把关——任何
+    MCP 工具都可能有任意副作用，宁可多确认一次。
+    """
+    from .mcp_client import (
+        DEFAULT_TIMEOUT_MS,
+        McpClientError,
+        call_tool,
+        list_servers,
+        list_tools,
+    )
+
+    def _timeout_ms() -> int:
+        try:
+            return int(args.get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        except (TypeError, ValueError):
+            return DEFAULT_TIMEOUT_MS
+
+    try:
+        if action == "mcp.servers.list":
+            servers = list_servers()
+            return {
+                "success": True,
+                "result": {
+                    "servers": servers,
+                    "count": len(servers),
+                    "hint": "服务器在 ~/.tiangong/v3/mcp_servers.json 中由用户配置；模型只能引用 server 名。",
+                },
+            }
+        if action == "mcp.tools.list":
+            server = str(target or args.get("server") or "").strip()
+            result = list_tools(server, timeout_ms=_timeout_ms())
+            return {"success": True, "result": result}
+        if action == "mcp.tool.call":
+            server = str(target or args.get("server") or "").strip()
+            tool = str(args.get("tool") or args.get("name") or "").strip()
+            arguments = args.get("arguments") or {}
+            result = call_tool(server, tool, arguments, timeout_ms=_timeout_ms())
+            return {
+                "success": not result.get("is_error"),
+                # 两种失败（isError / McpClientError）保持同一形状：
+                # error + message + result 三键齐全，下游按 error 分类。
+                "error": "" if not result.get("is_error") else "mcp.tool.is_error",
+                "result": result,
+                "message": "MCP tool reported isError" if result.get("is_error") else "",
+            }
+    except McpClientError as exc:
+        return {"success": False, "error": exc.code, "result": None, "message": str(exc)}
+    return {"success": False, "error": "mcp.action.unknown", "result": None, "message": f"unknown mcp action: {action}"}
 
 
 def _sqlite_query(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/.tiangong-generated-source.json
@@ -1,8 +1,8 @@
 {
-  "file_count": 148,
+  "file_count": 149,
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
+  "tree_sha256": "825c485d88dd541e593eb1532e6ee57c07f7a75f459a7a8cbd3dde0ee0d96d9d",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/model_adapters/core.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/model_adapters/core.py
@@ -129,7 +129,7 @@ def _omni_parameters_schema(strict: bool = False) -> Dict[str, Any]:
     schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search。优先直接调用生产 action。"},
+            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search/mcp.servers.list/mcp.tools.list/mcp.tool.call。优先直接调用生产 action。"},
             "target": {"type": "string", "description": "主目标：文件路径、URL、对象ID、输出路径或空字符串。"},
             "args": {
                 "type": "object",
@@ -223,6 +223,7 @@ def _tool_description() -> str:
         "搜索: browser.search_web(网页搜索)/web.search/http.get(读URL)/browser.open.\n"
         "质检交付: qc.*(质量检查)/deliverable.package(交付打包).\n"
         "系统: life.body.state.query/life.activity.query/system.capabilities/system.health/rollback.list/rollback.apply.\n"
+        "扩展: mcp.servers.list(列出用户配置的 MCP 服务器)/mcp.tools.list(列出某服务器的工具)/mcp.tool.call(调用 MCP 工具，A3 需用户确认；服务器只能引用用户已配置的名字，不可自造命令)。\n"
         "受托管小说能力采用最小暴露：通用工具说明不公布其动作名。只有用户明确要求全书/长期多章工程或续作已有托管项目，并且模型实际读取对应受托管 Skill 后，才按该 Skill 公布的动作执行。单章、少量章节、一次性协作资料包不得升级为整书项目。\n"
         "技能选择有双通道：系统已提供 active/related Skill 时直接读取该 Skill；没有匹配且任务需要专用流程时，模型可调用 skill.route 再 skill.get/skill.read。选定后以具体 Skill 的作用域和工作流为准，通用动作说明不得覆盖它。\n"
     )

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/mcp_client.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/mcp_client.py
@@ -1,0 +1,443 @@
+"""MCP (Model Context Protocol) client for omni_body actions.
+
+v1 设计（2026-08-22，"作 omni_body action 接入"方案）：
+
+- **安全边界**：服务器进程只能来自用户管理的
+  ``~/.tiangong/v3/mcp_servers.json``——模型只能引用已配置的服务器名，
+  绝不能自造命令行。配置文件是唯一的 spawn 授权面。
+- **权限链全复用**：mcp.tool.call 注册为 A3，走网关既有确认链；
+  mcp.servers.list / mcp.tools.list 为 A0 只读。
+- **进程生命周期**：每次调用独立 spawn → initialize → 请求 → close。
+  无僵尸进程、无陈旧会话、无并发争用；代价是每次约百毫秒启动，
+  桌面场景可接受。持久会话留作后续。stdout/stderr 各有独立读线程
+  （stderr 持续消费防止服务器日志撑爆管道缓冲导致死锁，只保留尾部
+  用于诊断）；超时/失败清理时按进程树收割（Windows npx/uvx 的 .cmd
+  shim 之下还有真实孙进程）。
+- **传输**：JSON-RPC 2.0 over stdio，按行分隔（MCP stdio 传输）。
+- **资源上限**：默认 30s 超时 / 256KB 输出上限 / 512 行读取上限，
+  均可被 args 有限度覆盖；子进程环境做白名单最小化继承。
+
+配置格式（用户手写，带 ``mcp.servers.list`` 可视化校验）::
+
+    {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/root"],
+          "env": {"NODE_OPTIONS": "--enable-source-maps"},
+          "enabled": true
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROTOCOL_VERSION = "2024-11-05"
+CLIENT_INFO = {"name": "tiangong-omni-body", "version": "3.5"}
+
+CONFIG_PATH = Path.home() / ".tiangong" / "v3" / "mcp_servers.json"
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 120_000
+MAX_OUTPUT_BYTES = 256 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+# stderr 尾部诊断缓冲与 stdout 读线程的生产侧上限（防失控服务器把
+# _lines 队列灌成无界内存）。
+_STDERR_TAIL_BYTES = 4096
+_MAX_QUEUED_LINES = 100_000
+
+# 子进程环境白名单：Windows 进程启动所需的最小集合 + PATH（npx/node/
+# uvx 常见发行方式需要）。绝不整份继承宿主环境（防泄漏宿主凭据变量）。
+_INHERIT_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "ComSpec", "PATHEXT", "windir", "OS",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+    "PATH", "TEMP", "TMP", "USERPROFILE", "HOME",
+    "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "PROGRAMDATA", "HOMEDRIVE", "HOMEPATH",
+)
+
+
+class McpClientError(RuntimeError):
+    """MCP 调用失败（配置缺失/进程失败/协议错误/超时）。"""
+
+    def __init__(self, code: str, detail: str = ""):
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def load_server_config(config_path: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """读取并校验服务器配置；文件缺失返回空表（未配置≠错误）。"""
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        raise McpClientError("mcp.config.invalid", str(exc)) from exc
+    servers = data.get("servers") if isinstance(data, dict) else None
+    if servers is None:
+        return {}
+    if not isinstance(servers, dict):
+        raise McpClientError("mcp.config.invalid", "servers must be an object")
+    clean: Dict[str, Dict[str, Any]] = {}
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or "").strip()
+        if not command:
+            continue
+        args = [str(item) for item in raw.get("args") or [] if str(item).strip()]
+        env = {
+            str(key): str(value)
+            for key, value in (raw.get("env") or {}).items()
+            if str(key).strip()
+        } if isinstance(raw.get("env"), dict) else {}
+        clean[str(name).strip()] = {
+            "command": command,
+            "args": args,
+            "env": env,
+            "enabled": raw.get("enabled") is not False,
+        }
+    return clean
+
+
+def list_servers() -> List[Dict[str, Any]]:
+    """已配置服务器的只读清单（不含 env 值，防凭据泄漏给模型）。"""
+    rows = []
+    for name, cfg in sorted(load_server_config().items()):
+        rows.append({
+            "server": name,
+            "enabled": bool(cfg["enabled"]),
+            "command": cfg["command"],
+            "args": cfg["args"],
+            "env_keys": sorted(cfg["env"].keys()),
+            "config_path": str(CONFIG_PATH),
+        })
+    return rows
+
+
+def _resolve_server(server: str) -> Dict[str, Any]:
+    name = str(server or "").strip()
+    if not name:
+        raise McpClientError("mcp.server.required", "target or args.server is required")
+    config = load_server_config()
+    cfg = config.get(name)
+    if cfg is None:
+        raise McpClientError(
+            "mcp.server.unknown",
+            f"'{name}' is not configured; known: {sorted(config.keys())}",
+        )
+    if not cfg["enabled"]:
+        raise McpClientError("mcp.server.disabled", name)
+    return cfg
+
+
+def _safe_env(extra: Dict[str, str]) -> Dict[str, str]:
+    env = {key: os.environ[key] for key in _INHERIT_ENV_KEYS if os.environ.get(key)}
+    env.update(extra)
+    return env
+
+
+class _ServerProcess:
+    """一个 MCP 服务器子进程的完整生命周期（行分隔 JSON-RPC）。"""
+
+    def __init__(self, cfg: Dict[str, Any], timeout_ms: int):
+        self.timeout_ms = max(1_000, min(int(timeout_ms), MAX_TIMEOUT_MS))
+        # Windows 下 npx/uvx 实为 .cmd  shim，CreateProcess 只认可执行
+        # 本体——先经 PATHEXT 解析成真实路径，否则配置里的 "npx" 会
+        # 直接 FileNotFoundError。解析失败即干净报错，不落到进程层。
+        command = shutil.which(cfg["command"])
+        if command is None:
+            raise McpClientError(
+                "mcp.server.command_not_found",
+                f"'{cfg['command']}' is not on PATH",
+            )
+        # POSIX 下放进独立进程组，超时清理才能整组收割（与 Windows 的
+        # taskkill /T 对应）。
+        try:
+            self._proc = subprocess.Popen(
+                [command, *cfg["args"]],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_safe_env(cfg["env"]),
+                cwd=str(Path.home()),
+                # 桌面冻结应用内 spawn 控制台进程必须隐窗，否则每次调用
+                # 都会闪一个黑色控制台（与本仓 sandbox_runtime 同款约定）。
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+        except OSError as exc:
+            raise McpClientError("mcp.server.spawn_failed", str(exc)) from exc
+        self._lines: "queue.Queue[bytes | None]" = queue.Queue()
+        self._stderr_tail = b""
+        self._stdout_flood = False
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # stderr 必须有独立消费者：stdio MCP 服务器（npx 安装日志、node
+        # 警告）普遍往 stderr 打日志，PIPE 无人读时写满管道缓冲（Windows
+        # 约 64KB）即阻塞服务器进程，表现为首次调用就超时。
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+        self._next_id = 0
+
+    def _read_loop(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for raw in self._proc.stdout:
+                if self._lines.qsize() >= _MAX_QUEUED_LINES:
+                    # 消费侧上限（512 行无响应即 flood）远小于此；到这里的
+                    # 只可能是失控服务器，停止排队防止内存无界增长。
+                    self._stdout_flood = True
+                    break
+                self._lines.put(raw)
+                if len(raw) > MAX_LINE_BYTES:
+                    break
+        except Exception:
+            pass
+        finally:
+            self._lines.put(None)
+
+    def _stderr_loop(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while True:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except Exception:
+            pass
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if len(data) > MAX_LINE_BYTES:
+            raise McpClientError("mcp.request.too_large", str(len(data)))
+        try:
+            self._proc.stdin.write(data + b"\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # 服务器已退出（stdin 断裂）时转成结构化错误，避免裸
+            # BrokenPipeError 逃出 mcp.* 错误码体系。
+            raise McpClientError("mcp.server.exited", f"stdin broken: {exc}") from None
+
+    def _recv_response(self, request_id: int) -> Dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_ms / 1000
+        received = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms")
+            try:
+                raw = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms") from None
+            if raw is None:
+                # stdout EOF：诊断信息直接取 stderr 读线程的尾部缓冲。
+                # 此处绝不能同步 read() stderr——服务器已死但其孙进程
+                # （npx shim 的 worker）仍持有写端时该读永不返回，
+                # timeout_ms 保护会被整个架空。
+                if self._stdout_flood:
+                    raise McpClientError(
+                        "mcp.protocol.flood",
+                        f"server produced >{_MAX_QUEUED_LINES} queued stdout lines",
+                    )
+                detail = self._stderr_tail.decode("utf-8", errors="replace").strip()[-400:]
+                raise McpClientError("mcp.server.exited", detail)
+            received += 1
+            if received > 512:
+                raise McpClientError("mcp.protocol.flood", ">512 lines without response")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except Exception:
+                continue  # 服务器 banner/日志行，跳过
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def request(self, method: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        response = self._recv_response(request_id)
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            raise McpClientError("mcp.rpc.error", f"{err.get('code')}: {err.get('message')}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise McpClientError("mcp.protocol.invalid", "result is not an object")
+        return result
+
+    def notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def handshake(self) -> Dict[str, Any]:
+        info = self.request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": CLIENT_INFO,
+        })
+        self.notify("notifications/initialized")
+        return info
+
+    def _kill_tree(self) -> None:
+        """按进程树收割：Windows 的 .cmd shim 之下还有真实孙进程。"""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(self._proc.pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+                return
+            except Exception:
+                pass
+        else:
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin is not None and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=3)
+            return
+        except Exception:
+            pass
+        self._kill_tree()
+        # kill 后仍要 wait 收尸，避免句柄/僵尸泄漏。
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _connect(server: str, timeout_ms: int) -> tuple[Dict[str, Any], _ServerProcess]:
+    cfg = _resolve_server(server)
+    proc: _ServerProcess | None = None
+    try:
+        proc = _ServerProcess(cfg, timeout_ms)
+        info = proc.handshake()
+        return info, proc
+    except Exception:
+        if proc is not None:
+            proc.close()
+        raise
+
+
+def list_tools(server: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dict[str, Any]:
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/list", {})
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise McpClientError("mcp.protocol.invalid", "tools is not a list")
+        # 输出上限：整体序列化超预算即留名占位并停止——放不下就丢，
+        # 绝不把超预算的完整工具（大 inputSchema 可达数 MB）放大进
+        # 模型上下文与审计记录。
+        trimmed: List[Dict[str, Any]] = []
+        budget = MAX_OUTPUT_BYTES
+        truncated = False
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            row = dict(tool)
+            desc = str(row.get("description") or "")
+            if len(desc.encode("utf-8")) > 4096:
+                row["description"] = desc[:2048] + "…"
+            size = len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
+            if size > budget:
+                trimmed.append({"name": str(row.get("name") or ""), "_truncated": True})
+                truncated = True
+                break
+            budget -= size
+            trimmed.append(row)
+        return {
+            "server": server,
+            "server_info": info.get("serverInfo") or {},
+            "tools": trimmed,
+            "truncated": truncated,
+        }
+    finally:
+        proc.close()
+
+
+def call_tool(
+    server: str,
+    tool: str,
+    arguments: Dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    tool_name = str(tool or "").strip()
+    if not tool_name:
+        raise McpClientError("mcp.tool.required", "args.tool is required")
+    if not isinstance(arguments or {}, dict):
+        raise McpClientError("mcp.arguments.invalid", "args.arguments must be an object")
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/call", {"name": tool_name, "arguments": dict(arguments or {})})
+        content = result.get("content")
+        texts: List[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+        joined = "\n".join(texts)
+        encoded = joined.encode("utf-8")
+        truncated = len(encoded) > MAX_OUTPUT_BYTES
+        if truncated:
+            joined = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
+        return {
+            "server": server,
+            "tool": tool_name,
+            "is_error": bool(result.get("isError")),
+            "text": joined,
+            "truncated": truncated,
+            "structured": result.get("structuredContent")
+            if isinstance(result.get("structuredContent"), dict)
+            else None,
+        }
+    finally:
+        proc.close()
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DEFAULT_TIMEOUT_MS",
+    "McpClientError",
+    "call_tool",
+    "list_servers",
+    "list_tools",
+    "load_server_config",
+]

--- a/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
+++ b/app/backend/tiangong-backend/v3/bundled_skills/omni_body_skill/tools/pro_apps_v34.py
@@ -70,6 +70,10 @@ PRO_APP_ACTIONS: Dict[str, Dict[str, Any]] = {
     "docker.compose.config": {"risk": "A0", "implemented": True, "summary": "Validate/print docker compose config for a compose file."},
 
     "sqlite.query": {"risk": "A2", "implemented": True, "summary": "Run a SQLite query against a workspace database; SELECT by default, writes require confirmed=true."},
+
+    "mcp.servers.list": {"risk": "A0", "implemented": True, "summary": "List user-configured MCP servers from ~/.tiangong/v3/mcp_servers.json (read-only, no env values)."},
+    "mcp.tools.list": {"risk": "A0", "implemented": True, "summary": "Connect to a configured MCP server and list its tools with input schemas."},
+    "mcp.tool.call": {"risk": "A3", "implemented": True, "summary": "Call one tool on a configured MCP server; A3 confirmation chain applies because MCP tools can have arbitrary side effects."},
 }
 
 APP_PROFILES: Dict[str, Dict[str, Any]] = {
@@ -190,6 +194,15 @@ APP_PROFILES: Dict[str, Dict[str, Any]] = {
         "bridge_actions": [],
         "official_path": "stdlib sqlite3 local database query/limited update executor.",
     },
+    "mcp": {
+        "label": "Model Context Protocol",
+        "modules": [],
+        "executables": [],
+        "env": [],
+        "native_actions": ["mcp.servers.list", "mcp.tools.list", "mcp.tool.call"],
+        "bridge_actions": [],
+        "official_path": "MCP stdio servers declared by the user in ~/.tiangong/v3/mcp_servers.json; the model can only reference configured server names and can never invent spawn commands.",
+    },
 }
 
 
@@ -208,6 +221,8 @@ def handle_pro_app_action(runtime: Any, op_id: str, action: str, target: str | N
         return _bridge_pack_create(runtime, target, args)
     if action.startswith("browser.playwright."):
         return _browser_playwright(runtime, action, target, args)
+    if action.startswith("mcp."):
+        return _mcp_action(runtime, action, target, args)
     if action == "microsoft.graph.request_pack.create":
         return _request_pack(runtime, target, args, provider="microsoft_graph")
     if action == "microsoft.office.com.script.create":
@@ -926,6 +941,59 @@ def _docker_action(runtime: Any, action: str, target: str | None, args: Dict[str
         return {"success": False, "message": f"unsupported docker action: {action}"}
     res = subprocess.run(cmd, cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 60)))
     return {"success": res.returncode == 0, "result": {"cmd": cmd[1:], "returncode": res.returncode, "stdout": res.stdout, "stderr": res.stderr}, "evidence": {"path": "docker", "exists": True, "bytes": len(res.stdout)}}
+
+
+def _mcp_action(runtime: Any, action: str, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:
+    """MCP 接入（v1）：服务器只能来自用户配置文件，模型不可自造命令。
+
+    权限链全复用：mcp.tool.call 注册为 A3，由网关确认链把关——任何
+    MCP 工具都可能有任意副作用，宁可多确认一次。
+    """
+    from .mcp_client import (
+        DEFAULT_TIMEOUT_MS,
+        McpClientError,
+        call_tool,
+        list_servers,
+        list_tools,
+    )
+
+    def _timeout_ms() -> int:
+        try:
+            return int(args.get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        except (TypeError, ValueError):
+            return DEFAULT_TIMEOUT_MS
+
+    try:
+        if action == "mcp.servers.list":
+            servers = list_servers()
+            return {
+                "success": True,
+                "result": {
+                    "servers": servers,
+                    "count": len(servers),
+                    "hint": "服务器在 ~/.tiangong/v3/mcp_servers.json 中由用户配置；模型只能引用 server 名。",
+                },
+            }
+        if action == "mcp.tools.list":
+            server = str(target or args.get("server") or "").strip()
+            result = list_tools(server, timeout_ms=_timeout_ms())
+            return {"success": True, "result": result}
+        if action == "mcp.tool.call":
+            server = str(target or args.get("server") or "").strip()
+            tool = str(args.get("tool") or args.get("name") or "").strip()
+            arguments = args.get("arguments") or {}
+            result = call_tool(server, tool, arguments, timeout_ms=_timeout_ms())
+            return {
+                "success": not result.get("is_error"),
+                # 两种失败（isError / McpClientError）保持同一形状：
+                # error + message + result 三键齐全，下游按 error 分类。
+                "error": "" if not result.get("is_error") else "mcp.tool.is_error",
+                "result": result,
+                "message": "MCP tool reported isError" if result.get("is_error") else "",
+            }
+    except McpClientError as exc:
+        return {"success": False, "error": exc.code, "result": None, "message": str(exc)}
+    return {"success": False, "error": "mcp.action.unknown", "result": None, "message": f"unknown mcp action: {action}"}
 
 
 def _sqlite_query(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/frontend-v2/renderer/plugins/execute-side-block.mjs
+++ b/app/frontend-v2/renderer/plugins/execute-side-block.mjs
@@ -1,5 +1,13 @@
+function esc(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 function row(label, value) {
-  return `<div class="rs-line"><span class="rs-label">${label}:</span><span class="rs-value">${value}</span></div>`;
+  return `<div class="rs-line"><span class="rs-label">${esc(label)}:</span><span class="rs-value">${esc(value)}</span></div>`;
 }
 
 function fmt(value, fallback = "未读取") {

--- a/app/life-service/runtime314/life_service/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/life_service/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "life-service-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/life_service",
-  "tree_sha256": "7d89d77a50a91cc013e0a5d3565df65b03dca69fc3f2a2d8b78d2f7dfca95e39",
+  "tree_sha256": "7906849ffaa1a2c1ba239b7031ff905eb5d8f26cfa97385ea1331a9657f32856",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/life_service/journal_replay.py
+++ b/app/life-service/runtime314/life_service/journal_replay.py
@@ -39,8 +39,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable
 
-from contracts import canonical_sha256
 from .capability_health import ingest_outcome
+from .complete_core import canonical as journal_canonical
 
 
 class JournalReplayError(RuntimeError):
@@ -71,6 +71,10 @@ EVENT_REGISTRY: dict[str, EventClass] = {
     # ---- 自主任务 ----
     "autonomy.task_generated": EventClass.REPLAYABLE_PROJECTION,
     "autonomy.task_status_changed": EventClass.REPLAYABLE_PROJECTION,
+    # standalone 冻结运行时（P11 handoff 缺失回退形态）的自主行动审计
+    # 事实；投影权威在 fact cache，嵌入式重放只需放行不崩溃。
+    "autonomy.action_completed": EventClass.AUDIT_ONLY,
+    "autonomy.action_failed": EventClass.AUDIT_ONLY,
     # ---- 终态执行（不可逆外部效果证据） ----
     "execution.committed": EventClass.EXTERNAL_TERMINAL_EVIDENCE,
     # ---- 能力治理（指针事件 payload 自带完整新状态） ----
@@ -90,6 +94,8 @@ EVENT_REGISTRY: dict[str, EventClass] = {
     "learning.discarded": EventClass.REPLAYABLE_PROJECTION,
     "learning.decision_noop": EventClass.AUDIT_ONLY,
     # ---- 自我迭代升级卡 ----
+    # noop 决策只落审计事件，投影门控键由调度器写侧维护，audit-only。
+    "self_iteration.decision_noop": EventClass.AUDIT_ONLY,
     "upgrade.card_created": EventClass.REPLAYABLE_PROJECTION,
     "upgrade.card_confirmed": EventClass.REPLAYABLE_PROJECTION,
     "upgrade.card_cancelled": EventClass.REPLAYABLE_PROJECTION,
@@ -137,8 +143,22 @@ def _event_ms(event: Mapping[str, Any]) -> int:
         return 0
 
 
+def _journal_fingerprint(value: Any) -> str:
+    """Journal 载荷指纹：与写侧哈希链（complete_core.canonical）同一序列化。
+
+    journal 事件载荷不是签名契约：工具 receipt 可合法携带有限 float
+    telemetry（见 embedded_runtime 写侧注释）。contracts.canonical_sha256
+    对 float/int 超 2^53 直接 raise，用它比较既有投影会在启动重放抛裸
+    TypeError——journal 是权威 WAL，重放必须总能启动。两侧统一用写侧
+    序列化后，指纹对含 float 的载荷稳定且与落盘哈希链一致。
+    """
+    import hashlib
+
+    return hashlib.sha256(journal_canonical(value)).hexdigest()
+
+
 def _same(a: Any, b: Any) -> bool:
-    return canonical_sha256(a) == canonical_sha256(b)
+    return _journal_fingerprint(a) == _journal_fingerprint(b)
 
 
 def _require_mapping(value: Any, code: str) -> dict[str, Any]:
@@ -164,7 +184,7 @@ def _merge_asserted_memory_projection(existing: dict[str, Any], asserted: Mappin
             existing[key] = deepcopy(value)
             changed = True
             continue
-        if canonical_sha256(existing.get(key)) != canonical_sha256(value):
+        if _journal_fingerprint(existing.get(key)) != _journal_fingerprint(value):
             raise JournalReplayError("life.projection.memory_conflict")
     return changed
 
@@ -180,7 +200,7 @@ def _merge_generated_task_projection(existing: dict[str, Any], generated: Mappin
             existing[key] = deepcopy(value)
             changed = True
             continue
-        if canonical_sha256(existing.get(key)) != canonical_sha256(value):
+        if _journal_fingerprint(existing.get(key)) != _journal_fingerprint(value):
             raise JournalReplayError("life.projection.autonomy_task_conflict")
     return changed
 

--- a/app/main.js
+++ b/app/main.js
@@ -1996,7 +1996,18 @@ function processExecutablePath(pid) {
     const match = output.match(/ExecutablePath=(.*)/i);
     return (match?.[1] || "").trim();
   } catch (_error) {
-    return "";
+    // Windows 11 24H2+ 移除了 wmic；回退 PowerShell CIM。取不到路径时
+    // 调用方（isReplaceableBackendListener*）必须保守地视为"不可替换"，
+    // 绝不能因为探测手段缺失就 taskkill 无关进程。
+    try {
+      return execFileSync(
+        "powershell",
+        ["-NoProfile", "-NonInteractive", "-Command", `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').ExecutablePath`],
+        { encoding: "utf8", windowsHide: true, stdio: ["ignore", "pipe", "ignore"] }
+      ).trim();
+    } catch (_fallbackError) {
+      return "";
+    }
   }
 }
 
@@ -2007,7 +2018,9 @@ function isReplaceableBackendListener(pid, dir) {
   const expectedExe = frozenBackendExecutablePath(dir);
   if (!expectedExe) return isSourceBackendDir(dir) && imageName.includes("tiangong-backend");
   const actualExe = processExecutablePath(pid);
-  return !actualExe || normalizeFsPath(actualExe) !== normalizeFsPath(expectedExe);
+  // 探测失败（wmic/PowerShell 均不可用）时保守拒绝：宁可漏替换自家旧
+  // 监听（退化为端口占用报错），不可误杀恰好叫 python.exe 的无关进程。
+  return Boolean(actualExe) && normalizeFsPath(actualExe) !== normalizeFsPath(expectedExe);
 }
 
 function shouldReplaceExistingBackend(dir) {
@@ -3844,7 +3857,19 @@ async function processExecutablePathAsync(pid) {
     const match = output.match(/ExecutablePath=(.*)/i);
     return (match?.[1] || "").trim();
   } catch (_error) {
-    return "";
+    // 与同步版一致：wmic 缺失（Win11 24H2+）时回退 PowerShell CIM。
+    try {
+      return (
+        await execFileText("powershell", [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').ExecutablePath`,
+        ])
+      ).trim();
+    } catch (_fallbackError) {
+      return "";
+    }
   }
 }
 
@@ -3894,7 +3919,8 @@ async function isReplaceableBackendListenerAsync(pid, dir) {
   const expectedExe = frozenBackendExecutablePath(dir);
   if (!expectedExe) return isSourceBackendDir(dir) && imageName.includes("tiangong-backend");
   const actualExe = await processExecutablePathAsync(pid);
-  return !actualExe || normalizeFsPath(actualExe) !== normalizeFsPath(expectedExe);
+  // 探测失败时保守拒绝（与同步版一致），防误杀无关进程。
+  return Boolean(actualExe) && normalizeFsPath(actualExe) !== normalizeFsPath(expectedExe);
 }
 
 async function killProcessTreeAsync(pid) {

--- a/app/main.js
+++ b/app/main.js
@@ -92,10 +92,13 @@ function configureSourceIsolation() {
   return Object.freeze({ profileRoot, userData, runtimeRoot, workspaceRoot });
 }
 
-// 便携模式（U 盘 TiangongData）必须先于任何 runtime root 解析执行：
-// resolveWorkspaceMode()/runtimeStateRoot() 在模块加载期就会读取并
-// 永久缓存 userData 派生路径，若 setPath 晚于它们，全部运行时状态
-// （日志/gateway 状态/恢复密钥）会写进本机固定目录，便携语义失效。
+const SOURCE_ISOLATION = configureSourceIsolation();
+
+// 便携模式（U 盘 TiangongData）必须在 resolveWorkspaceMode()/runtimeStateRoot()
+// 之前执行：它们在模块加载期就会读取并永久缓存 userData 派生路径，
+// setPath 晚于它们的话，全部运行时状态（日志/gateway 状态/恢复密钥）
+// 会写进本机固定目录，便携语义失效。source 隔离与 portable 互斥
+// （SOURCE_MODE 下 portableExecutableDir 恒空），先后仅是架构约束。
 const portableExecutableDir = SOURCE_MODE
   ? ""
   : String(process.env.PORTABLE_EXECUTABLE_DIR || "").trim();
@@ -112,8 +115,6 @@ if (portableExecutableDir) {
     delete process.env.TIANGONG_PORTABLE_MODE;
   }
 }
-
-const SOURCE_ISOLATION = configureSourceIsolation();
 
 // 工作区写入模式：workspace（默认，写边界=工作区）/ full（全盘，硬禁区除外）。
 // 由后端保存在 workspace_settings.json，启动时注入子进程；切换模式后重启应用生效。

--- a/app/main.js
+++ b/app/main.js
@@ -92,6 +92,27 @@ function configureSourceIsolation() {
   return Object.freeze({ profileRoot, userData, runtimeRoot, workspaceRoot });
 }
 
+// 便携模式（U 盘 TiangongData）必须先于任何 runtime root 解析执行：
+// resolveWorkspaceMode()/runtimeStateRoot() 在模块加载期就会读取并
+// 永久缓存 userData 派生路径，若 setPath 晚于它们，全部运行时状态
+// （日志/gateway 状态/恢复密钥）会写进本机固定目录，便携语义失效。
+const portableExecutableDir = SOURCE_MODE
+  ? ""
+  : String(process.env.PORTABLE_EXECUTABLE_DIR || "").trim();
+if (portableExecutableDir) {
+  const portableUserData = path.join(portableExecutableDir, "TiangongData");
+  try {
+    fs.mkdirSync(portableUserData, { recursive: true });
+    fs.accessSync(portableUserData, fs.constants.R_OK | fs.constants.W_OK);
+    app.setPath("userData", portableUserData);
+    process.env.TIANGONG_PORTABLE_MODE = "1";
+  } catch (_error) {
+    // Read-only/removing portable media must not crash before the first
+    // window.  The normal per-user data path remains the authority.
+    delete process.env.TIANGONG_PORTABLE_MODE;
+  }
+}
+
 const SOURCE_ISOLATION = configureSourceIsolation();
 
 // 工作区写入模式：workspace（默认，写边界=工作区）/ full（全盘，硬禁区除外）。
@@ -142,23 +163,6 @@ const WEB_QA_MODE = Boolean(WEB_QA_TARGET && WEB_QA_WORKSPACE);
 // The desktop has exactly one application runtime: Total Gateway on 7184.
 // 7174/7175/7176 are retired listener ports, never a selectable deployment
 // mode.  Startup only clears a verified stale listener left by an old build.
-
-const portableExecutableDir = SOURCE_MODE
-  ? ""
-  : String(process.env.PORTABLE_EXECUTABLE_DIR || "").trim();
-if (portableExecutableDir) {
-  const portableUserData = path.join(portableExecutableDir, "TiangongData");
-  try {
-    fs.mkdirSync(portableUserData, { recursive: true });
-    fs.accessSync(portableUserData, fs.constants.R_OK | fs.constants.W_OK);
-    app.setPath("userData", portableUserData);
-    process.env.TIANGONG_PORTABLE_MODE = "1";
-  } catch (_error) {
-    // Read-only/removing portable media must not crash before the first
-    // window.  The normal per-user data path remains the authority.
-    delete process.env.TIANGONG_PORTABLE_MODE;
-  }
-}
 
 // The application runtime (and legacy diagnostic child processes, when explicitly enabled)
 // must call provider APIs directly. Proxy variables inherited from the host shell can

--- a/app/secure-updater.js
+++ b/app/secure-updater.js
@@ -60,8 +60,13 @@ function boundedHttpsGet(rawUrl, maxBytes, allowedOrigins, onChunk) {
       res.on("data", (chunk) => {
         total += chunk.length;
         if (total > maxBytes) { req.destroy(new Error("update_response_too_large")); return; }
-        if (onChunk) onChunk(chunk, total, contentLength);
-        else chunks.push(chunk);
+        if (onChunk) {
+          // onChunk 在流事件回调内同步执行（writeSync 落盘）；磁盘满等
+          // 异常若任其冒泡会成为主进程 uncaughtException 且外层 Promise
+          // 永不 settle。统一转成 req.destroy -> reject。
+          try { onChunk(chunk, total, contentLength); }
+          catch (error) { req.destroy(error); }
+        } else chunks.push(chunk);
       });
       res.on("end", () => resolve(onChunk ? { total, contentLength } : Buffer.concat(chunks)));
       res.on("error", reject);
@@ -82,7 +87,11 @@ function verifyManifestEnvelope({ envelope, trust, state = {}, currentVersion = 
   const signed = envelope.signed;
   if (signed.schema !== "tiangong.update.manifest.v1") throw new Error("update_manifest_schema_invalid");
   const metadataVersion = Number(signed.metadata_version);
-  if (!Number.isSafeInteger(metadataVersion) || metadataVersion <= Number(state.highest_metadata_version || 0)) throw new Error("update_metadata_rollback_or_replay");
+  // 只拒绝更旧的 metadata_version：相同的必然出自签名方（签名/过期/
+  // 版本三重校验在前），是幂等重查而非重放。旧实现用 <= 会把"服务器
+  // 尚未发布新 manifest 时的再次检查"判成 replay，已就绪的更新被
+  // recordError 打成 ERROR 后永远无法下载。
+  if (!Number.isSafeInteger(metadataVersion) || metadataVersion < Number(state.highest_metadata_version || 0)) throw new Error("update_metadata_rollback_or_replay");
   const expires = Date.parse(String(signed.expires || ""));
   if (!Number.isFinite(expires) || expires <= now) throw new Error("update_manifest_expired");
   const releaseVersion = String(signed.release_version || "");
@@ -139,7 +148,11 @@ class SecureUpdater {
 
   recordError(error) {
     const message = error?.message || String(error || "update_failed");
-    this._save({ phase: "ERROR", error: message });
+    // DOWNLOADED/APPLYING/COMMITTED 是资产已就绪状态：检查/网络失败只
+    // 记录错误，绝不作废已下载（哈希已验证）或已提交的更新，否则
+    // "下载完再点一次检查且失败"就会让 apply() 的前置条件永远不满足。
+    const assetPhase = ["DOWNLOADED", "APPLYING", "COMMITTED"].includes(this.state.phase);
+    this._save({ phase: assetPhase ? this.state.phase : "ERROR", error: message });
     return { ok: false, error: message, status: this.status() };
   }
 
@@ -148,7 +161,11 @@ class SecureUpdater {
     const manifestUrl = String(this.trust.manifest_url || "");
     const allowedOrigins = this._origins();
     if (!manifestUrl || !this.trust.public_key_pem || !this.trust.key_id || !this.trust.expected_publisher || !allowedOrigins.size) throw new Error("update_trust_root_incomplete");
-    this._save({ phase: "CHECKING", error: "" });
+    // 已就绪的下载不因再次检查而作废：失败时 recordError 保留资产
+    // phase；成功且仍是同一版本时保持 DOWNLOADED，只有服务器发布
+    // 新版本才回到 AVAILABLE。
+    const previouslyDownloaded = this.state.phase === "DOWNLOADED" ? this.state.available : null;
+    this._save({ phase: this.state.phase === "DOWNLOADED" ? "DOWNLOADED" : "CHECKING", error: "" });
     const raw = await boundedHttpsGet(manifestUrl, MAX_METADATA_BYTES, allowedOrigins);
     let envelope;
     try { envelope = JSON.parse(raw.toString("utf8")); } catch { throw new Error("update_manifest_json_invalid"); }
@@ -158,8 +175,10 @@ class SecureUpdater {
       state: this.state,
       currentVersion: this.currentVersion,
     });
+    const sameRelease = previouslyDownloaded
+      && compareVersion(String(signed.release_version), String(previouslyDownloaded.release_version)) === 0;
     this._save({
-      phase: "AVAILABLE",
+      phase: sameRelease ? "DOWNLOADED" : "AVAILABLE",
       available: signed,
       highest_metadata_version: Number(signed.metadata_version),
       error: "",
@@ -175,13 +194,24 @@ class SecureUpdater {
     const partial = `${destination}.partial`;
     await fsp.rm(partial, { force: true });
     const fd = fs.openSync(partial, "w", 0o600); let written = 0;
+    const writeAll = (buffer) => {
+      // writeSync 对大 buffer 可能部分写，循环到写完。
+      let offset = 0;
+      while (offset < buffer.length) offset += fs.writeSync(fd, buffer, offset);
+    };
     try {
-      await boundedHttpsGet(String(target.url), Number(target.size), this._origins(), (chunk, total) => {
-        fs.writeSync(fd, chunk); written = total;
-        this.onProgress({ phase: "DOWNLOADING", written, total: Number(target.size), percent: Math.min(100, Math.round(written * 100 / Number(target.size))) });
-      });
-      fs.fsyncSync(fd);
-    } finally { fs.closeSync(fd); }
+      try {
+        await boundedHttpsGet(String(target.url), Number(target.size), this._origins(), (chunk, total) => {
+          writeAll(chunk); written = total;
+          this.onProgress({ phase: "DOWNLOADING", written, total: Number(target.size), percent: Math.min(100, Math.round(written * 100 / Number(target.size))) });
+        });
+        fs.fsyncSync(fd);
+      } finally { fs.closeSync(fd); }
+    } catch (error) {
+      // 网络中断/磁盘满等任何失败都清掉半成品，不留无法通过哈希校验的 partial。
+      await fsp.rm(partial, { force: true });
+      throw error;
+    }
     if (written !== Number(target.size)) { await fsp.rm(partial, { force: true }); throw new Error("update_download_size_mismatch"); }
     const digest = await sha256File(partial);
     if (digest.toLowerCase() !== String(target.sha256).toLowerCase()) { await fsp.rm(partial, { force: true }); throw new Error("update_download_hash_mismatch"); }
@@ -266,14 +296,24 @@ class SecureUpdater {
         error: "",
       });
     }).catch(() => {
-      this._save({
+      // 新安装包哈希不可得（文件被杀毒隔离/删除等）：绝不能把基线指向
+      // 无法验证的文件而保留旧哈希——那会让之后每次 apply() 的基线复核
+      // 恒抛 update_rollback_hash_mismatch，永久无法升级。旧基线仍完整
+      // 时保留旧基线；旧基线也缺失则清空，让 _seedLastKnownGoodInstaller
+      // 从打包基线重建。
+      const patch = {
         phase: "COMMITTED",
         highest_release_version: this.currentVersion,
-        last_known_good_installer: installer,
         transaction_token: "",
         health_marker: "",
-        error: "",
-      });
+        error: "update_baseline_hash_unavailable",
+      };
+      const previousInstaller = String(this.state.last_known_good_installer || "");
+      if (previousInstaller && fs.existsSync(previousInstaller)) {
+        this._save(patch);
+      } else {
+        this._save({ ...patch, last_known_good_installer: "", last_known_good_installer_sha256: "" });
+      }
     });
     return true;
   }

--- a/readable-python-source/omni_body_skill/.tiangong-generated-source.json
+++ b/readable-python-source/omni_body_skill/.tiangong-generated-source.json
@@ -1,8 +1,8 @@
 {
-  "file_count": 148,
+  "file_count": 149,
   "mapping_id": "omni-body-runtime",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/omni_body_skill",
-  "tree_sha256": "64355337535b78dfed7a2b11bd4b3e171a4c4665b9d990e6f5d583abd6a1a4d9",
+  "tree_sha256": "825c485d88dd541e593eb1532e6ee57c07f7a75f459a7a8cbd3dde0ee0d96d9d",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/readable-python-source/omni_body_skill/model_adapters/core.py
+++ b/readable-python-source/omni_body_skill/model_adapters/core.py
@@ -129,7 +129,7 @@ def _omni_parameters_schema(strict: bool = False) -> Dict[str, Any]:
     schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search。优先直接调用生产 action。"},
+            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search/mcp.servers.list/mcp.tools.list/mcp.tool.call。优先直接调用生产 action。"},
             "target": {"type": "string", "description": "主目标：文件路径、URL、对象ID、输出路径或空字符串。"},
             "args": {
                 "type": "object",
@@ -223,6 +223,7 @@ def _tool_description() -> str:
         "搜索: browser.search_web(网页搜索)/web.search/http.get(读URL)/browser.open.\n"
         "质检交付: qc.*(质量检查)/deliverable.package(交付打包).\n"
         "系统: life.body.state.query/life.activity.query/system.capabilities/system.health/rollback.list/rollback.apply.\n"
+        "扩展: mcp.servers.list(列出用户配置的 MCP 服务器)/mcp.tools.list(列出某服务器的工具)/mcp.tool.call(调用 MCP 工具，A3 需用户确认；服务器只能引用用户已配置的名字，不可自造命令)。\n"
         "受托管小说能力采用最小暴露：通用工具说明不公布其动作名。只有用户明确要求全书/长期多章工程或续作已有托管项目，并且模型实际读取对应受托管 Skill 后，才按该 Skill 公布的动作执行。单章、少量章节、一次性协作资料包不得升级为整书项目。\n"
         "技能选择有双通道：系统已提供 active/related Skill 时直接读取该 Skill；没有匹配且任务需要专用流程时，模型可调用 skill.route 再 skill.get/skill.read。选定后以具体 Skill 的作用域和工作流为准，通用动作说明不得覆盖它。\n"
     )

--- a/readable-python-source/omni_body_skill/tools/mcp_client.py
+++ b/readable-python-source/omni_body_skill/tools/mcp_client.py
@@ -1,0 +1,443 @@
+"""MCP (Model Context Protocol) client for omni_body actions.
+
+v1 设计（2026-08-22，"作 omni_body action 接入"方案）：
+
+- **安全边界**：服务器进程只能来自用户管理的
+  ``~/.tiangong/v3/mcp_servers.json``——模型只能引用已配置的服务器名，
+  绝不能自造命令行。配置文件是唯一的 spawn 授权面。
+- **权限链全复用**：mcp.tool.call 注册为 A3，走网关既有确认链；
+  mcp.servers.list / mcp.tools.list 为 A0 只读。
+- **进程生命周期**：每次调用独立 spawn → initialize → 请求 → close。
+  无僵尸进程、无陈旧会话、无并发争用；代价是每次约百毫秒启动，
+  桌面场景可接受。持久会话留作后续。stdout/stderr 各有独立读线程
+  （stderr 持续消费防止服务器日志撑爆管道缓冲导致死锁，只保留尾部
+  用于诊断）；超时/失败清理时按进程树收割（Windows npx/uvx 的 .cmd
+  shim 之下还有真实孙进程）。
+- **传输**：JSON-RPC 2.0 over stdio，按行分隔（MCP stdio 传输）。
+- **资源上限**：默认 30s 超时 / 256KB 输出上限 / 512 行读取上限，
+  均可被 args 有限度覆盖；子进程环境做白名单最小化继承。
+
+配置格式（用户手写，带 ``mcp.servers.list`` 可视化校验）::
+
+    {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/root"],
+          "env": {"NODE_OPTIONS": "--enable-source-maps"},
+          "enabled": true
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROTOCOL_VERSION = "2024-11-05"
+CLIENT_INFO = {"name": "tiangong-omni-body", "version": "3.5"}
+
+CONFIG_PATH = Path.home() / ".tiangong" / "v3" / "mcp_servers.json"
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 120_000
+MAX_OUTPUT_BYTES = 256 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+# stderr 尾部诊断缓冲与 stdout 读线程的生产侧上限（防失控服务器把
+# _lines 队列灌成无界内存）。
+_STDERR_TAIL_BYTES = 4096
+_MAX_QUEUED_LINES = 100_000
+
+# 子进程环境白名单：Windows 进程启动所需的最小集合 + PATH（npx/node/
+# uvx 常见发行方式需要）。绝不整份继承宿主环境（防泄漏宿主凭据变量）。
+_INHERIT_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "ComSpec", "PATHEXT", "windir", "OS",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+    "PATH", "TEMP", "TMP", "USERPROFILE", "HOME",
+    "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "PROGRAMDATA", "HOMEDRIVE", "HOMEPATH",
+)
+
+
+class McpClientError(RuntimeError):
+    """MCP 调用失败（配置缺失/进程失败/协议错误/超时）。"""
+
+    def __init__(self, code: str, detail: str = ""):
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def load_server_config(config_path: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """读取并校验服务器配置；文件缺失返回空表（未配置≠错误）。"""
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        raise McpClientError("mcp.config.invalid", str(exc)) from exc
+    servers = data.get("servers") if isinstance(data, dict) else None
+    if servers is None:
+        return {}
+    if not isinstance(servers, dict):
+        raise McpClientError("mcp.config.invalid", "servers must be an object")
+    clean: Dict[str, Dict[str, Any]] = {}
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or "").strip()
+        if not command:
+            continue
+        args = [str(item) for item in raw.get("args") or [] if str(item).strip()]
+        env = {
+            str(key): str(value)
+            for key, value in (raw.get("env") or {}).items()
+            if str(key).strip()
+        } if isinstance(raw.get("env"), dict) else {}
+        clean[str(name).strip()] = {
+            "command": command,
+            "args": args,
+            "env": env,
+            "enabled": raw.get("enabled") is not False,
+        }
+    return clean
+
+
+def list_servers() -> List[Dict[str, Any]]:
+    """已配置服务器的只读清单（不含 env 值，防凭据泄漏给模型）。"""
+    rows = []
+    for name, cfg in sorted(load_server_config().items()):
+        rows.append({
+            "server": name,
+            "enabled": bool(cfg["enabled"]),
+            "command": cfg["command"],
+            "args": cfg["args"],
+            "env_keys": sorted(cfg["env"].keys()),
+            "config_path": str(CONFIG_PATH),
+        })
+    return rows
+
+
+def _resolve_server(server: str) -> Dict[str, Any]:
+    name = str(server or "").strip()
+    if not name:
+        raise McpClientError("mcp.server.required", "target or args.server is required")
+    config = load_server_config()
+    cfg = config.get(name)
+    if cfg is None:
+        raise McpClientError(
+            "mcp.server.unknown",
+            f"'{name}' is not configured; known: {sorted(config.keys())}",
+        )
+    if not cfg["enabled"]:
+        raise McpClientError("mcp.server.disabled", name)
+    return cfg
+
+
+def _safe_env(extra: Dict[str, str]) -> Dict[str, str]:
+    env = {key: os.environ[key] for key in _INHERIT_ENV_KEYS if os.environ.get(key)}
+    env.update(extra)
+    return env
+
+
+class _ServerProcess:
+    """一个 MCP 服务器子进程的完整生命周期（行分隔 JSON-RPC）。"""
+
+    def __init__(self, cfg: Dict[str, Any], timeout_ms: int):
+        self.timeout_ms = max(1_000, min(int(timeout_ms), MAX_TIMEOUT_MS))
+        # Windows 下 npx/uvx 实为 .cmd  shim，CreateProcess 只认可执行
+        # 本体——先经 PATHEXT 解析成真实路径，否则配置里的 "npx" 会
+        # 直接 FileNotFoundError。解析失败即干净报错，不落到进程层。
+        command = shutil.which(cfg["command"])
+        if command is None:
+            raise McpClientError(
+                "mcp.server.command_not_found",
+                f"'{cfg['command']}' is not on PATH",
+            )
+        # POSIX 下放进独立进程组，超时清理才能整组收割（与 Windows 的
+        # taskkill /T 对应）。
+        try:
+            self._proc = subprocess.Popen(
+                [command, *cfg["args"]],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_safe_env(cfg["env"]),
+                cwd=str(Path.home()),
+                # 桌面冻结应用内 spawn 控制台进程必须隐窗，否则每次调用
+                # 都会闪一个黑色控制台（与本仓 sandbox_runtime 同款约定）。
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+        except OSError as exc:
+            raise McpClientError("mcp.server.spawn_failed", str(exc)) from exc
+        self._lines: "queue.Queue[bytes | None]" = queue.Queue()
+        self._stderr_tail = b""
+        self._stdout_flood = False
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # stderr 必须有独立消费者：stdio MCP 服务器（npx 安装日志、node
+        # 警告）普遍往 stderr 打日志，PIPE 无人读时写满管道缓冲（Windows
+        # 约 64KB）即阻塞服务器进程，表现为首次调用就超时。
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+        self._next_id = 0
+
+    def _read_loop(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for raw in self._proc.stdout:
+                if self._lines.qsize() >= _MAX_QUEUED_LINES:
+                    # 消费侧上限（512 行无响应即 flood）远小于此；到这里的
+                    # 只可能是失控服务器，停止排队防止内存无界增长。
+                    self._stdout_flood = True
+                    break
+                self._lines.put(raw)
+                if len(raw) > MAX_LINE_BYTES:
+                    break
+        except Exception:
+            pass
+        finally:
+            self._lines.put(None)
+
+    def _stderr_loop(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while True:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except Exception:
+            pass
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if len(data) > MAX_LINE_BYTES:
+            raise McpClientError("mcp.request.too_large", str(len(data)))
+        try:
+            self._proc.stdin.write(data + b"\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # 服务器已退出（stdin 断裂）时转成结构化错误，避免裸
+            # BrokenPipeError 逃出 mcp.* 错误码体系。
+            raise McpClientError("mcp.server.exited", f"stdin broken: {exc}") from None
+
+    def _recv_response(self, request_id: int) -> Dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_ms / 1000
+        received = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms")
+            try:
+                raw = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms") from None
+            if raw is None:
+                # stdout EOF：诊断信息直接取 stderr 读线程的尾部缓冲。
+                # 此处绝不能同步 read() stderr——服务器已死但其孙进程
+                # （npx shim 的 worker）仍持有写端时该读永不返回，
+                # timeout_ms 保护会被整个架空。
+                if self._stdout_flood:
+                    raise McpClientError(
+                        "mcp.protocol.flood",
+                        f"server produced >{_MAX_QUEUED_LINES} queued stdout lines",
+                    )
+                detail = self._stderr_tail.decode("utf-8", errors="replace").strip()[-400:]
+                raise McpClientError("mcp.server.exited", detail)
+            received += 1
+            if received > 512:
+                raise McpClientError("mcp.protocol.flood", ">512 lines without response")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except Exception:
+                continue  # 服务器 banner/日志行，跳过
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def request(self, method: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        response = self._recv_response(request_id)
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            raise McpClientError("mcp.rpc.error", f"{err.get('code')}: {err.get('message')}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise McpClientError("mcp.protocol.invalid", "result is not an object")
+        return result
+
+    def notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def handshake(self) -> Dict[str, Any]:
+        info = self.request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": CLIENT_INFO,
+        })
+        self.notify("notifications/initialized")
+        return info
+
+    def _kill_tree(self) -> None:
+        """按进程树收割：Windows 的 .cmd shim 之下还有真实孙进程。"""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(self._proc.pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+                return
+            except Exception:
+                pass
+        else:
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin is not None and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=3)
+            return
+        except Exception:
+            pass
+        self._kill_tree()
+        # kill 后仍要 wait 收尸，避免句柄/僵尸泄漏。
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _connect(server: str, timeout_ms: int) -> tuple[Dict[str, Any], _ServerProcess]:
+    cfg = _resolve_server(server)
+    proc: _ServerProcess | None = None
+    try:
+        proc = _ServerProcess(cfg, timeout_ms)
+        info = proc.handshake()
+        return info, proc
+    except Exception:
+        if proc is not None:
+            proc.close()
+        raise
+
+
+def list_tools(server: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dict[str, Any]:
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/list", {})
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise McpClientError("mcp.protocol.invalid", "tools is not a list")
+        # 输出上限：整体序列化超预算即留名占位并停止——放不下就丢，
+        # 绝不把超预算的完整工具（大 inputSchema 可达数 MB）放大进
+        # 模型上下文与审计记录。
+        trimmed: List[Dict[str, Any]] = []
+        budget = MAX_OUTPUT_BYTES
+        truncated = False
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            row = dict(tool)
+            desc = str(row.get("description") or "")
+            if len(desc.encode("utf-8")) > 4096:
+                row["description"] = desc[:2048] + "…"
+            size = len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
+            if size > budget:
+                trimmed.append({"name": str(row.get("name") or ""), "_truncated": True})
+                truncated = True
+                break
+            budget -= size
+            trimmed.append(row)
+        return {
+            "server": server,
+            "server_info": info.get("serverInfo") or {},
+            "tools": trimmed,
+            "truncated": truncated,
+        }
+    finally:
+        proc.close()
+
+
+def call_tool(
+    server: str,
+    tool: str,
+    arguments: Dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    tool_name = str(tool or "").strip()
+    if not tool_name:
+        raise McpClientError("mcp.tool.required", "args.tool is required")
+    if not isinstance(arguments or {}, dict):
+        raise McpClientError("mcp.arguments.invalid", "args.arguments must be an object")
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/call", {"name": tool_name, "arguments": dict(arguments or {})})
+        content = result.get("content")
+        texts: List[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+        joined = "\n".join(texts)
+        encoded = joined.encode("utf-8")
+        truncated = len(encoded) > MAX_OUTPUT_BYTES
+        if truncated:
+            joined = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
+        return {
+            "server": server,
+            "tool": tool_name,
+            "is_error": bool(result.get("isError")),
+            "text": joined,
+            "truncated": truncated,
+            "structured": result.get("structuredContent")
+            if isinstance(result.get("structuredContent"), dict)
+            else None,
+        }
+    finally:
+        proc.close()
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DEFAULT_TIMEOUT_MS",
+    "McpClientError",
+    "call_tool",
+    "list_servers",
+    "list_tools",
+    "load_server_config",
+]

--- a/readable-python-source/omni_body_skill/tools/pro_apps_v34.py
+++ b/readable-python-source/omni_body_skill/tools/pro_apps_v34.py
@@ -70,6 +70,10 @@ PRO_APP_ACTIONS: Dict[str, Dict[str, Any]] = {
     "docker.compose.config": {"risk": "A0", "implemented": True, "summary": "Validate/print docker compose config for a compose file."},
 
     "sqlite.query": {"risk": "A2", "implemented": True, "summary": "Run a SQLite query against a workspace database; SELECT by default, writes require confirmed=true."},
+
+    "mcp.servers.list": {"risk": "A0", "implemented": True, "summary": "List user-configured MCP servers from ~/.tiangong/v3/mcp_servers.json (read-only, no env values)."},
+    "mcp.tools.list": {"risk": "A0", "implemented": True, "summary": "Connect to a configured MCP server and list its tools with input schemas."},
+    "mcp.tool.call": {"risk": "A3", "implemented": True, "summary": "Call one tool on a configured MCP server; A3 confirmation chain applies because MCP tools can have arbitrary side effects."},
 }
 
 APP_PROFILES: Dict[str, Dict[str, Any]] = {
@@ -190,6 +194,15 @@ APP_PROFILES: Dict[str, Dict[str, Any]] = {
         "bridge_actions": [],
         "official_path": "stdlib sqlite3 local database query/limited update executor.",
     },
+    "mcp": {
+        "label": "Model Context Protocol",
+        "modules": [],
+        "executables": [],
+        "env": [],
+        "native_actions": ["mcp.servers.list", "mcp.tools.list", "mcp.tool.call"],
+        "bridge_actions": [],
+        "official_path": "MCP stdio servers declared by the user in ~/.tiangong/v3/mcp_servers.json; the model can only reference configured server names and can never invent spawn commands.",
+    },
 }
 
 
@@ -208,6 +221,8 @@ def handle_pro_app_action(runtime: Any, op_id: str, action: str, target: str | N
         return _bridge_pack_create(runtime, target, args)
     if action.startswith("browser.playwright."):
         return _browser_playwright(runtime, action, target, args)
+    if action.startswith("mcp."):
+        return _mcp_action(runtime, action, target, args)
     if action == "microsoft.graph.request_pack.create":
         return _request_pack(runtime, target, args, provider="microsoft_graph")
     if action == "microsoft.office.com.script.create":
@@ -926,6 +941,59 @@ def _docker_action(runtime: Any, action: str, target: str | None, args: Dict[str
         return {"success": False, "message": f"unsupported docker action: {action}"}
     res = subprocess.run(cmd, cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 60)))
     return {"success": res.returncode == 0, "result": {"cmd": cmd[1:], "returncode": res.returncode, "stdout": res.stdout, "stderr": res.stderr}, "evidence": {"path": "docker", "exists": True, "bytes": len(res.stdout)}}
+
+
+def _mcp_action(runtime: Any, action: str, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:
+    """MCP 接入（v1）：服务器只能来自用户配置文件，模型不可自造命令。
+
+    权限链全复用：mcp.tool.call 注册为 A3，由网关确认链把关——任何
+    MCP 工具都可能有任意副作用，宁可多确认一次。
+    """
+    from .mcp_client import (
+        DEFAULT_TIMEOUT_MS,
+        McpClientError,
+        call_tool,
+        list_servers,
+        list_tools,
+    )
+
+    def _timeout_ms() -> int:
+        try:
+            return int(args.get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        except (TypeError, ValueError):
+            return DEFAULT_TIMEOUT_MS
+
+    try:
+        if action == "mcp.servers.list":
+            servers = list_servers()
+            return {
+                "success": True,
+                "result": {
+                    "servers": servers,
+                    "count": len(servers),
+                    "hint": "服务器在 ~/.tiangong/v3/mcp_servers.json 中由用户配置；模型只能引用 server 名。",
+                },
+            }
+        if action == "mcp.tools.list":
+            server = str(target or args.get("server") or "").strip()
+            result = list_tools(server, timeout_ms=_timeout_ms())
+            return {"success": True, "result": result}
+        if action == "mcp.tool.call":
+            server = str(target or args.get("server") or "").strip()
+            tool = str(args.get("tool") or args.get("name") or "").strip()
+            arguments = args.get("arguments") or {}
+            result = call_tool(server, tool, arguments, timeout_ms=_timeout_ms())
+            return {
+                "success": not result.get("is_error"),
+                # 两种失败（isError / McpClientError）保持同一形状：
+                # error + message + result 三键齐全，下游按 error 分类。
+                "error": "" if not result.get("is_error") else "mcp.tool.is_error",
+                "result": result,
+                "message": "MCP tool reported isError" if result.get("is_error") else "",
+            }
+    except McpClientError as exc:
+        return {"success": False, "error": exc.code, "result": None, "message": str(exc)}
+    return {"success": False, "error": "mcp.action.unknown", "result": None, "message": f"unknown mcp action: {action}"}
 
 
 def _sqlite_query(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/communication_service/channel_authority.py
+++ b/src/communication_service/channel_authority.py
@@ -48,6 +48,7 @@ class ChannelAuthorityGate:
         self._lock = threading.RLock()
         self._leases: dict[tuple[str, str, str], ChannelOwnershipLease] = {}
         self._draining: set[tuple[str, str, str]] = set()
+        self._drain_backup: dict[tuple[str, str, str], ChannelOwnershipLease] = {}
         self._inflight: dict[tuple[str, str, str], dict[str, int]] = {}
 
     def install_lease(self, lease: ChannelOwnershipLease, *, now_ms: int) -> bool:
@@ -99,10 +100,36 @@ class ChannelAuthorityGate:
     ) -> tuple[int, int]:
         key = _scope_key(channel, tenant_id, link_account_id)
         with self._lock:
-            self._leases.pop(key, None)
+            lease = self._leases.pop(key, None)
             self._draining.add(key)
+            # 暂存被摘除的租约：drain 前置检查失败时 abort_drain 恢复，
+            # 否则一次失败的 drain 会永久停用该通道的轮询与发送。
+            if lease is not None:
+                self._drain_backup[key] = lease
             counts = self._inflight.get(key, {})
             return counts.get("POLL", 0), counts.get("SEND", 0)
+
+    def abort_drain(
+        self,
+        *,
+        channel: str,
+        tenant_id: str,
+        link_account_id: str,
+    ) -> bool:
+        """Drain 前置校验失败：回滚到 begin_drain 之前的状态。
+
+        恢复的租约若已过期，后续 authorize 会按既有 lease_expired 语义
+        自行清理——通道回到正常租约生命周期，而不是卡在 draining。
+        """
+
+        key = _scope_key(channel, tenant_id, link_account_id)
+        with self._lock:
+            self._draining.discard(key)
+            lease = self._drain_backup.pop(key, None)
+            if lease is None or key in self._leases:
+                return False
+            self._leases[key] = lease
+            return True
 
     def _authorize_locked(
         self,

--- a/src/communication_service/drain.py
+++ b/src/communication_service/drain.py
@@ -46,36 +46,47 @@ class CommunicationDrainInspector:
             tenant_id=tenant_id,
             link_account_id=link_account_id,
         )
-        inbox = self._inbox.channel_drain_facts(
-            channel=channel,
-            tenant_id=tenant_id,
-            link_account_id=link_account_id,
-        )
-        deliveries = self._deliveries.channel_drain_facts(
-            channel=channel,
-            tenant_id=tenant_id,
-            link_account_id=link_account_id,
-        )
-        if inflight_poll_count:
-            raise ChannelDrainNotReady("channel.drain.poll_inflight")
-        if gate_inflight_send_count or deliveries.inflight_send_count:
-            raise ChannelDrainNotReady("channel.drain.send_inflight")
-        if inbox.unacknowledged_count:
-            raise ChannelDrainNotReady("channel.drain.inbox_unacknowledged")
-        if deliveries.unresolved_delivery_count:
-            raise ChannelDrainNotReady("channel.drain.delivery_unresolved")
-        return build_channel_drain_evidence(
-            channel=channel,
-            tenant_id=tenant_id,
-            link_account_id=link_account_id,
-            gateway_epoch=gateway_epoch,
-            legacy_owner_component_id=legacy_owner_component_id,
-            legacy_owner_instance_id=legacy_owner_instance_id,
-            inbox_ledger_sha256=inbox.ledger_sha256,
-            delivery_ledger_sha256=deliveries.ledger_sha256,
-            last_cursor_sha256=inbox.last_cursor_sha256,
-            observed_at_ms=observed_at_ms,
-        )
+        try:
+            inbox = self._inbox.channel_drain_facts(
+                channel=channel,
+                tenant_id=tenant_id,
+                link_account_id=link_account_id,
+            )
+            deliveries = self._deliveries.channel_drain_facts(
+                channel=channel,
+                tenant_id=tenant_id,
+                link_account_id=link_account_id,
+            )
+            if inflight_poll_count:
+                raise ChannelDrainNotReady("channel.drain.poll_inflight")
+            if gate_inflight_send_count or deliveries.inflight_send_count:
+                raise ChannelDrainNotReady("channel.drain.send_inflight")
+            if inbox.unacknowledged_count:
+                raise ChannelDrainNotReady("channel.drain.inbox_unacknowledged")
+            if deliveries.unresolved_delivery_count:
+                raise ChannelDrainNotReady("channel.drain.delivery_unresolved")
+            return build_channel_drain_evidence(
+                channel=channel,
+                tenant_id=tenant_id,
+                link_account_id=link_account_id,
+                gateway_epoch=gateway_epoch,
+                legacy_owner_component_id=legacy_owner_component_id,
+                legacy_owner_instance_id=legacy_owner_instance_id,
+                inbox_ledger_sha256=inbox.ledger_sha256,
+                delivery_ledger_sha256=deliveries.ledger_sha256,
+                last_cursor_sha256=inbox.last_cursor_sha256,
+                observed_at_ms=observed_at_ms,
+            )
+        except Exception:
+            # 前置校验失败：回滚 begin_drain 摘掉的租约与 draining 状态，
+            # 否则一次失败的 drain 会让该通道停止轮询/发送，直到外部
+            # 重新安装租约才能恢复。
+            self._channel_authority.abort_drain(
+                channel=channel,
+                tenant_id=tenant_id,
+                link_account_id=link_account_id,
+            )
+            raise
 
 
 __all__ = ["ChannelDrainNotReady", "CommunicationDrainInspector"]

--- a/src/communication_service/feishu_route.py
+++ b/src/communication_service/feishu_route.py
@@ -442,11 +442,16 @@ class FeishuRouteLedger:
             ).fetchone()
             if previous is not None:
                 old = self._unprotect_resource(previous)
-                if old != FeishuProtectedResource(
+                # created_at_ms 是观测时间而非身份字段：附件下载窗口崩溃
+                # 后平台重投同一事件时捕获时间必然不同，若参与身份比对
+                # 该事件将永远无法持久化/ACK。身份 = resource_id 派生所
+                # 用的全部字段。
+                identity = FeishuProtectedResource(
                     resource_id=resource_id,
-                    created_at_ms=created_at_ms,
+                    created_at_ms=0,
                     **payload,
-                ):
+                )
+                if old.model_copy(update={"created_at_ms": 0}) != identity:
                     raise FeishuRouteConflict("Feishu resource identity changed")
                 return resource_id
             self._connection.execute(

--- a/src/communication_service/runtime.py
+++ b/src/communication_service/runtime.py
@@ -232,7 +232,7 @@ class CommunicationRuntime:
                 source_instance_id=instance_id,
             )
         )
-        return cls(
+        runtime = cls(
             config,
             instance_id,
             lease,
@@ -248,6 +248,12 @@ class CommunicationRuntime:
             raw_inbound,
             time.monotonic_ns(),
         )
+        # 崩溃恢复接线：上一进程在 SEND 副作用中途退出时留下的
+        # SIDE_EFFECT_STARTED 投递没有网关重发的保证，只能在启动时
+        # 主动转入 RECONCILE_REQUIRED，否则它们永久悬空，
+        # unresolved_delivery_count 恒 >0，drain/割接被永久阻塞。
+        runtime.deliveries.recover_ambiguous(now_ms=observed_ms)
+        return runtime
 
     def health_payload(self) -> dict[str, object]:
         uptime_ms = max(0, (time.monotonic_ns() - self._started_monotonic_ns) // 1_000_000)

--- a/src/communication_service/wechat_inbound.py
+++ b/src/communication_service/wechat_inbound.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol, Self
@@ -13,6 +14,7 @@ from contracts import (
     AttachmentRef,
     InboundEnvelope,
     InboundScope,
+    canonical_json_bytes,
     canonical_sha256,
     derive_inbound_scope_keys,
 )
@@ -31,6 +33,30 @@ def _sorted_unique(values: tuple[str, ...]) -> tuple[str, ...]:
     if tuple(sorted(set(values))) != values:
         raise ValueError("policy set fields must be sorted and unique")
     return values
+
+
+_LOCAL_BATCH_CURSOR_PREFIX = "tg-local-wechat-batch-v1:"
+
+
+def external_cursor_from_local(token: str) -> str:
+    """Map a persisted cursor token to the token the platform will accept.
+
+    A mid-batch crash leaves a local checkpoint token in cursor state; that
+    checkpoint carries the batch's external ``get_updates_buf`` token (JSON
+    encoded) and only the external form may be sent to the platform. Returns
+    "" when the checkpoint predates this encoding or fails to parse — the
+    caller falls back to the credentials cursor instead of replaying the
+    local token at the platform (which it would reject).
+    """
+
+    if not token.startswith(_LOCAL_BATCH_CURSOR_PREFIX):
+        return token
+    try:
+        payload = json.loads(token[len(_LOCAL_BATCH_CURSOR_PREFIX):])
+    except ValueError:
+        return ""
+    external = payload.get("external_cursor_token") if isinstance(payload, dict) else None
+    return external if isinstance(external, str) and external else ""
 
 
 class WechatInboundPolicy(BaseModel):
@@ -356,25 +382,6 @@ class WechatTextInboundProcessor:
                 attachments=attachments,
                 sequence=sequence,
             )
-        ingress = InboxIngress(
-            ingress_id=envelope.inbound_id,
-            envelope=envelope,
-            raw_payload_object_id=poll.raw_payload_object_id,
-            raw_payload_sha256=poll.raw_payload_sha256,
-            raw_payload_size_bytes=poll.raw_payload_size_bytes,
-            cursor_stream_key=derive_cursor_stream_key(
-                "wechat", policy.tenant_id, policy.link_account_id
-            ),
-            previous_cursor_sha256=poll.previous_cursor_sha256,
-            next_cursor_token=poll.next_cursor_token,
-            next_cursor_sha256=cursor_token_sha256(poll.next_cursor_token),
-            captured_at_ms=poll.captured_at_ms,
-            ingress_sha256="0" * 64,
-        ).with_computed_sha256()
-        persisted = self._inbox.persist_and_advance_cursor(
-            ingress,
-            persisted_at_ms=poll.persisted_at_ms,
-        )
         session = self._sessions.decide(
             account_id=policy.account_id,
             sender_ref=sender_ref,
@@ -392,6 +399,37 @@ class WechatTextInboundProcessor:
             sequence=sequence,
             received_at_ms=poll.captured_at_ms,
             incoming_context_token=incoming_context_token,
+        )
+        if existing_ingress is not None:
+            # 平台重投已持久化消息：存量 ingress 原样重放（对照飞书实现）。
+            # 绝不能按新 poll 重建——raw 对象 id、游标链、captured_at_ms
+            # 等易变字段必然不同，会触发 InboxConflictError 让 duplicate
+            # 分支永远不可达，轮询器在重投循环里永久报错。
+            if (
+                existing_ingress.raw_payload_sha256 != poll.raw_payload_sha256
+                or existing_ingress.raw_payload_size_bytes != poll.raw_payload_size_bytes
+            ):
+                raise WechatInboundError("wechat duplicate event changed its raw payload")
+            ingress = existing_ingress
+        else:
+            ingress = InboxIngress(
+                ingress_id=envelope.inbound_id,
+                envelope=envelope,
+                raw_payload_object_id=poll.raw_payload_object_id,
+                raw_payload_sha256=poll.raw_payload_sha256,
+                raw_payload_size_bytes=poll.raw_payload_size_bytes,
+                cursor_stream_key=derive_cursor_stream_key(
+                    "wechat", policy.tenant_id, policy.link_account_id
+                ),
+                previous_cursor_sha256=poll.previous_cursor_sha256,
+                next_cursor_token=poll.next_cursor_token,
+                next_cursor_sha256=cursor_token_sha256(poll.next_cursor_token),
+                captured_at_ms=poll.captured_at_ms,
+                ingress_sha256="0" * 64,
+            ).with_computed_sha256()
+        persisted = self._inbox.persist_and_advance_cursor(
+            ingress,
+            persisted_at_ms=poll.persisted_at_ms,
         )
         return WechatInboundOutcome(
             envelope=envelope,
@@ -411,7 +449,10 @@ class WechatTextInboundProcessor:
         """Persist a getupdates message batch before exposing its final external cursor.
 
         Intermediate cursor tokens are local recovery checkpoints bound to the immutable
-        raw batch object. Only the final member stores the platform get_updates_buf.
+        raw batch object. Only the final member stores the platform get_updates_buf;
+        every intermediate checkpoint also carries that external token (JSON
+        encoded) so a crash mid-batch can resume polling the platform instead of
+        replaying the local checkpoint token at it.
         """
 
         if not raw_messages or len(raw_messages) > 1_000:
@@ -422,16 +463,16 @@ class WechatTextInboundProcessor:
         for index, raw_message in enumerate(raw_messages):
             final = index == len(raw_messages) - 1
             next_token = poll.next_cursor_token if final else (
-                "tg-local-wechat-batch-v1:"
-                + canonical_sha256(
+                _LOCAL_BATCH_CURSOR_PREFIX
+                + canonical_json_bytes(
                     {
                         "raw_payload_object_id": poll.raw_payload_object_id,
                         "raw_payload_sha256": poll.raw_payload_sha256,
                         "member_index": index + 1,
                         "member_count": len(raw_messages),
-                        "external_cursor_sha256": final_cursor_sha256,
+                        "external_cursor_token": poll.next_cursor_token,
                     }
-                )
+                ).decode("utf-8")
             )
             member_poll = poll.model_copy(
                 update={
@@ -452,6 +493,7 @@ __all__ = [
     "WechatInboundPolicy",
     "WechatPollRecord",
     "WechatTextInboundProcessor",
+    "external_cursor_from_local",
     "extract_ilink_text",
     "extract_ilink_media_items",
 ]

--- a/src/communication_service/wechat_worker.py
+++ b/src/communication_service/wechat_worker.py
@@ -25,6 +25,7 @@ from .wechat_inbound import (
     WechatInboundPolicy,
     WechatPollRecord,
     WechatTextInboundProcessor,
+    external_cursor_from_local,
 )
 from .wechat_session import WechatSessionLedger
 
@@ -255,7 +256,12 @@ class WechatProductionAdapter:
         ):
             decision = self._sessions.get_decision(pending.ingress.envelope.channel_message_ref)
             if decision is None:
-                raise WechatPollError("wechat.poll.pending_decision_missing")
+                # 旧版本"先 persist 后 decide"崩溃窗口留下的无决策记录：
+                # 跳过并记状态，绝不 raise——那会让本账号每次轮询循环的
+                # 第一步就失败，所有入站消息永久阻塞。新写入顺序（decide
+                # 先于 persist）已杜绝产生新的此类记录。
+                self._set_state("degraded")
+                continue
             if decision.should_forward:
                 acceptance = self._forward(pending.ingress.envelope, pending.permit, now_ms=now_ms)
                 evidence = (
@@ -296,6 +302,13 @@ class WechatProductionAdapter:
                 stream_key = derive_cursor_stream_key("wechat", self._tenant_id, self._link_account_id)
                 cursor_state = self._inbox.get_cursor(stream_key)
                 cursor = cursor_state.cursor_token if cursor_state is not None else values["cursor"]
+                # 批处理中途崩溃后 cursor state 里是本地检查点 token，平台
+                # 不认识它；解码出检查点携带的外部游标，解码不了（旧格式/
+                # 损坏）就退回凭据里的初始游标，绝不能把本地 token 发给平台。
+                external = external_cursor_from_local(str(cursor))
+                if not external:
+                    external = str(values["cursor"])
+                cursor = external
                 previous_sha = None if cursor_state is None else cursor_state.cursor_sha256
                 with self._authority(now_ms=self._clock_ms()):
                     response, raw = self._transport.get_updates(

--- a/src/life_service/journal_replay.py
+++ b/src/life_service/journal_replay.py
@@ -39,8 +39,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable
 
-from contracts import canonical_sha256
 from .capability_health import ingest_outcome
+from .complete_core import canonical as journal_canonical
 
 
 class JournalReplayError(RuntimeError):
@@ -71,6 +71,10 @@ EVENT_REGISTRY: dict[str, EventClass] = {
     # ---- 自主任务 ----
     "autonomy.task_generated": EventClass.REPLAYABLE_PROJECTION,
     "autonomy.task_status_changed": EventClass.REPLAYABLE_PROJECTION,
+    # standalone 冻结运行时（P11 handoff 缺失回退形态）的自主行动审计
+    # 事实；投影权威在 fact cache，嵌入式重放只需放行不崩溃。
+    "autonomy.action_completed": EventClass.AUDIT_ONLY,
+    "autonomy.action_failed": EventClass.AUDIT_ONLY,
     # ---- 终态执行（不可逆外部效果证据） ----
     "execution.committed": EventClass.EXTERNAL_TERMINAL_EVIDENCE,
     # ---- 能力治理（指针事件 payload 自带完整新状态） ----
@@ -90,6 +94,8 @@ EVENT_REGISTRY: dict[str, EventClass] = {
     "learning.discarded": EventClass.REPLAYABLE_PROJECTION,
     "learning.decision_noop": EventClass.AUDIT_ONLY,
     # ---- 自我迭代升级卡 ----
+    # noop 决策只落审计事件，投影门控键由调度器写侧维护，audit-only。
+    "self_iteration.decision_noop": EventClass.AUDIT_ONLY,
     "upgrade.card_created": EventClass.REPLAYABLE_PROJECTION,
     "upgrade.card_confirmed": EventClass.REPLAYABLE_PROJECTION,
     "upgrade.card_cancelled": EventClass.REPLAYABLE_PROJECTION,
@@ -137,8 +143,22 @@ def _event_ms(event: Mapping[str, Any]) -> int:
         return 0
 
 
+def _journal_fingerprint(value: Any) -> str:
+    """Journal 载荷指纹：与写侧哈希链（complete_core.canonical）同一序列化。
+
+    journal 事件载荷不是签名契约：工具 receipt 可合法携带有限 float
+    telemetry（见 embedded_runtime 写侧注释）。contracts.canonical_sha256
+    对 float/int 超 2^53 直接 raise，用它比较既有投影会在启动重放抛裸
+    TypeError——journal 是权威 WAL，重放必须总能启动。两侧统一用写侧
+    序列化后，指纹对含 float 的载荷稳定且与落盘哈希链一致。
+    """
+    import hashlib
+
+    return hashlib.sha256(journal_canonical(value)).hexdigest()
+
+
 def _same(a: Any, b: Any) -> bool:
-    return canonical_sha256(a) == canonical_sha256(b)
+    return _journal_fingerprint(a) == _journal_fingerprint(b)
 
 
 def _require_mapping(value: Any, code: str) -> dict[str, Any]:
@@ -164,7 +184,7 @@ def _merge_asserted_memory_projection(existing: dict[str, Any], asserted: Mappin
             existing[key] = deepcopy(value)
             changed = True
             continue
-        if canonical_sha256(existing.get(key)) != canonical_sha256(value):
+        if _journal_fingerprint(existing.get(key)) != _journal_fingerprint(value):
             raise JournalReplayError("life.projection.memory_conflict")
     return changed
 
@@ -180,7 +200,7 @@ def _merge_generated_task_projection(existing: dict[str, Any], generated: Mappin
             existing[key] = deepcopy(value)
             changed = True
             continue
-        if canonical_sha256(existing.get(key)) != canonical_sha256(value):
+        if _journal_fingerprint(existing.get(key)) != _journal_fingerprint(value):
             raise JournalReplayError("life.projection.autonomy_task_conflict")
     return changed
 

--- a/src/omni_body_skill/model_adapters/core.py
+++ b/src/omni_body_skill/model_adapters/core.py
@@ -129,7 +129,7 @@ def _omni_parameters_schema(strict: bool = False) -> Dict[str, Any]:
     schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search。优先直接调用生产 action。"},
+            "action": {"type": "string", "description": "要执行的 Omni Body 动作。直接从已实现 action 中选择，例如 file.write/file.read/file.list/code.read/code.write/code.patch_replace/shell.run/quality.run_tests/qc.*/deliverable.package/docx.create/pptx.create/sheet.create/pdf.extract_text/web.search/mcp.servers.list/mcp.tools.list/mcp.tool.call。优先直接调用生产 action。"},
             "target": {"type": "string", "description": "主目标：文件路径、URL、对象ID、输出路径或空字符串。"},
             "args": {
                 "type": "object",
@@ -223,6 +223,7 @@ def _tool_description() -> str:
         "搜索: browser.search_web(网页搜索)/web.search/http.get(读URL)/browser.open.\n"
         "质检交付: qc.*(质量检查)/deliverable.package(交付打包).\n"
         "系统: life.body.state.query/life.activity.query/system.capabilities/system.health/rollback.list/rollback.apply.\n"
+        "扩展: mcp.servers.list(列出用户配置的 MCP 服务器)/mcp.tools.list(列出某服务器的工具)/mcp.tool.call(调用 MCP 工具，A3 需用户确认；服务器只能引用用户已配置的名字，不可自造命令)。\n"
         "受托管小说能力采用最小暴露：通用工具说明不公布其动作名。只有用户明确要求全书/长期多章工程或续作已有托管项目，并且模型实际读取对应受托管 Skill 后，才按该 Skill 公布的动作执行。单章、少量章节、一次性协作资料包不得升级为整书项目。\n"
         "技能选择有双通道：系统已提供 active/related Skill 时直接读取该 Skill；没有匹配且任务需要专用流程时，模型可调用 skill.route 再 skill.get/skill.read。选定后以具体 Skill 的作用域和工作流为准，通用动作说明不得覆盖它。\n"
     )

--- a/src/omni_body_skill/tools/mcp_client.py
+++ b/src/omni_body_skill/tools/mcp_client.py
@@ -1,0 +1,443 @@
+"""MCP (Model Context Protocol) client for omni_body actions.
+
+v1 设计（2026-08-22，"作 omni_body action 接入"方案）：
+
+- **安全边界**：服务器进程只能来自用户管理的
+  ``~/.tiangong/v3/mcp_servers.json``——模型只能引用已配置的服务器名，
+  绝不能自造命令行。配置文件是唯一的 spawn 授权面。
+- **权限链全复用**：mcp.tool.call 注册为 A3，走网关既有确认链；
+  mcp.servers.list / mcp.tools.list 为 A0 只读。
+- **进程生命周期**：每次调用独立 spawn → initialize → 请求 → close。
+  无僵尸进程、无陈旧会话、无并发争用；代价是每次约百毫秒启动，
+  桌面场景可接受。持久会话留作后续。stdout/stderr 各有独立读线程
+  （stderr 持续消费防止服务器日志撑爆管道缓冲导致死锁，只保留尾部
+  用于诊断）；超时/失败清理时按进程树收割（Windows npx/uvx 的 .cmd
+  shim 之下还有真实孙进程）。
+- **传输**：JSON-RPC 2.0 over stdio，按行分隔（MCP stdio 传输）。
+- **资源上限**：默认 30s 超时 / 256KB 输出上限 / 512 行读取上限，
+  均可被 args 有限度覆盖；子进程环境做白名单最小化继承。
+
+配置格式（用户手写，带 ``mcp.servers.list`` 可视化校验）::
+
+    {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/root"],
+          "env": {"NODE_OPTIONS": "--enable-source-maps"},
+          "enabled": true
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROTOCOL_VERSION = "2024-11-05"
+CLIENT_INFO = {"name": "tiangong-omni-body", "version": "3.5"}
+
+CONFIG_PATH = Path.home() / ".tiangong" / "v3" / "mcp_servers.json"
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 120_000
+MAX_OUTPUT_BYTES = 256 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+# stderr 尾部诊断缓冲与 stdout 读线程的生产侧上限（防失控服务器把
+# _lines 队列灌成无界内存）。
+_STDERR_TAIL_BYTES = 4096
+_MAX_QUEUED_LINES = 100_000
+
+# 子进程环境白名单：Windows 进程启动所需的最小集合 + PATH（npx/node/
+# uvx 常见发行方式需要）。绝不整份继承宿主环境（防泄漏宿主凭据变量）。
+_INHERIT_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "ComSpec", "PATHEXT", "windir", "OS",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+    "PATH", "TEMP", "TMP", "USERPROFILE", "HOME",
+    "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "PROGRAMDATA", "HOMEDRIVE", "HOMEPATH",
+)
+
+
+class McpClientError(RuntimeError):
+    """MCP 调用失败（配置缺失/进程失败/协议错误/超时）。"""
+
+    def __init__(self, code: str, detail: str = ""):
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def load_server_config(config_path: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """读取并校验服务器配置；文件缺失返回空表（未配置≠错误）。"""
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        raise McpClientError("mcp.config.invalid", str(exc)) from exc
+    servers = data.get("servers") if isinstance(data, dict) else None
+    if servers is None:
+        return {}
+    if not isinstance(servers, dict):
+        raise McpClientError("mcp.config.invalid", "servers must be an object")
+    clean: Dict[str, Dict[str, Any]] = {}
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or "").strip()
+        if not command:
+            continue
+        args = [str(item) for item in raw.get("args") or [] if str(item).strip()]
+        env = {
+            str(key): str(value)
+            for key, value in (raw.get("env") or {}).items()
+            if str(key).strip()
+        } if isinstance(raw.get("env"), dict) else {}
+        clean[str(name).strip()] = {
+            "command": command,
+            "args": args,
+            "env": env,
+            "enabled": raw.get("enabled") is not False,
+        }
+    return clean
+
+
+def list_servers() -> List[Dict[str, Any]]:
+    """已配置服务器的只读清单（不含 env 值，防凭据泄漏给模型）。"""
+    rows = []
+    for name, cfg in sorted(load_server_config().items()):
+        rows.append({
+            "server": name,
+            "enabled": bool(cfg["enabled"]),
+            "command": cfg["command"],
+            "args": cfg["args"],
+            "env_keys": sorted(cfg["env"].keys()),
+            "config_path": str(CONFIG_PATH),
+        })
+    return rows
+
+
+def _resolve_server(server: str) -> Dict[str, Any]:
+    name = str(server or "").strip()
+    if not name:
+        raise McpClientError("mcp.server.required", "target or args.server is required")
+    config = load_server_config()
+    cfg = config.get(name)
+    if cfg is None:
+        raise McpClientError(
+            "mcp.server.unknown",
+            f"'{name}' is not configured; known: {sorted(config.keys())}",
+        )
+    if not cfg["enabled"]:
+        raise McpClientError("mcp.server.disabled", name)
+    return cfg
+
+
+def _safe_env(extra: Dict[str, str]) -> Dict[str, str]:
+    env = {key: os.environ[key] for key in _INHERIT_ENV_KEYS if os.environ.get(key)}
+    env.update(extra)
+    return env
+
+
+class _ServerProcess:
+    """一个 MCP 服务器子进程的完整生命周期（行分隔 JSON-RPC）。"""
+
+    def __init__(self, cfg: Dict[str, Any], timeout_ms: int):
+        self.timeout_ms = max(1_000, min(int(timeout_ms), MAX_TIMEOUT_MS))
+        # Windows 下 npx/uvx 实为 .cmd  shim，CreateProcess 只认可执行
+        # 本体——先经 PATHEXT 解析成真实路径，否则配置里的 "npx" 会
+        # 直接 FileNotFoundError。解析失败即干净报错，不落到进程层。
+        command = shutil.which(cfg["command"])
+        if command is None:
+            raise McpClientError(
+                "mcp.server.command_not_found",
+                f"'{cfg['command']}' is not on PATH",
+            )
+        # POSIX 下放进独立进程组，超时清理才能整组收割（与 Windows 的
+        # taskkill /T 对应）。
+        try:
+            self._proc = subprocess.Popen(
+                [command, *cfg["args"]],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_safe_env(cfg["env"]),
+                cwd=str(Path.home()),
+                # 桌面冻结应用内 spawn 控制台进程必须隐窗，否则每次调用
+                # 都会闪一个黑色控制台（与本仓 sandbox_runtime 同款约定）。
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+        except OSError as exc:
+            raise McpClientError("mcp.server.spawn_failed", str(exc)) from exc
+        self._lines: "queue.Queue[bytes | None]" = queue.Queue()
+        self._stderr_tail = b""
+        self._stdout_flood = False
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # stderr 必须有独立消费者：stdio MCP 服务器（npx 安装日志、node
+        # 警告）普遍往 stderr 打日志，PIPE 无人读时写满管道缓冲（Windows
+        # 约 64KB）即阻塞服务器进程，表现为首次调用就超时。
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+        self._next_id = 0
+
+    def _read_loop(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for raw in self._proc.stdout:
+                if self._lines.qsize() >= _MAX_QUEUED_LINES:
+                    # 消费侧上限（512 行无响应即 flood）远小于此；到这里的
+                    # 只可能是失控服务器，停止排队防止内存无界增长。
+                    self._stdout_flood = True
+                    break
+                self._lines.put(raw)
+                if len(raw) > MAX_LINE_BYTES:
+                    break
+        except Exception:
+            pass
+        finally:
+            self._lines.put(None)
+
+    def _stderr_loop(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while True:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except Exception:
+            pass
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if len(data) > MAX_LINE_BYTES:
+            raise McpClientError("mcp.request.too_large", str(len(data)))
+        try:
+            self._proc.stdin.write(data + b"\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # 服务器已退出（stdin 断裂）时转成结构化错误，避免裸
+            # BrokenPipeError 逃出 mcp.* 错误码体系。
+            raise McpClientError("mcp.server.exited", f"stdin broken: {exc}") from None
+
+    def _recv_response(self, request_id: int) -> Dict[str, Any]:
+        deadline = time.monotonic() + self.timeout_ms / 1000
+        received = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms")
+            try:
+                raw = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise McpClientError("mcp.timeout", f"{self.timeout_ms}ms") from None
+            if raw is None:
+                # stdout EOF：诊断信息直接取 stderr 读线程的尾部缓冲。
+                # 此处绝不能同步 read() stderr——服务器已死但其孙进程
+                # （npx shim 的 worker）仍持有写端时该读永不返回，
+                # timeout_ms 保护会被整个架空。
+                if self._stdout_flood:
+                    raise McpClientError(
+                        "mcp.protocol.flood",
+                        f"server produced >{_MAX_QUEUED_LINES} queued stdout lines",
+                    )
+                detail = self._stderr_tail.decode("utf-8", errors="replace").strip()[-400:]
+                raise McpClientError("mcp.server.exited", detail)
+            received += 1
+            if received > 512:
+                raise McpClientError("mcp.protocol.flood", ">512 lines without response")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except Exception:
+                continue  # 服务器 banner/日志行，跳过
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def request(self, method: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        response = self._recv_response(request_id)
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            raise McpClientError("mcp.rpc.error", f"{err.get('code')}: {err.get('message')}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise McpClientError("mcp.protocol.invalid", "result is not an object")
+        return result
+
+    def notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def handshake(self) -> Dict[str, Any]:
+        info = self.request("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": CLIENT_INFO,
+        })
+        self.notify("notifications/initialized")
+        return info
+
+    def _kill_tree(self) -> None:
+        """按进程树收割：Windows 的 .cmd shim 之下还有真实孙进程。"""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(self._proc.pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+                return
+            except Exception:
+                pass
+        else:
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin is not None and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=3)
+            return
+        except Exception:
+            pass
+        self._kill_tree()
+        # kill 后仍要 wait 收尸，避免句柄/僵尸泄漏。
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _connect(server: str, timeout_ms: int) -> tuple[Dict[str, Any], _ServerProcess]:
+    cfg = _resolve_server(server)
+    proc: _ServerProcess | None = None
+    try:
+        proc = _ServerProcess(cfg, timeout_ms)
+        info = proc.handshake()
+        return info, proc
+    except Exception:
+        if proc is not None:
+            proc.close()
+        raise
+
+
+def list_tools(server: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dict[str, Any]:
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/list", {})
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise McpClientError("mcp.protocol.invalid", "tools is not a list")
+        # 输出上限：整体序列化超预算即留名占位并停止——放不下就丢，
+        # 绝不把超预算的完整工具（大 inputSchema 可达数 MB）放大进
+        # 模型上下文与审计记录。
+        trimmed: List[Dict[str, Any]] = []
+        budget = MAX_OUTPUT_BYTES
+        truncated = False
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            row = dict(tool)
+            desc = str(row.get("description") or "")
+            if len(desc.encode("utf-8")) > 4096:
+                row["description"] = desc[:2048] + "…"
+            size = len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
+            if size > budget:
+                trimmed.append({"name": str(row.get("name") or ""), "_truncated": True})
+                truncated = True
+                break
+            budget -= size
+            trimmed.append(row)
+        return {
+            "server": server,
+            "server_info": info.get("serverInfo") or {},
+            "tools": trimmed,
+            "truncated": truncated,
+        }
+    finally:
+        proc.close()
+
+
+def call_tool(
+    server: str,
+    tool: str,
+    arguments: Dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> Dict[str, Any]:
+    tool_name = str(tool or "").strip()
+    if not tool_name:
+        raise McpClientError("mcp.tool.required", "args.tool is required")
+    if not isinstance(arguments or {}, dict):
+        raise McpClientError("mcp.arguments.invalid", "args.arguments must be an object")
+    info, proc = _connect(server, timeout_ms)
+    try:
+        result = proc.request("tools/call", {"name": tool_name, "arguments": dict(arguments or {})})
+        content = result.get("content")
+        texts: List[str] = []
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+        joined = "\n".join(texts)
+        encoded = joined.encode("utf-8")
+        truncated = len(encoded) > MAX_OUTPUT_BYTES
+        if truncated:
+            joined = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
+        return {
+            "server": server,
+            "tool": tool_name,
+            "is_error": bool(result.get("isError")),
+            "text": joined,
+            "truncated": truncated,
+            "structured": result.get("structuredContent")
+            if isinstance(result.get("structuredContent"), dict)
+            else None,
+        }
+    finally:
+        proc.close()
+
+
+__all__ = [
+    "CONFIG_PATH",
+    "DEFAULT_TIMEOUT_MS",
+    "McpClientError",
+    "call_tool",
+    "list_servers",
+    "list_tools",
+    "load_server_config",
+]

--- a/src/omni_body_skill/tools/pro_apps_v34.py
+++ b/src/omni_body_skill/tools/pro_apps_v34.py
@@ -70,6 +70,10 @@ PRO_APP_ACTIONS: Dict[str, Dict[str, Any]] = {
     "docker.compose.config": {"risk": "A0", "implemented": True, "summary": "Validate/print docker compose config for a compose file."},
 
     "sqlite.query": {"risk": "A2", "implemented": True, "summary": "Run a SQLite query against a workspace database; SELECT by default, writes require confirmed=true."},
+
+    "mcp.servers.list": {"risk": "A0", "implemented": True, "summary": "List user-configured MCP servers from ~/.tiangong/v3/mcp_servers.json (read-only, no env values)."},
+    "mcp.tools.list": {"risk": "A0", "implemented": True, "summary": "Connect to a configured MCP server and list its tools with input schemas."},
+    "mcp.tool.call": {"risk": "A3", "implemented": True, "summary": "Call one tool on a configured MCP server; A3 confirmation chain applies because MCP tools can have arbitrary side effects."},
 }
 
 APP_PROFILES: Dict[str, Dict[str, Any]] = {
@@ -190,6 +194,15 @@ APP_PROFILES: Dict[str, Dict[str, Any]] = {
         "bridge_actions": [],
         "official_path": "stdlib sqlite3 local database query/limited update executor.",
     },
+    "mcp": {
+        "label": "Model Context Protocol",
+        "modules": [],
+        "executables": [],
+        "env": [],
+        "native_actions": ["mcp.servers.list", "mcp.tools.list", "mcp.tool.call"],
+        "bridge_actions": [],
+        "official_path": "MCP stdio servers declared by the user in ~/.tiangong/v3/mcp_servers.json; the model can only reference configured server names and can never invent spawn commands.",
+    },
 }
 
 
@@ -208,6 +221,8 @@ def handle_pro_app_action(runtime: Any, op_id: str, action: str, target: str | N
         return _bridge_pack_create(runtime, target, args)
     if action.startswith("browser.playwright."):
         return _browser_playwright(runtime, action, target, args)
+    if action.startswith("mcp."):
+        return _mcp_action(runtime, action, target, args)
     if action == "microsoft.graph.request_pack.create":
         return _request_pack(runtime, target, args, provider="microsoft_graph")
     if action == "microsoft.office.com.script.create":
@@ -926,6 +941,59 @@ def _docker_action(runtime: Any, action: str, target: str | None, args: Dict[str
         return {"success": False, "message": f"unsupported docker action: {action}"}
     res = subprocess.run(cmd, cwd=str(runtime.workspace), capture_output=True, text=True, timeout=int(args.get("timeout", 60)))
     return {"success": res.returncode == 0, "result": {"cmd": cmd[1:], "returncode": res.returncode, "stdout": res.stdout, "stderr": res.stderr}, "evidence": {"path": "docker", "exists": True, "bytes": len(res.stdout)}}
+
+
+def _mcp_action(runtime: Any, action: str, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:
+    """MCP 接入（v1）：服务器只能来自用户配置文件，模型不可自造命令。
+
+    权限链全复用：mcp.tool.call 注册为 A3，由网关确认链把关——任何
+    MCP 工具都可能有任意副作用，宁可多确认一次。
+    """
+    from .mcp_client import (
+        DEFAULT_TIMEOUT_MS,
+        McpClientError,
+        call_tool,
+        list_servers,
+        list_tools,
+    )
+
+    def _timeout_ms() -> int:
+        try:
+            return int(args.get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        except (TypeError, ValueError):
+            return DEFAULT_TIMEOUT_MS
+
+    try:
+        if action == "mcp.servers.list":
+            servers = list_servers()
+            return {
+                "success": True,
+                "result": {
+                    "servers": servers,
+                    "count": len(servers),
+                    "hint": "服务器在 ~/.tiangong/v3/mcp_servers.json 中由用户配置；模型只能引用 server 名。",
+                },
+            }
+        if action == "mcp.tools.list":
+            server = str(target or args.get("server") or "").strip()
+            result = list_tools(server, timeout_ms=_timeout_ms())
+            return {"success": True, "result": result}
+        if action == "mcp.tool.call":
+            server = str(target or args.get("server") or "").strip()
+            tool = str(args.get("tool") or args.get("name") or "").strip()
+            arguments = args.get("arguments") or {}
+            result = call_tool(server, tool, arguments, timeout_ms=_timeout_ms())
+            return {
+                "success": not result.get("is_error"),
+                # 两种失败（isError / McpClientError）保持同一形状：
+                # error + message + result 三键齐全，下游按 error 分类。
+                "error": "" if not result.get("is_error") else "mcp.tool.is_error",
+                "result": result,
+                "message": "MCP tool reported isError" if result.get("is_error") else "",
+            }
+    except McpClientError as exc:
+        return {"success": False, "error": exc.code, "result": None, "message": str(exc)}
+    return {"success": False, "error": "mcp.action.unknown", "result": None, "message": f"unknown mcp action: {action}"}
 
 
 def _sqlite_query(runtime: Any, target: str | None, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_channel_cutover.py
+++ b/tests/test_channel_cutover.py
@@ -606,14 +606,18 @@ class CommunicationDrainInspectorTests(unittest.TestCase):
                     legacy_owner_instance_id="legacy-instance",
                     observed_at_ms=1_300,
                 )
-        with self.assertRaisesRegex(ChannelAuthorityError, "draining"):
-            gate.authorize(
-                channel="wechat",
-                tenant_id="tenant-1",
-                link_account_id="account-1",
-                operation="POLL",
-                now_ms=1_301,
-            )
+        # drain 前置失败必须回滚（租约恢复、退出 draining）：调用方的
+        # 模式就是失败后重试 capture，通道在重试间隙绝不能被打断——
+        # 旧语义"失败也保持 draining"会让一次失败的 drain 永久停用
+        # 轮询与发送，直到人工重装租约。
+        restored_lease = gate.authorize(
+            channel="wechat",
+            tenant_id="tenant-1",
+            link_account_id="account-1",
+            operation="POLL",
+            now_ms=1_301,
+        )
+        self.assertIsNotNone(restored_lease)
         evidence = inspector.capture(
             channel="wechat",
             tenant_id="tenant-1",

--- a/tests/test_foundation_closeout.py
+++ b/tests/test_foundation_closeout.py
@@ -1451,12 +1451,13 @@ setTimeout(() => {
         self.assertNotIn("'unsafe-eval'", html)
         self.assertIn("Invoke-Rollback", helper)
         self.assertIn("update-baseline", installer)
-        # 便携模式重定向必须先于模块加载期的 workspace/runtime root 解析，
-        # 否则运行时状态被永久缓存到本机固定目录，便携语义失效。
+        # 启动三段式顺序：source 隔离 → 便携 userData 重定向 → workspace/
+        # runtime root 解析。portable 的 setPath 晚于 resolveWorkspaceMode
+        # 的话，运行时状态会被永久缓存到本机固定目录，便携语义失效。
         self.assertLess(
+            main.index("const SOURCE_ISOLATION = configureSourceIsolation();"),
             main.index('app.setPath("userData", portableUserData)'),
-            main.index("const SOURCE_ISOLATION = configureSourceIsolation()"),
-            "portable userData redirect must run before source isolation / workspace resolution",
+            "source isolation must stay ahead of the portable redirect",
         )
         self.assertLess(
             main.index('app.setPath("userData", portableUserData)'),

--- a/tests/test_foundation_closeout.py
+++ b/tests/test_foundation_closeout.py
@@ -1374,15 +1374,70 @@ const signed = {
 const sig = crypto.sign(null, Buffer.from(canonicalJson(signed)), pair.privateKey).toString("base64");
 const envelope = {signed, signature:{key_id:"root-1", sig}};
 const accepted = verifyManifestEnvelope({envelope, trust, state:{highest_metadata_version:0,highest_release_version:"3.0.3"}, currentVersion:"3.0.3"});
+// 相同 metadata_version 是幂等重查（服务器尚未发布新 manifest），必须放行；
+// 更旧的才是重放/降级攻击。
+let idempotent = "ok";
+try { verifyManifestEnvelope({envelope, trust, state:{highest_metadata_version:1,highest_release_version:"3.0.3"}, currentVersion:"3.0.3"}); } catch (error) { idempotent = error.message; }
 let replay = "";
-try { verifyManifestEnvelope({envelope, trust, state:{highest_metadata_version:1,highest_release_version:"3.0.3"}, currentVersion:"3.0.3"}); } catch (error) { replay = error.message; }
-console.log(JSON.stringify({version: accepted.release_version, replay}));
+try { verifyManifestEnvelope({envelope, trust, state:{highest_metadata_version:2,highest_release_version:"3.0.3"}, currentVersion:"3.0.3"}); } catch (error) { replay = error.message; }
+console.log(JSON.stringify({version: accepted.release_version, idempotent, replay}));
 '''
         completed = subprocess.run(["node", "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
         self.assertEqual(completed.returncode, 0, completed.stderr)
         data = json.loads(completed.stdout)
         self.assertEqual(data["version"], "3.0.4")
+        self.assertEqual(data["idempotent"], "ok")
         self.assertIn("rollback_or_replay", data["replay"])
+
+    def test_updater_phase_preservation_and_baseline_recovery(self) -> None:
+        """资产 phase 不被检查失败作废；基线哈希不可得时保留旧基线。"""
+        script = r'''
+const fs = require("fs"); const os = require("os"); const path = require("path");
+const { SecureUpdater } = require("./app/secure-updater");
+function makeUpdater(tag) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "updater-" + tag + "-"));
+  return new SecureUpdater({ app: null, userData: tmp, currentVersion: "3.0.4",
+    trustPath: path.join(tmp, "trust.json") });
+}
+const assert = (cond, label) => { if (!cond) { console.error("ASSERT_FAIL:" + label); process.exit(1); } };
+
+// 1) DOWNLOADED 是资产状态：recordError 只记错误，不作废下载。
+const a = makeUpdater("asset");
+a._save({ phase: "DOWNLOADED", available: { release_version: "3.0.5" },
+  download_path: path.join(a.root, "pkg.exe"), download_sha256: "a".repeat(64) });
+fs.writeFileSync(a.state.download_path, "x");
+a.recordError(new Error("update_http_500"));
+assert(a.status().phase === "DOWNLOADED", "phase_downloaded_kept");
+
+// 2) 无资产状态失败正常进入 ERROR。
+const b = makeUpdater("idle");
+b._save({ phase: "AVAILABLE" });
+b.recordError(new Error("boom"));
+assert(b.status().phase === "ERROR", "phase_error_reached");
+
+// 3) markHealthy 新包哈希不可得：保留旧基线与旧哈希，绝不提交
+//    "新文件+旧哈希"的错配基线（那会永久锁死后续 apply）。
+const c = makeUpdater("baseline");
+const good = path.join(c.root, "good.exe");
+fs.writeFileSync(good, "baseline");
+c._save({ phase: "APPLYING", transaction_token: "tok",
+  health_marker: path.join(c.root, "m.json"),
+  download_path: path.join(c.root, "vanished.exe"),
+  last_known_good_installer: good, last_known_good_installer_sha256: "b".repeat(64) });
+assert(c.markHealthy("tok") === true, "markhealthy_accepted");
+setTimeout(() => {
+  const state = JSON.parse(fs.readFileSync(c.statePath, "utf8"));
+  assert(state.phase === "COMMITTED", "committed");
+  assert(state.last_known_good_installer === good, "old_baseline_kept");
+  assert(state.last_known_good_installer_sha256 === "b".repeat(64), "old_baseline_hash_kept");
+  assert(String(state.error).includes("baseline_hash_unavailable"), "error_recorded");
+  console.log(JSON.stringify({ ok: true }));
+}, 150);
+'''
+        completed = subprocess.run(["node", "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        data = json.loads(completed.stdout)
+        self.assertTrue(data["ok"])
 
     def test_electron_update_and_security_boundaries_are_present(self) -> None:
         main = (ROOT / "app" / "main.js").read_text(encoding="utf-8")
@@ -1396,6 +1451,18 @@ console.log(JSON.stringify({version: accepted.release_version, replay}));
         self.assertNotIn("'unsafe-eval'", html)
         self.assertIn("Invoke-Rollback", helper)
         self.assertIn("update-baseline", installer)
+        # 便携模式重定向必须先于模块加载期的 workspace/runtime root 解析，
+        # 否则运行时状态被永久缓存到本机固定目录，便携语义失效。
+        self.assertLess(
+            main.index('app.setPath("userData", portableUserData)'),
+            main.index("const SOURCE_ISOLATION = configureSourceIsolation()"),
+            "portable userData redirect must run before source isolation / workspace resolution",
+        )
+        self.assertLess(
+            main.index('app.setPath("userData", portableUserData)'),
+            main.index("(function resolveWorkspaceMode()"),
+            "portable userData redirect must run before resolveWorkspaceMode IIFE",
+        )
 
     def test_generated_source_mirrors_are_in_sync(self) -> None:
         completed = subprocess.run(

--- a/tests/test_journal_reducer_registry.py
+++ b/tests/test_journal_reducer_registry.py
@@ -101,7 +101,17 @@ def test_unknown_event_type_fails_closed() -> None:
 
 def test_audit_only_events_are_noop() -> None:
     scope: dict = {"memories": {}, "memory_relations": [], "executions": {}, "autonomy": {}}
-    for event_type in ("life.heartbeat", "affect.decayed", "life.episode.opened", "memory.recalled"):
+    for event_type in (
+        "life.heartbeat",
+        "affect.decayed",
+        "life.episode.opened",
+        "memory.recalled",
+        # 历史遗漏回归：noop 决策与 standalone 自主行动事实必须已登记，
+        # 否则含这些事件的 journal 重放即 fail-closed，生命无法启动。
+        "self_iteration.decision_noop",
+        "autonomy.action_completed",
+        "autonomy.action_failed",
+    ):
         assert _replay(scope, event_type, {}) is False
 
 
@@ -157,7 +167,37 @@ def test_capability_outcome_uses_idempotency_key_identity() -> None:
     assert health["seen_outcome_ids"] == ["outcome_r1"]
 
 
-def test_learning_published_rebuilds_card_and_artifact_entry() -> None:
+def test_capability_executed_with_float_telemetry_replays_without_error() -> None:
+    """回归 P0-2：journal 载荷合法携带有限 float（工具 telemetry），
+
+    写侧哈希链允许 float；重放比较若用签名契约的 canonical_sha256 会在
+    第二次启动（投影已存在的幂等比较）抛裸 TypeError，生命无法启动。
+    """
+    scope = {
+        "capability_pointers": {"lineage_test": _pointer("art_v1")},
+        "executions": {},
+    }
+    execution = {
+        "execution_id": "caprun_float1",
+        "artifact_id": "art_v1",
+        "status": "completed",
+        "steps": [{"ok": True, "telemetry": {"latency_s": 1.25, "score": 0.98}}],
+    }
+    assert _replay(scope, "capability.executed", {"execution": execution}) is True
+    # 幂等重放（existing 已存在，走 _same 指纹比较）：不再 TypeError。
+    assert _replay(scope, "capability.executed", {"execution": execution}) is False
+    # 内容真正变化时指纹仍能检出差异（没退化成恒等），事件权威覆盖投影。
+    changed_execution = {**execution, "status": "failed", "steps": [{"ok": False, "telemetry": {"retry_s": 2.5}}]}
+    assert _replay(scope, "capability.executed", {"execution": changed_execution}) is True
+    assert scope["executions"]["caprun_float1"]["status"] == "failed"
+
+
+def test_memory_assert_with_float_content_replays_idempotently() -> None:
+    scope: dict = {"memories": {}, "memory_relations": [], "executions": {}, "autonomy": {}}
+    assertion = {"memory_id": "mem_float_1", "content": {"weight_kg": 62.5}, "created_at": "2026-08-22T12:00:00Z"}
+    assert _replay(scope, "memory.asserted", {"assertion": assertion}) is True
+    # 第二次重放走不可变字段指纹比较：float content 不得触发 TypeError。
+    assert _replay(scope, "memory.asserted", {"assertion": assertion}) is False
     scope: dict = {"learning": {}, "capabilities": {}, "knowledge": {}}
     artifact = {"artifact_id": "art_learn_1", "kind": "skill", "title": "测试技能"}
     card = {

--- a/tests/test_mcp_omni_actions.py
+++ b/tests/test_mcp_omni_actions.py
@@ -1,0 +1,311 @@
+"""MCP omni_body 接入（v1）端到端测试。
+
+用真实子进程（sys.executable 驱动的假 MCP 服务器脚本）走完整
+stdio JSON-RPC 链路：handshake -> tools/list -> tools/call，以及
+超时、未知/禁用服务器、错误工具、配置解析与安全边界。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omni_body_skill.tools import mcp_client
+from omni_body_skill.tools.mcp_client import McpClientError
+
+
+FAKE_SERVER = textwrap.dedent(
+    """
+    import json, sys, time
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        method = msg.get("method")
+        if "id" not in msg:
+            continue
+        if method == "initialize":
+            result = {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "fake-mcp", "version": "1.0"}}
+        elif method == "tools/list":
+            result = {"tools": [
+                {"name": "echo", "description": "echo tool", "inputSchema": {"type": "object", "properties": {"payload": {"type": "string"}}}},
+                {"name": "fail", "description": "always fails", "inputSchema": {"type": "object"}},
+                {"name": "slow", "description": "sleeps 10s", "inputSchema": {"type": "object"}},
+            ]}
+        elif method == "tools/call":
+            name = msg["params"]["name"]
+            args = msg["params"].get("arguments") or {}
+            if name == "fail":
+                result = {"content": [{"type": "text", "text": "boom"}], "isError": True}
+            elif name == "slow":
+                time.sleep(10)
+                result = {"content": [{"type": "text", "text": "finally"}]}
+            else:
+                result = {"content": [{"type": "text", "text": "echo:" + str(args.get("payload", ""))}]}
+        else:
+            sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "error": {"code": -32601, "message": "method not found"}}) + "\\n")
+            sys.stdout.flush()
+            continue
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": result}) + "\\n")
+        sys.stdout.flush()
+    """
+)
+
+
+@pytest.fixture()
+def mcp_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    server_script = tmp_path / "fake_mcp_server.py"
+    server_script.write_text(FAKE_SERVER, encoding="utf-8")
+    config = tmp_path / "mcp_servers.json"
+    config.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "fake": {
+                        "command": sys.executable,
+                        "args": [str(server_script)],
+                        "env": {"FAKE_SECRET": "should-not-leak"},
+                    },
+                    "disabled_one": {
+                        "command": sys.executable,
+                        "args": [str(server_script)],
+                        "enabled": False,
+                    },
+                }
+            },
+            ensure_ascii=True,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config)
+    return config
+
+
+def test_servers_list_hides_env_values(mcp_setup) -> None:
+    rows = mcp_client.list_servers()
+    assert [row["server"] for row in rows] == ["disabled_one", "fake"]
+    fake = next(row for row in rows if row["server"] == "fake")
+    assert fake["env_keys"] == ["FAKE_SECRET"]  # only key names, never values
+    assert "should-not-leak" not in json.dumps(rows, ensure_ascii=False)
+
+
+def test_unknown_and_disabled_servers_fail_closed(mcp_setup) -> None:
+    with pytest.raises(McpClientError) as caught:
+        mcp_client.list_tools("nope")
+    assert caught.value.code == "mcp.server.unknown"
+    with pytest.raises(McpClientError) as caught:
+        mcp_client.list_tools("disabled_one")
+    assert caught.value.code == "mcp.server.disabled"
+
+
+def test_tools_list_end_to_end(mcp_setup) -> None:
+    result = mcp_client.list_tools("fake", timeout_ms=15000)
+    assert result["server_info"]["name"] == "fake-mcp"
+    assert [tool["name"] for tool in result["tools"]] == ["echo", "fail", "slow"]
+
+
+def test_tool_call_end_to_end(mcp_setup) -> None:
+    result = mcp_client.call_tool("fake", "echo", {"payload": "nihao"}, timeout_ms=15000)
+    assert result["text"] == "echo:nihao"
+    assert result["is_error"] is False
+
+
+def test_tool_error_is_reported_not_raised(mcp_setup) -> None:
+    result = mcp_client.call_tool("fake", "fail", {}, timeout_ms=15000)
+    assert result["is_error"] is True
+    assert result["text"] == "boom"
+
+
+def test_timeout_kills_slow_tool(mcp_setup) -> None:
+    with pytest.raises(McpClientError) as caught:
+        mcp_client.call_tool("fake", "slow", {}, timeout_ms=1500)
+    assert caught.value.code == "mcp.timeout"
+
+
+def test_missing_config_means_empty_not_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", tmp_path / "absent.json")
+    assert mcp_client.list_servers() == []
+    with pytest.raises(McpClientError) as caught:
+        mcp_client.list_tools("anything")
+    assert caught.value.code == "mcp.server.unknown"
+
+
+def test_command_not_found_is_clean_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """配置里的命令不在 PATH 上（如未装 node 时的 npx）须干净报错。"""
+    config = tmp_path / "mcp_servers.json"
+    config.write_text(
+        json.dumps({"servers": {"ghost": {"command": "tiangong-no-such-command-xyz"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config)
+    with pytest.raises(McpClientError) as caught:
+        mcp_client.list_tools("ghost", timeout_ms=5000)
+    assert caught.value.code == "mcp.server.command_not_found"
+
+
+def test_omni_dispatch_and_risk_classification(mcp_setup) -> None:
+    from omni_body_skill.tools.pro_apps_v34 import PRO_APP_ACTIONS, handle_pro_app_action
+
+    assert PRO_APP_ACTIONS["mcp.servers.list"]["risk"] == "A0"
+    assert PRO_APP_ACTIONS["mcp.tools.list"]["risk"] == "A0"
+    # Any MCP tool may have side effects: A3 rides the gateway confirmation chain.
+    assert PRO_APP_ACTIONS["mcp.tool.call"]["risk"] == "A3"
+
+    class _StubRuntime:
+        pass
+
+    listed = handle_pro_app_action(_StubRuntime(), "x", "mcp.servers.list", None, {})
+    assert listed["success"] is True
+    assert listed["result"]["count"] == 2
+
+    echoed = handle_pro_app_action(
+        _StubRuntime(),
+        "x",
+        "mcp.tool.call",
+        "fake",
+        {"tool": "echo", "arguments": {"payload": "hi"}, "timeout_ms": 15000},
+    )
+    assert echoed["success"] is True
+    assert echoed["result"]["text"] == "echo:hi"
+
+
+# ---------- stderr 管道与进程生命周期回归 ----------
+
+NOISY_SERVER = textwrap.dedent(
+    """
+    import json, sys
+    # 话痨服务器：先写 300KB stderr（远超 Windows 管道缓冲 ~64KB），
+    # 再正常服务协议。旧客户端 stderr 无人消费，服务器阻塞在写 stderr，
+    # 表现为首次调用即超时。
+    sys.stderr.write("E" * 300_000)
+    sys.stderr.flush()
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        if "id" not in msg:
+            continue
+        if msg.get("method") == "initialize":
+            result = {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "noisy", "version": "1.0"}}
+        elif msg.get("method") == "tools/call":
+            result = {"content": [{"type": "text", "text": "echo:" + str((msg["params"].get("arguments") or {}).get("payload", ""))}]}
+        else:
+            result = {"tools": []}
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": result}) + "\\n")
+        sys.stdout.flush()
+    """
+)
+
+
+def _write_config(tmp_path: Path, name: str, script_body: str, *, extra: dict | None = None) -> Path:
+    script = tmp_path / f"{name}_server.py"
+    script.write_text(script_body, encoding="utf-8")
+    servers = {
+        name: {"command": sys.executable, "args": [str(script)]},
+    }
+    if extra:
+        servers.update(extra)
+    config = tmp_path / f"{name}_mcp_servers.json"
+    config.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+    return config
+
+
+def test_noisy_stderr_server_still_serves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """stderr 写满管道缓冲后服务器仍能正常响应（死锁回归）。"""
+    config = _write_config(tmp_path, "noisy", NOISY_SERVER)
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config)
+    result = mcp_client.call_tool("noisy", "echo", {"payload": "ok"}, timeout_ms=15_000)
+    assert result["text"] == "echo:ok"
+
+
+CRASH_SERVER = textwrap.dedent(
+    """
+    import json, subprocess, sys
+    # 崩溃服务器：initialize 时先 spawn 孙进程（继承 stderr 写端、存活
+    # 10s），随后自身退出且不回包。旧客户端在 stdout EOF 后同步 read()
+    # stderr，被孙进程的写端挂住，3s 超时的调用实测挂到 60s。
+    for line in sys.stdin:
+        msg = json.loads(line.strip())
+        if msg.get("method") == "initialize":
+            # 孙进程只持有 stderr 写端（stdout 走 DEVNULL），精确复现
+            # "服务器已死 + 孙进程挂住 stderr" 的崩溃现场。
+            subprocess.Popen([sys.executable, "-c", "import time; time.sleep(10)"], stdout=subprocess.DEVNULL)
+            sys.exit(3)
+    """
+)
+
+
+def test_server_exit_with_grandchild_stderr_holder_returns_promptly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import time as _time
+
+    config = _write_config(tmp_path, "crashy", CRASH_SERVER)
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config)
+    started = _time.monotonic()
+    with pytest.raises(McpClientError) as caught:
+        mcp_client.call_tool("crashy", "echo", {}, timeout_ms=5_000)
+    elapsed = _time.monotonic() - started
+    assert caught.value.code == "mcp.server.exited"
+    # 诊断走 stderr 尾部缓冲，绝不等待孙进程放开写端（孙进程存活 10s）。
+    assert elapsed < 4.5, f"call blocked for {elapsed:.1f}s despite grandchild stderr holder"
+
+
+def test_list_tools_enforces_output_budget(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """单个工具带 3MB inputSchema 时清单必须截断到预算内（放大回归）。"""
+    big_server = textwrap.dedent(
+        """
+        import json, sys
+        for line in sys.stdin:
+            msg = json.loads(line.strip())
+            if "id" not in msg:
+                continue
+            if msg.get("method") == "initialize":
+                result = {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "big", "version": "1.0"}}
+            else:
+                result = {"tools": [
+                    {"name": "small", "description": "ok", "inputSchema": {"type": "object"}},
+                    {"name": "huge", "description": "giant schema", "inputSchema": {"type": "object", "properties": {"blob": {"type": "string", "default": "x" * 3_000_000}}}},
+                    {"name": "after", "description": "never reached", "inputSchema": {"type": "object"}},
+                ]}
+            sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": result}) + "\\n")
+            sys.stdout.flush()
+        """
+    )
+    config = _write_config(tmp_path, "big", big_server)
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config)
+    result = mcp_client.list_tools("big", timeout_ms=15_000)
+    assert result["truncated"] is True
+    serialized = len(json.dumps(result, ensure_ascii=False).encode("utf-8"))
+    assert serialized <= 256 * 1024 + 2_048, f"tools list inflated to {serialized} bytes"
+    names = [tool["name"] for tool in result["tools"]]
+    assert "after" not in names  # 超预算后立即停止
+    assert result["tools"][-1].get("_truncated") is True
+
+
+def test_is_error_failure_shape_carries_error_code(mcp_setup) -> None:
+    from omni_body_skill.tools.pro_apps_v34 import handle_pro_app_action
+
+    class _StubRuntime:
+        pass
+
+    failed = handle_pro_app_action(
+        _StubRuntime(),
+        "x",
+        "mcp.tool.call",
+        "fake",
+        {"tool": "fail", "timeout_ms": 15000},
+    )
+    # isError 与 McpClientError 两种失败形状一致：error 键始终在场。
+    assert failed["success"] is False
+    assert failed["error"] == "mcp.tool.is_error"
+    assert failed["result"]["is_error"] is True

--- a/tests/test_wechat_inbound.py
+++ b/tests/test_wechat_inbound.py
@@ -256,6 +256,99 @@ class WechatInboundTests(unittest.TestCase):
         self.assertEqual(cursor.revision, 2)
         self.assertEqual(self.inbox.count_records(), 2)
 
+    def _poll_with_object(self, object_id, *, previous=None, next_token="cursor-1", captured=2_000):
+        return WechatPollRecord(
+            raw_payload_object_id=object_id,
+            raw_payload_sha256="a" * 64,
+            raw_payload_size_bytes=100,
+            previous_cursor_sha256=previous,
+            next_cursor_token=next_token,
+            captured_at_ms=captured,
+            persisted_at_ms=captured + 1,
+        )
+
+    def test_redelivery_with_fresh_volatile_fields_replays_stored_ingress(self):
+        """平台重投：raw 对象 id/捕获时间全新，必须走 duplicate 而非冲突。
+
+        旧实现按新 poll 重建 InboxIngress，volatile 字段必然与存量不同，
+        InboxConflictError 让 duplicate 分支永远不可达、轮询器死循环。
+        """
+        first = self.processor.process(
+            message(), policy=self.policy, poll=self.poll(captured=2_000)
+        )
+        self.assertFalse(first.inbox_duplicate)
+        # 新一轮轮询：同一消息被平台重发，本地 raw store 落了新对象、
+        # 捕获时间也变了——只有内容 sha 与首投一致。
+        redelivered = self.processor.process(
+            message(),
+            policy=self.policy,
+            poll=self._poll_with_object("raw-wechat-batch-2", captured=9_000),
+        )
+        self.assertTrue(redelivered.inbox_duplicate)
+        self.assertTrue(redelivered.decision.duplicate)
+        self.assertEqual(redelivered.envelope.text, "你好")
+        self.assertEqual(self.inbox.count_records(), 1)
+
+    def test_local_checkpoint_cursor_carries_external_token(self):
+        """批中途崩溃后 cursor state 是本地检查点：必须能解码回外部游标。"""
+        from contracts import canonical_json_bytes
+        from communication_service.wechat_inbound import external_cursor_from_local
+
+        poll = self.poll(next_token="external-buffer-9")
+        batch = self.processor.process_batch(
+            (
+                message("message-1", sequence=1),
+                message("message-2", sequence=2, context_token=None),
+            ),
+            policy=self.policy,
+            poll=poll,
+        )
+        # 成员 0 的检查点在 permit 链上只暴露 sha；用同源构造验证解析。
+        checkpoint = "tg-local-wechat-batch-v1:" + canonical_json_bytes(
+            {
+                "raw_payload_object_id": "raw-wechat-batch-1",
+                "raw_payload_sha256": "a" * 64,
+                "member_index": 1,
+                "member_count": 2,
+                "external_cursor_token": "external-buffer-9",
+            }
+        ).decode("utf-8")
+        # 崩溃重启：worker 读到的合成检查点可还原出整批的外部游标。
+        self.assertEqual(external_cursor_from_local(checkpoint), "external-buffer-9")
+        # 批正常完成时 cursor state 落的是外部游标本身。
+        cursor = self.inbox.get_cursor(batch.ack_permit.cursor_stream_key)
+        self.assertEqual(cursor.cursor_token, "external-buffer-9")
+        # 普通外部游标原样返回；旧格式/损坏的检查点返回空串（调用方回退）。
+        self.assertEqual(external_cursor_from_local("plain-token"), "plain-token")
+        self.assertEqual(external_cursor_from_local("tg-local-wechat-batch-v1:not-json"), "")
+
+    def test_mid_batch_crash_then_full_redelivery_recovers_without_conflict(self):
+        """批处理中途崩溃：重发整批，已持久化成员走 duplicate、其余正常插入。"""
+        poll = self.poll(next_token="external-buffer-2")
+        batch = self.processor.process_batch(
+            (
+                message("message-1", sequence=1, context_token="token-1"),
+                message("message-2", sequence=2, context_token=None),
+            ),
+            policy=self.policy,
+            poll=poll,
+        )
+        self.assertEqual(self.inbox.count_records(), 2)
+        # 平台视角整批重发（新 raw 对象/新捕获时间，内容 sha 相同）。
+        redelivered = self.processor.process_batch(
+            (
+                message("message-1", sequence=1, context_token="token-1"),
+                message("message-2", sequence=2, context_token=None),
+            ),
+            policy=self.policy,
+            poll=self._poll_with_object(
+                "raw-wechat-batch-2", previous=None, next_token="external-buffer-3", captured=9_000
+            ),
+        )
+        self.assertTrue(redelivered.outcomes[0].inbox_duplicate)
+        self.assertTrue(redelivered.outcomes[1].inbox_duplicate)
+        self.assertEqual(self.inbox.count_records(), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

全仓审计（6 模块并行审查 + 交叉复核）发现 86 项，本 PR 修复三批共 17 项（2 个 P0、9 个高危/严重、6 个中危），每项带回归测试。

## 第一批：生命核心 + MCP + XSS + wmic

- **P0** `self_iteration.decision_noop` 未登记 Reducer Registry → noop 决策后重启生命永久无法启动；顺带登记 `autonomy.action_completed/failed`
- **P0** journal 写侧允许 float、重放比较侧 raise 的序列化不对称 → 含 float telemetry 的事件第二次启动必抛 TypeError；重放指纹统一用写侧序列化（contracts 签名禁 float 约束不变）
- MCP client：stderr 管道无消费者死锁（实测复现）、服务器崩溃后 `stderr.read()` 无限期挂死（实测 3s 超时挂 60s）、kill 不杀进程树、list_tools 预算放大 12 倍、失败返回形状统一
- 前端执行页侧栏存储型 XSS（设置自由文本 → innerHTML）
- Win11 24H2 无 wmic 时机杀无关进程（本机实测 ENOENT；PowerShell CIM 回退 + 探测失败保守拒绝）

## 第二批：secure-updater 四连环 + 便携版

- 防回滚 `<=` 改 `<`（相同 metadata_version 是幂等重查，签名/过期/版本三重校验在前）；资产 phase（DOWNLOADED 等）不再被检查失败作废；下载 writeSync 异常不再冒泡主进程崩溃且 Promise 悬挂；markHealthy 失败不再提交"新文件+旧哈希"永久锁死升级
- 便携版 userData 重定向上移到 runtime root 解析之前（旧实现把全部运行时状态写进本机 %APPDATA%，便携语义失效）

## 第三批：微信/飞书崩溃恢复链（对照飞书正确实现补齐微信缺位）

- 平台重投已持久化消息：存量 ingress 原样重放（旧实现必然 InboxConflictError、duplicate 分支死代码）
- decide（幂等）前移到 persist 之前，消除毒丸窗口；存量毒丸跳过不再卡死通道
- 批中途崩溃：检查点 token 携带外部游标，worker 解码后发平台（旧实现把本地合成 token 发给平台，通道永久 degraded）
- 启动接线 `recover_ambiguous`（SEND 崩溃恢复）；飞书资源身份排除 `created_at_ms`；drain 失败回滚租约不再永久停用通道

## 测试

- 针对性回归全绿：registry 11、生命重放 50、MCP 13、通信 123、foundation 62
- 联合回归 885 passed / 4 failed——4 个失败单跑与带负载复现均无法重现（3 轮全过），判定为满负载时序 flaky（extreme_life 系列已有 timing-sensitive 官方标记）

🤖 Generated with [Claude Code](https://claude.com/claude-code)