### PR TITLE
fix: 审计收尾批——前端四项中危 + 通信限流/会话过期 + Electron 小项

### DIFF
--- a/app/frontend-v2/renderer/core/state.mjs
+++ b/app/frontend-v2/renderer/core/state.mjs
@@ -256,7 +256,7 @@ function cleanMessages(messages, sessionId = "") {
         sessionId: boundedText(item?.sessionId || item?.session_id || item?.conversationId || item?.conversation_id || sessionId || "", 256),
         kind: item?.kind ? boundedText(item.kind, 64) : null,
         requestId: item?.requestId || item?.request_id ? boundedText(item?.requestId || item?.request_id, 256) : null
-      })).filter((item) => item.role && item.content).slice(-80)
+      })).filter((item) => item.role && (item.content || item.kind === "work")).slice(-80)
     : [];
 }
 

--- a/app/frontend-v2/renderer/plugins/life-panel.mjs
+++ b/app/frontend-v2/renderer/plugins/life-panel.mjs
@@ -1019,9 +1019,14 @@ function renderOverview(payload) {
   const attemptBudget = numberValue(budget.attempt_limit, numberValue(settings.llm_daily_attempt_budget));
   const used = numberValue(budget.used);
   const attempts = numberValue(budget.attempts);
-  const budgetTotal = dailyBudget > 0 ? dailyBudget : attemptBudget;
-  const budgetValue = dailyBudget > 0 ? used : attempts;
-  const budgetText = budgetTotal > 0 ? `${budgetValue}/${budgetTotal}` : displayValue(used || attempts || 0);
+  // budget=0 是新语义的"当天完全禁止模型调用"，不是"未配置"：
+  // 字段存在（含 0）就按字面值渲染（0/0 即禁用条），只有字段缺失
+  // 才回退尝试预算或"未配置"文案。
+  const dailyConfigured = budget.success_limit !== undefined && budget.success_limit !== null
+    || settings.llm_daily_budget !== undefined && settings.llm_daily_budget !== null;
+  const budgetTotal = dailyConfigured ? dailyBudget : attemptBudget;
+  const budgetValue = dailyConfigured ? used : attempts;
+  const budgetText = dailyConfigured || attemptBudget > 0 ? `${budgetValue}/${budgetTotal}` : displayValue(used || attempts || 0);
   const recent = safeObject(
     Object.keys(safeObject(summary.recent_autonomous_action)).length
       ? summary.recent_autonomous_action
@@ -1043,7 +1048,7 @@ function renderOverview(payload) {
       <section class="life-card">
         ${sectionTitle("模型预算", "今日 · 不含必做日程")}
         ${budgetAvailable ? `
-          ${progressBar("非日程调用预算", budgetValue, budgetTotal || Math.max(used, attempts, 1), budgetTotal > 0 ? budgetText : "未配置预算上限")}
+          ${progressBar("非日程调用预算", budgetValue, budgetTotal || Math.max(used, attempts, 1), dailyConfigured || attemptBudget > 0 ? budgetText : "未配置预算上限")}
           <div class="life-budget-grid">
             ${kvRows([
               ["成功", budget.successes ?? 0, "ok"],
@@ -2158,8 +2163,13 @@ function collectSettings(form) {
     if (!input || input.disabled) continue;
     let value = field.type === "checkbox" ? Boolean(input.checked) : input.value;
     if (field.type === "number") {
-      const number = Number(value);
-      value = Number.isFinite(number) ? number : 0;
+      const raw = String(input.value || "").trim();
+      const number = Number(raw);
+      // 空输入/非法输入=保留后端现值，绝不静默折叠为 0——预算类字段
+      // 的 0 在新语义下意味着"当天完全禁止模型调用"（Number("")===0，
+      // 空串必须单独拦截）。
+      if (!raw || !Number.isFinite(number)) continue;
+      value = number;
     }
     setNested(payload, field.key, value);
   }

--- a/app/frontend-v2/renderer/plugins/settings-panel.mjs
+++ b/app/frontend-v2/renderer/plugins/settings-panel.mjs
@@ -607,6 +607,11 @@ export const settingsPanelPlugin = {
         actions.refreshConfig?.();
         await loadLinks();
         await ensureWechatQrIfNeeded();
+      } else {
+        // 微信登录轮询的生命周期绑定设置页：离开即停，否则隐藏面板
+        // 每 2.5s 仍请求一次状态直到登录过期；重新进入时 loadLinks 会
+        // 立即刷新一次，轮询由登录动作按需重启。
+        stopWechatStatusTimer();
       }
     }
 

--- a/app/main.js
+++ b/app/main.js
@@ -1934,16 +1934,24 @@ async function copyMediaToClipboard(payload = {}) {
   }
   try {
     const materialized = await materializeMediaTarget(target);
-    const ext = targetImageExtension(materialized.path || target);
-    if (materialized.path && CHAT_IMAGE_EXTENSIONS.includes(ext) && ext !== "svg") {
-      const image = nativeImage.createFromPath(materialized.path);
-      if (!image.isEmpty()) {
-        clipboard.writeImage(image);
-        return { ok: true, copiedAs: "image", target, path: materialized.path };
+    try {
+      const ext = targetImageExtension(materialized.path || target);
+      if (materialized.path && CHAT_IMAGE_EXTENSIONS.includes(ext) && ext !== "svg") {
+        const image = nativeImage.createFromPath(materialized.path);
+        if (!image.isEmpty()) {
+          clipboard.writeImage(image);
+          return { ok: true, copiedAs: "image", target };
+        }
+      }
+      clipboard.writeText(target);
+      return { ok: true, copiedAs: "path", target, warning: "media_clipboard_fell_back_to_path" };
+    } finally {
+      // 下载的临时文件在剪贴板拿到内容后立即删除：旧实现从不清理，
+      // 反复复制远程图片会让 tiangong-media-cache 无限增长。
+      if (materialized.temporary && materialized.path) {
+        fs.promises.unlink(materialized.path).catch(() => {});
       }
     }
-    clipboard.writeText(target);
-    return { ok: true, copiedAs: "path", target, warning: "media_clipboard_fell_back_to_path" };
   } catch (error) {
     return { ok: false, error: error?.message || String(error), target };
   }

--- a/app/service-supervisor.js
+++ b/app/service-supervisor.js
@@ -380,6 +380,9 @@ class ServiceSupervisor {
       return await operation;
     } finally {
       if (this._drainPromise === operation) this._drainPromise = null;
+      // 复位 draining：唯一旧复位点是 startAll()，drainAll 后走 start()/
+      // restart() 的调用方会恒收 services_draining，服务永远拉不起来。
+      if (!this._drainPromise) this._draining = false;
     }
   }
 }

--- a/src/communication_service/embedded_runtime.py
+++ b/src/communication_service/embedded_runtime.py
@@ -103,7 +103,11 @@ class EmbeddedCommunicationService:
                 if action in {"wechat_login_start", "wechat.login.start", "login_start"}:
                     result = self.runtime.wechat_login_start(dict(body.get("payload") or {}), now_ms=now_ms)
                 elif action in {"wechat_login_wait", "wechat.login.wait", "login_wait"}:
-                    result = self.runtime.wechat_login_wait(dict(body.get("payload") or body), now_ms=now_ms)
+                    # 扁平调用形式下 body 带 action 键，wait 的字段白名单
+                    # 只认 session_key/verify_code——与 login_start 的取参
+                    # 方式对齐，payload 优先、扁平回退时剔除 action。
+                    flat = {key: value for key, value in body.items() if key not in {"action", "type"}}
+                    result = self.runtime.wechat_login_wait(dict(body.get("payload") or flat), now_ms=now_ms)
                 elif action in {"wechat_start", "wechat.adapter.start", "start"}:
                     result = self.runtime.wechat_adapter_start({}, now_ms=now_ms)
                 elif action in {"wechat_stop", "wechat.adapter.stop", "stop"}:

--- a/src/communication_service/runtime.py
+++ b/src/communication_service/runtime.py
@@ -57,6 +57,7 @@ from .wechat_login import WECHAT_LOGIN_TTL_MS, WechatLoginError, WechatLoginMana
 from .wechat_typing import WechatTypingManager
 from .wechat_text_outbound import (
     HttpWechatIlinkTextTransport,
+    WechatRateGate,
     WechatTextDeliveryService,
     default_wechat_text_policy,
 )
@@ -106,10 +107,17 @@ class CommunicationRuntime:
         self._workers_lock = threading.RLock()
         self._delivery_lock = threading.RLock()
         self._delivery_dispatcher: VerifiedDeliveryDispatcher | None = None
+        # 文本与文件投递共享同一把账号级限流闸：各持独立 RateGate 时
+        # min_attempt_interval 的账号级限速实际可达两倍。
+        self._wechat_rate_gate = WechatRateGate(
+            clock_ms=lambda: time.time_ns() // 1_000_000,
+            sleeper=time.sleep,
+        )
         self._wechat_text_delivery = WechatTextDeliveryService(
             deliveries,
             wechat_sessions,
             HttpWechatIlinkTextTransport(),
+            rate_gate=self._wechat_rate_gate,
         )
         self._artifact_source = (
             None
@@ -130,6 +138,7 @@ class CommunicationRuntime:
                 staging_root=config.state_root / "staging" / "wechat-outbound",
                 clock_ms=lambda: time.time_ns() // 1_000_000,
                 sleeper=time.sleep,
+                rate_gate=self._wechat_rate_gate,
             )
         )
         self._feishu_transport = HttpFeishuApiTransport()

--- a/src/communication_service/wechat_text_outbound.py
+++ b/src/communication_service/wechat_text_outbound.py
@@ -301,15 +301,19 @@ class WechatRateGate:
         self._next_attempt_ms: dict[str, int] = {}
 
     def wait(self, account_key: str, *, minimum_interval_ms: int) -> None:
-        with self._lock:
-            now = self._clock_ms()
-            earliest = self._next_attempt_ms.get(account_key, now)
-            if now < earliest:
-                self._sleeper((earliest - now) / 1_000)
+        while True:
+            with self._lock:
                 now = self._clock_ms()
-                if now < earliest:
+                earliest = self._next_attempt_ms.get(account_key, now)
+                if now >= earliest:
+                    self._next_attempt_ms[account_key] = now + minimum_interval_ms
+                    return
+            # 退避窗口在锁外睡眠：持锁睡眠会让无关账号的发送全部排队
+            # 等这一个账号的退避结束（跨账号队头阻塞）。
+            self._sleeper((earliest - now) / 1_000)
+            with self._lock:
+                if self._clock_ms() < earliest:
                     raise WechatTextOutboundError("wechat.send.rate_gate.clock_stalled")
-            self._next_attempt_ms[account_key] = max(now, earliest) + minimum_interval_ms
 
 
 def split_wechat_text(text: str, *, limit: int) -> tuple[str, ...]:

--- a/src/communication_service/wechat_worker.py
+++ b/src/communication_service/wechat_worker.py
@@ -114,6 +114,12 @@ class WechatIlinkPollTransport:
                 raise WechatPollError("wechat.poll.response_shape_invalid")
             ret = value.get("ret")
             if isinstance(ret, bool) or ret not in {None, 0, "0"}:
+                if ret in {-14, "-14"}:
+                    # 会话/凭据过期（与出站侧 WECHAT_SESSION_EXPIRED_CODE 对齐）：
+                    # 不能并进 platform_rejected 的 1 秒重试——那会退化成每秒
+                    # 打一次平台直到人工干预。进入可见的过期状态并长退避，
+                    # 等待重新扫码后 vault 换发新 token 自然恢复。
+                    raise WechatPollError("wechat.poll.context_expired")
                 raise WechatPollError("wechat.poll.platform_rejected")
             return value, raw
         except WechatPollError:
@@ -379,8 +385,12 @@ class WechatProductionAdapter:
                 self._set_state("starting", exc.code)
                 self._closed.wait(0.5)
             except (ProductionIngressError, WechatPollError) as exc:
-                self._set_state("degraded", str(exc))
-                self._closed.wait(1.0)
+                if str(exc) == "wechat.poll.context_expired":
+                    self._set_state("credentials_expired", "wechat.poll.context_expired")
+                    self._closed.wait(60.0)
+                else:
+                    self._set_state("degraded", str(exc))
+                    self._closed.wait(1.0)
             except Exception:
                 self._set_state("error", "wechat.poll.internal_error")
                 self._closed.wait(1.0)

--- a/src/total_gateway/communication_client.py
+++ b/src/total_gateway/communication_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import re
 from typing import Any, Mapping
 
 from contracts import (
@@ -22,6 +23,20 @@ class CommunicationClientError(RuntimeError):
         super().__init__(code)
         self.code = code
         self.ambiguous = ambiguous
+
+
+_REASON_CODE_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,160}")
+
+
+def _sanitized_reason_code(value: Any) -> str:
+    """通信服务回传的 reason_code 只接受受限字符集。
+
+    异常/被攻陷的对端返回含换行或控制字符的 reason_code 时，直接透传
+    会注入日志与 UI（对照 backend_client 的同款白名单）。
+    """
+
+    raw = str(value or "")
+    return raw if _REASON_CODE_PATTERN.fullmatch(raw) else "communication_client.rejected"
 
 
 def _strict_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -136,7 +151,7 @@ class CommunicationControlClient:
                 )
             if response.status < 200 or response.status >= 300 or value.get("ok") is not True:
                 raise CommunicationClientError(
-                    str(value.get("reason_code") or "communication_client.rejected"),
+                    _sanitized_reason_code(value.get("reason_code")),
                     ambiguous=(
                         external_send_started
                         and value.get("outcome_unknown") is not False
@@ -185,7 +200,7 @@ class CommunicationControlClient:
                 raise CommunicationClientError("communication_client.response.invalid_json")
             if response.status != 200 or value.get("ok") is not True:
                 raise CommunicationClientError(
-                    str(value.get("reason_code") or "communication_client.rejected")
+                    _sanitized_reason_code(value.get("reason_code"))
                 )
             return value
         except CommunicationClientError:


### PR DESCRIPTION
## 概要

全仓审计第五批（收尾）：修复剩余中危 10 项——前端 4、通信 3、Electron 2、网关 1。

## 修复清单

**前端**
1. 流式回复占位（`kind=work`）不再被 `cleanMessages` 过滤——切换会话后整轮回复静默消失的根因
2. budget=0 新语义渲染判定：字段存在（含 0）按字面渲染（0/0 即禁用条），不再显示"未配置"与帮助文案矛盾
3. 生命设置数字字段空/非法输入跳过不提交（保留后端现值），不再静默折叠为 0（=当天禁用全部模型调用）；`Number("")===0` 单独拦截
4. 微信登录轮询定时器绑定设置页生命周期，离开即停

**通信**
5. 微信文本/文件投递共享同一把账号级 RateGate（独立闸让账号级限速实际可达两倍）
6. `WechatRateGate` 退避睡眠移出锁——消除跨账号队头阻塞
7. 轮询识别会话过期码（-14）：进入可见的 `credentials_expired` 状态并长退避，替代每秒打一次平台的死循环
8. `login_wait` 扁平调用形式剔除 `action` 键（字段白名单因此必拒的缺陷）

**Electron / 网关**
9. 远程媒体复制后立即删除临时下载文件（`tiangong-media-cache` 无限增长）；`drainAll` 后复位 `_draining`（`start()/restart()` 不再恒收 `services_draining`）
10. `communication_client` 的 `reason_code` 加受限字符集白名单（防异常对端注入日志/UI）

## 测试

通信 + 网关客户端过滤集 133 passed / 53 subtests 全绿；JS 语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)