### PR TITLE
fix(v3): 修多次思考路径 generation=1 + MiMo Token Plan 支持 + httpx 0.28 兼容 + spawn_v3 封装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 .env.*
 !.env.example
 /.tiangong-release-hash-cache.json
+**/.tiangong-release-hash-cache.json
+**/.in/

--- a/app/backend/tiangong-backend/v3/endpoint_security.py
+++ b/app/backend/tiangong-backend/v3/endpoint_security.py
@@ -32,7 +32,8 @@ _OFFICIAL_HOSTS: dict[str, frozenset[str]] = {
     "minimax_m3": frozenset({"api.minimaxi.com"}),
     "minimax": frozenset({"api.minimaxi.com"}),
     "google": frozenset({"generativelanguage.googleapis.com"}),
-    "mimo": frozenset({"api.xiaomimimo.com"}),
+    # bug-fix: MiMo Token Plan endpoint 支持（2026-08-25）
+    "mimo": frozenset({"api.xiaomimimo.com", "token-plan-cn.xiaomimimo.com"}),
 }
 
 

--- a/app/backend/tiangong-backend/v3/jineng/http_kehuduan.py
+++ b/app/backend/tiangong-backend/v3/jineng/http_kehuduan.py
@@ -5,6 +5,15 @@ P18.1 production boundary:
 configured Endpoint -> Protocol Transport -> ProviderTurnEnvelope.
 L4 optimization remains advisory and can never choose the endpoint/protocol.
 """
+# 2026-08-25 fix: 多次思考路径 — 流式期间过滤内联 <think>/<thinking>/<reasoning> 块，
+# 避免思考文本进入正文流；_qingli_sikao 支持三种标签成对删除与未闭合兜底。
+# 2026-08-25 fix: 多次思考路径根治 - cc 修复：
+#   1) 接通 Kimi 遗留的流式过滤器 dead code（llm_diaoyong 两个 execute_streaming_turn
+#      调用点原先传原始 on_text_chunk，过滤器从未生效）；
+#   2) 修复 _LiushiSikaoGuolvqi 两处 bug：部分标签前缀持留分支缺 break 导致死循环、
+#      前缀判定过宽（“a < b”等普通文本会被无限持留卡住流式输出）；
+#   3) _qingli_sikao 真正实现三种标签（think/thinking/reasoning）成对删除与
+#      未闭合兜底（删到文本末尾），与头注释声明一致。
 from __future__ import annotations
 
 import base64
@@ -67,6 +76,125 @@ if _LLM_CALL_MAX_SECONDS <= 0:
     _LLM_CALL_MAX_SECONDS = 300.0
 L4_OPTIMIZATION_TRACE_PATH = ZHUIZONG_LUJING / "l4_model_optimization.jsonl"
 _MODEL_ADAPTER_CORE: Any | None = None
+
+
+# bug-fix: 多次思考路径 - 流式 think 标签状态机过滤
+_SIKAO_BIAOQIAN_MING = ("think", "thinking", "reasoning")
+_SIKAO_KAI_RE = re.compile(
+    r"<\s*(?:think|thinking|reasoning)\b[^>]*>",
+    flags=re.IGNORECASE,
+)
+_SIKAO_BI_RE = re.compile(
+    r"<\s*/\s*(?:think|thinking|reasoning)\b[^>]*>",
+    flags=re.IGNORECASE,
+)
+# bug-fix: 多次思考路径根治 - 成对删除与未闭合兜底（供 _qingli_sikao 使用）：
+# 未闭合的开标签从标签起删到文本末尾，避免截断残留触发外层整轮重跑。
+_SIKAO_CHENGDUI_RE = re.compile(
+    _SIKAO_KAI_RE.pattern + r".*?" + _SIKAO_BI_RE.pattern + r"\s*",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+_SIKAO_WEIBI_RE = re.compile(
+    _SIKAO_KAI_RE.pattern + r".*\Z",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+# bug-fix: 多次思考路径根治 - 前缀判定收紧：尾部必须是 "<"、"</" 或
+# “<标签名前缀[ 属性]”形态；普通文本里的 "<"（如代码 “a < b”）不再被误持留。
+_SIKAO_KEWANC_QIANZHUI_RE = re.compile(
+    r"^<\s*/?\s*([A-Za-z]{1,12})(?:\s[^>]*)?$",
+    flags=re.DOTALL,
+)
+
+
+def _keneng_sikao_biaoqian_qianzhui(tail: str) -> bool:
+    """判断缓冲区尾部是否可能是 think 系列开/闭标签的未完成前缀。"""
+    if tail in ("<", "</"):
+        return True  # 仅 "<" / "</"，标签名未定，先留住
+    pipei = _SIKAO_KEWANC_QIANZHUI_RE.match(tail)
+    if not pipei:
+        return False
+    zimu = pipei.group(1).lower()
+    return any(ming.startswith(zimu) for ming in _SIKAO_BIAOQIAN_MING)
+
+
+class _LiushiSikaoGuolvqi:
+    """流式 think 标签状态机过滤器。
+
+    跨 chunk 保留内部缓冲区：识别 <think>/<thinking>/<reasoning>（含属性、
+    大小写不敏感）的内联思考块并丢弃；思考块外的文本即时透传。
+    流结束（jieshu）时：仍在思考块内 → 剩余整段丢弃；在块外 → 剩余透传。
+    """
+
+    def __init__(self) -> None:
+        self._huanchong = ""
+        self._zai_sikao = False
+
+    def push(self, chunk: str) -> str:
+        self._huanchong += str(chunk or "")
+        return self._chouqu()
+
+    def jieshu(self) -> str:
+        if self._zai_sikao:
+            self._huanchong = ""
+            self._zai_sikao = False
+            return ""
+        shengyu, self._huanchong = self._huanchong, ""
+        return shengyu
+
+    def _chouqu(self) -> str:
+        shuchu: list[str] = []
+        while self._huanchong:
+            if self._zai_sikao:
+                bi = _SIKAO_BI_RE.search(self._huanchong)
+                if bi:
+                    self._huanchong = self._huanchong[bi.end():]
+                    self._zai_sikao = False
+                    continue
+                # 未找到闭合：尾部可能是不完整闭合标签，留住；其余丢弃
+                qie_dian = self._huanchong.rfind("<")
+                if qie_dian >= 0 and _keneng_sikao_biaoqian_qianzhui(self._huanchong[qie_dian:]):
+                    self._huanchong = self._huanchong[qie_dian:]
+                else:
+                    self._huanchong = ""
+                break
+            kai = _SIKAO_KAI_RE.search(self._huanchong)
+            if kai:
+                shuchu.append(self._huanchong[:kai.start()])
+                self._huanchong = self._huanchong[kai.end():]
+                self._zai_sikao = True
+                continue
+            qie_dian = self._huanchong.rfind("<")
+            if qie_dian >= 0 and _keneng_sikao_biaoqian_qianzhui(self._huanchong[qie_dian:]):
+                shuchu.append(self._huanchong[:qie_dian])
+                self._huanchong = self._huanchong[qie_dian:]
+                # bug-fix: 多次思考路径根治 - 持留部分标签前缀后必须 break：
+                # 缺少 break 时缓冲区不变，while 循环原地打转（流式 hang）。
+                break
+            else:
+                shuchu.append(self._huanchong)
+                self._huanchong = ""
+        return "".join(shuchu)
+
+
+def _baozhuang_liushi_sikao_guolv(
+    on_text_chunk: Callable[[str], None] | None,
+) -> tuple[Callable[[str], None] | None, Callable[[], None] | None]:
+    """每次 llm_diaoyong 调用创建一个新过滤器，过滤后的 chunk 转发给原回调。"""
+    if on_text_chunk is None:
+        return None, None
+    guolvqi = _LiushiSikaoGuolvqi()
+
+    def _chunk(text: str) -> None:
+        guolv_hou = guolvqi.push(text)
+        if guolv_hou:
+            on_text_chunk(guolv_hou)
+
+    def _flush() -> None:
+        shengyu = guolvqi.jieshu()
+        if shengyu:
+            on_text_chunk(shengyu)
+
+    return _chunk, _flush
 
 
 class NativeAudioModelReply(ModelTurnReply):
@@ -837,13 +965,16 @@ class HttpKehuduan:
             payload["stream_options"] = {"include_usage": True}
 
         effective_llm_max_seconds = _effective_llm_deadline_seconds()
+        # bug-fix: 多次思考路径根治 - 接通流式 think 过滤器（原为 dead code）：
+        # 本次 llm_diaoyong 独立一个过滤器实例，流式 chunk 先滤掉内联思考块再回调。
+        liushi_on_chunk, liushi_flush = _baozhuang_liushi_sikao_guolv(on_text_chunk)
         try:
             executed = execute_streaming_turn(
                 client=self._kehuduan,
                 endpoint=endpoint,
                 api_key=miyao,
                 canonical_payload=payload,
-                on_text_chunk=on_text_chunk,
+                on_text_chunk=liushi_on_chunk,
                 on_reasoning_chunk=on_reasoning_chunk,
                 retry_limit=HTTP_RETRY_LIMIT,
                 retry_sleep_seconds=HTTP_RETRY_SLEEP_SECONDS,
@@ -893,6 +1024,10 @@ class HttpKehuduan:
                 reason="native_audio_model_deadline" if exc.deadline_exceeded else "native_audio_model_error",
             )
 
+        # bug-fix: 多次思考路径根治 - 流结束 flush 过滤器：未配对 "<" 尾巴等
+        # 持留文本在此放出；仍在思考块内则整段丢弃（截断思考不进正文）。
+        if liushi_flush:
+            liushi_flush()
         turn = _canonicalize_provider_turn(executed.turn)
 
         # MiniMax legacy safety rescue is retained, but only after a turn with
@@ -904,19 +1039,24 @@ class HttpKehuduan:
             and not turn.tool_calls
         ):
             rescue_payload = _minimax_empty_length_rescue_payload(payload)
+            # bug-fix: 多次思考路径根治 - rescue 是一次全新模型调用：新建独立过滤器，
+            # 避免沿用上一次可能停留在思考块内的状态把 rescue 正文整段丢掉。
+            rescue_on_chunk, rescue_flush = _baozhuang_liushi_sikao_guolv(on_text_chunk)
             try:
                 rescue = execute_streaming_turn(
                     client=self._kehuduan,
                     endpoint=endpoint,
                     api_key=miyao,
                     canonical_payload=rescue_payload,
-                    on_text_chunk=on_text_chunk,
+                    on_text_chunk=rescue_on_chunk,
                     on_reasoning_chunk=on_reasoning_chunk,
                     retry_limit=HTTP_RETRY_LIMIT,
                     retry_sleep_seconds=HTTP_RETRY_SLEEP_SECONDS,
                     transient_status_codes=TRANSIENT_STATUS_CODES,
                     max_wall_clock_seconds=effective_llm_max_seconds,
                 )
+                if rescue_flush:
+                    rescue_flush()
                 turn = _canonicalize_provider_turn(rescue.turn)
                 optimization_trace["empty_length_rescue"] = True
             except TransportExecutionError:
@@ -1414,5 +1554,14 @@ def _zhuanhuan_openai_geshi(gongju_yuanshi: list[dict]) -> list[dict]:
 
 
 def _qingli_sikao(neirong: str) -> str:
-    """Remove provider reasoning blocks that arrive inside assistant content."""
-    return re.sub(r"<think>.*?</think>\s*", "", str(neirong or ""), flags=re.DOTALL | re.IGNORECASE).strip()
+    """Remove provider reasoning blocks that arrive inside assistant content.
+
+    bug-fix: 多次思考路径根治 - 支持三种标签（think/thinking/reasoning，含属性、
+    大小写不敏感）的成对删除与未闭合兜底：未闭合的开标签删到文本末尾，
+    孤立闭合标签一并清理，避免残留触发外层“未知内部标记”整轮重跑。
+    """
+    # bug-fix: 多次思考路径根治 - 先删成对块，再兜底删未闭合块，最后清孤立闭标签
+    wenben = _SIKAO_CHENGDUI_RE.sub("", str(neirong or ""))
+    wenben = _SIKAO_WEIBI_RE.sub("", wenben)
+    wenben = _SIKAO_BI_RE.sub("", wenben)
+    return wenben.strip()

--- a/app/backend/tiangong-backend/v3/jineng/model_transport_executor.py
+++ b/app/backend/tiangong-backend/v3/jineng/model_transport_executor.py
@@ -125,7 +125,12 @@ def execute_streaming_turn(
                 headers={**request.headers, **host_headers},
                 extensions={"sni_hostname": sni_hostname},
             )
-            with client.send(pinned_http_request, stream=True) as response:
+            # bug-fix: httpx 0.28 取消了 client.send(stream=True) 返回值的
+            # context manager 支持（2026-08-25，凌霜）。改为直接 send + try-finally
+            # 显式关闭 stream，避免 LLM 真实调用时立刻抛
+            # "'httpx.Response' object does not support the context manager protocol"。
+            response = client.send(pinned_http_request, stream=True)
+            try:
                 status = int(response.status_code)
                 if status in transient and attempt < retry_limit:
                     last_reason = f"HTTP {status}"
@@ -145,6 +150,8 @@ def execute_streaming_turn(
                         on_text_chunk(text)
                     if reasoning and on_reasoning_chunk:
                         on_reasoning_chunk(reasoning)
+            finally:
+                response.close()
             turn = transport.finalize_turn(endpoint, state)
             latency = round((time.perf_counter() - started) * 1000)
             return TransportExecutionResult(

--- a/app/backend/tiangong-backend/v3/model_endpoint.py
+++ b/app/backend/tiangong-backend/v3/model_endpoint.py
@@ -66,9 +66,13 @@ SERVICE_PRESETS: dict[str, ServicePreset] = {
         {ProtocolFamily.OPENAI_CHAT_COMPLETIONS.value: "https://api.minimaxi.com/v1"},
         "MiniMax-M3",
     ),
+    # bug-fix: MiMo Token Plan endpoint 支持（2026-08-25）
     "mimo": ServicePreset(
         "mimo", "mimo", ProtocolFamily.OPENAI_CHAT_COMPLETIONS.value,
-        {ProtocolFamily.OPENAI_CHAT_COMPLETIONS.value: "https://api.xiaomimimo.com/v1"},
+        {
+            ProtocolFamily.OPENAI_CHAT_COMPLETIONS.value: "https://api.xiaomimimo.com/v1",
+            "mimo_token_plan": "https://token-plan-cn.xiaomimimo.com/v1",
+        },
         "mimo-v2.5-pro",
     ),
     "scnet": ServicePreset(

--- a/app/backend/tiangong-backend/v3/simple_chain/kernel.py
+++ b/app/backend/tiangong-backend/v3/simple_chain/kernel.py
@@ -3,6 +3,9 @@
 P17-M2 拆分工程的延续：`_simple_chain_*` 家族与依赖闭包的整体迁出。
 后续新功能应落在本包的分层模块，不再向 zongdiaodu.py 添加顶层符号。
 """
+# 2026-08-25 fix: 多次思考路径根治 - 收紧 _runtime_detects_work_intent 弱信号 markers
+# （帮我查/查资料/写代码/裸扩展名等不再单独判 work），并新增
+# _simple_chain_fluent_text_reply 供 zongdiaodu 跳过 completion correction 强插续写。
 
 from __future__ import annotations
 
@@ -53,7 +56,8 @@ from ..duihua_qiaojie import (
 )
 from ..json_guards import error_payload
 from ..permission_settings import build_runtime_context_prompt, check_tool_permission
-from ..reply_sanitizer import extract_biaoxian_payload, strip_internal_reply_markers
+# bug-fix: 多次思考路径根治 - has_unknown_internal_markup 用于通顺答复判定
+from ..reply_sanitizer import extract_biaoxian_payload, has_unknown_internal_markup, strip_internal_reply_markers
 from ..run_context import (
     current_run_context,
     get_last_expression,
@@ -197,6 +201,27 @@ def _safe_visible_chat_reply(reply: str, raw: str = "") -> str:
         return raw_text
     return "我明白。"
 
+# bug-fix: 多次思考路径根治 - 明确动作动词：裸出现即构成“请求语境”。
+# 单字“写”、“生成”等泛化动词不在此列（“写代码”“生成是什么意思”只是提到动作词）。
+_WORK_STRONG_MUTATION_MARKERS = (
+    "创建", "新建", "写入", "保存", "修改", "修复", "更新", "追加", "覆盖",
+    "删除", "移动", "搬到", "放到", "复制", "重命名", "改名", "整理", "清理",
+    "打包", "压缩", "解压", "提交", "改成", "替换", "实现", "跑起来", "做完",
+)
+
+def _simple_chain_has_explicit_work_frame(user_text: str) -> bool:
+    """bug-fix: 多次思考路径根治 - 区分“请求干活”与“提到某个动作词”。
+
+    有命令语境（帮我/请/把/将/给我/执行/直接/开始…）或明确动作动词
+    （创建/修改/删除/打包…）才算请求干活；“help me with X”与裸提“X”分开。
+    """
+    compact = re.sub(r"\s+", "", str(user_text or "")).lower()
+    if not compact:
+        return False
+    if any(marker in compact for marker in _MUTATION_COMMAND_MARKERS):
+        return True
+    return any(marker in compact for marker in _WORK_STRONG_MUTATION_MARKERS)
+
 def _runtime_detects_work_intent(user_text: str) -> bool:
     text = _simple_chain_user_goal_text(user_text)
     lower = text.lower()
@@ -207,17 +232,41 @@ def _runtime_detects_work_intent(user_text: str) -> bool:
     # High-confidence read/list requests are work even when no mutation/deliverable exists.
     if build_action_obligations(text):
         return True
-    if _requires_real_mutation(text) or _has_delivery_intent(text) or _simple_chain_expected_suffixes(text):
+    # bug-fix: 多次思考路径根治 - mutation 命中须叠加“请求语境”：
+    # 裸泛化动词（“写代码”“我会写代码”里的单字“写”）不再直接判 work；
+    # “请帮我写代码”“修改这个文件”“把 X 整理成表格”等明确请求仍判 work。
+    if _requires_real_mutation(text) and _simple_chain_has_explicit_work_frame(text):
         return True
+    if _has_delivery_intent(text):
+        return True
+    # bug-fix: 多次思考路径根治 - 裸提扩展名（“什么是.docx文件”）不算干活；
+    # 扩展名叠加请求语境（“帮我转成 report.pdf”）才是交付契约。
+    if _simple_chain_expected_suffixes(text) and _simple_chain_has_explicit_work_frame(text):
+        return True
+    # bug-fix: 多次思考路径根治 - 收紧弱信号 markers：
+    # “查资料/搜资料/写代码/写小说/长链/多步骤/裸扩展名(docx/.txt/.zip)”
+    # 等泛化词不再单独判 work——纯文本问答被误判为 work 后，完成门必然不通过，
+    # 会触发 completion correction 强插续写（“多思考几轮”的头号来源）。
+    # 其中真命令已被上游判定覆盖：请帮我写代码/打包/修改→_requires_real_mutation
+    # 叠加请求语境判定，发我文档/根据附件→_has_delivery_intent，
+    # docx/.txt/.zip→_simple_chain_expected_suffixes，
+    # 因此“请帮我写代码”“整理成表格”“修改这个文件”等核心用例仍判 work。
+    # 这里只保留明确“干活”信号：具体产物（做成文件/txt）、明确执行（跑一下/运行一下/放桌面）、
+    # 具体查询对象（查这个/搜这个）。
     markers = (
         "生成word", "生成 word", "生成ppt", "生成 ppt", "生成excel", "生成 excel",
-        "做成文件", "发我文档", "整理成表格", "根据附件", "处理附件", "修改这个文件",
-        "做成txt", "做成 txt", "写代码", "跑一下", "运行一下", "帮我查", "帮我搜",
-        "查资料", "搜资料", "打包", "压缩", "放桌面", "写小说", "写一章", "续写",
-        "长链", "多步骤", "docx", "pptx", "xlsx", ".txt", ".zip",
+        "做成文件", "做成txt", "做成 txt", "跑一下", "运行一下", "放桌面",
+        "查这个", "查一下这", "搜这个", "搜一下这", "看下这个", "看一下这个",
     )
     compact = re.sub(r"\s+", "", lower)
     if any(marker.replace(" ", "").lower() in compact for marker in markers):
+        return True
+    # bug-fix: 多次思考路径根治 - “查/看/读 + 具体 URL”是明确干活信号；
+    # 裸提 URL（无动作词）仍按普通文本处理，避免闲聊被误判。
+    if re.search(r"https?://|www\.", lower) and re.search(
+        r"查|看|读|访问|打开|总结|分析|\b(?:fetch|open|read|check|look|browse|visit|summarize)\b",
+        lower,
+    ):
         return True
     english_action = re.search(
         r"\b(create|write|modify|edit|rename|move|copy|delete|remove|generate|build|run|execute|test|verify|search|find|summarize|analyse|analyze|read|package|compress|export|save|upload|download|send)\b",
@@ -228,6 +277,31 @@ def _runtime_detects_work_intent(user_text: str) -> bool:
         lower,
     )
     return bool(english_action and english_request_context)
+
+def _simple_chain_fluent_text_reply(huifu: Any) -> bool:
+    """bug-fix: 多次思考路径根治 - 判定模型回复是否已是可交付的通顺最终答复。
+
+    门槛刻意宽松（宁放过不误杀）：达到最短答复长度、无疑似工具调用残迹、
+    无未知内部标记、无未闭合代码围栏、无“我来帮你写 / I'll use X”式
+    只承诺未行动的过渡话术。命中即允许上层跳过 completion correction。
+    """
+    text = str(getattr(huifu, "visible_text", "") or huifu or "").strip()
+    if _count_nonspace_chars(text) < 6:
+        return False
+    if _SUSPECTED_TOOL_CALL_PATTERN.search(text):
+        return False
+    if has_unknown_internal_markup(text):
+        return False
+    if text.count("```") % 2 == 1:
+        return False
+    if re.search(
+        r"我来帮你|我来写|我来做|我来处理|我这就|马上给你|让我先"
+        r"|\b(?:i'?ll|let\s+me|i\s+will)\s+(?:use|call|run|invoke|check|read|search|open)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        return False
+    return True
 
 def _is_capability_or_meta_question(user_text: str) -> bool:
     text = str(user_text or "")

--- a/app/backend/tiangong-backend/v3/zongdiaodu.py
+++ b/app/backend/tiangong-backend/v3/zongdiaodu.py
@@ -2,6 +2,8 @@
 天工造物 v3：起源 — 总调度
 唤醒入口，编排全部引擎。函数式管道。
 """
+# 2026-08-25 fix: 多次思考路径根治 - completion correction 入口加“通顺文本答复短路”：
+# 全程零工具调用且模型已给出通顺最终答复时跳过强插续写，文本问答不再多出 2-3 轮思考。
 from __future__ import annotations
 
 from .simple_chain.kernel import ( 
@@ -126,6 +128,8 @@ from .simple_chain.kernel import (
     _simple_chain_explicit_read_paths,
     _simple_chain_explicit_retry_authorized,
     _simple_chain_explicit_skill_context,
+    # bug-fix: 多次思考路径根治 - 通顺答复判定，用于跳过 completion correction
+    _simple_chain_fluent_text_reply,
     _simple_chain_failure_text,
     _simple_chain_force_stopped_reply,
     _simple_chain_has_explicit_learning_intent,
@@ -4058,6 +4062,33 @@ class Zongdiaodu:
                         final_chain_status = final_status_now
                         break
                     final_reasons_now = proof_reasons_now
+
+                    # bug-fix: 多次思考路径根治 - 全程零工具调用且模型已给出通顺最终答复时，
+                    # 跳过 completion correction 强插续写：被误判为 work 的文本问答不再被
+                    # 强迫“再思考 N 轮”。宁放过不误杀——承诺行动却未行动（“我来帮你写”）、
+                    # 工具调用残迹、脏标记等情形仍走原 correction 路径。
+                    if (
+                        not quality_history
+                        and not generated_attachments
+                        and not required_read_paths
+                        and _simple_chain_fluent_text_reply(huifu)
+                    ):
+                        final_guard_exhausted = True
+                        final_chain_status = "chat_reply"
+                        if isinstance(run_state, dict):
+                            run_state["status"] = "chat_reply"
+                            run_state["stage"] = "chat_reply"
+                            run_state["terminal_reason"] = "fluent_text_reply_no_tool_work"
+                            _simple_chain_save_run_state(run_state)
+                        if run_control:
+                            run_control.step(
+                                "simple_chain_completion_correction",
+                                "Completion evidence correction",
+                                "skipped",
+                                "Model already produced a fluent final reply without any tool call; delivered as-is without forced continuation.",
+                                meta={"skipped_reason": "fluent_text_reply"},
+                            )
+                        break
 
                     correction_state = _simple_chain_completion_correction_state(run_state)
                     current_blockers = [

--- a/scripts/spawn_v3.py
+++ b/scripts/spawn_v3.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# 2026-08-25 add: spawn_v3 —— v3 桌面网关 HTTP API 封装（凌霜委托 cc）
+# 用途：把 v3 当 spawn 子 agent 调用；纯标准库（urllib），无额外依赖。
+# 用法：
+#   python3 scripts/spawn_v3.py --prompt "你好" --session-id s1 --timeout 90
+#   from scripts.spawn_v3 import SpawnV3; SpawnV3().ask("你好")["reply"]
+
+"""SpawnV3：v3 桌面网关（/api/v1/gateway/desktop/*）最小封装。
+
+- ask(prompt, session_id=None, timeout=120) -> {"generation", "status", "reply"}
+  - 提交 inbound 后轮询 status，直到 run.status 进入 COMPLETED / FAILED。
+  - FAILED 也正常返回（属于合法 run 终态，reply 里通常带失败原因）。
+  - 超时 raise TimeoutError。
+- HTTP 502/503/504 自动重试 1 次（间隔 1s），其余错误（4xx、连接失败等）直接 raise。
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+DEFAULT_BASE_URL = "http://127.0.0.1:17173"
+DEFAULT_TOKEN = "test-desktop-token-12345678901234567890"
+RETRYABLE_STATUS = (502, 503, 504)
+TERMINAL_STATUS = ("COMPLETED", "FAILED")
+
+
+class SpawnV3Error(RuntimeError):
+    """HTTP 非retryable错误 / 响应结构异常。"""
+
+
+class SpawnV3:
+    def __init__(self, base_url=None, token=None, poll_interval=2.0):
+        self.base_url = (base_url or os.environ.get("TIANGONG_V3_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.token = token or os.environ.get("TIANGONG_V3_TOKEN") or DEFAULT_TOKEN
+        self.poll_interval = poll_interval
+
+    # ---- HTTP 基础：502/503/504 重试 1 次，其他错 raise ----
+    def _http(self, method, path, query=None, body=None):
+        url = self.base_url + path
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+        data = json.dumps(body, ensure_ascii=False).encode("utf-8") if body is not None else None
+        headers = {"X-Tiangong-Token": self.token}
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        last_err = None
+        for attempt in (1, 2):
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    return json.loads(resp.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                last_err = SpawnV3Error(f"HTTP {e.code} {method} {path}: {e.read().decode('utf-8', 'replace')[:300]}")
+                if e.code in RETRYABLE_STATUS and attempt == 1:
+                    time.sleep(1.0)
+                    continue
+                raise last_err
+            except (urllib.error.URLError, OSError, ValueError) as e:
+                raise SpawnV3Error(f"{type(e).__name__} {method} {path}: {e}") from e
+        raise last_err  # 理论不可达
+
+    # ---- 提交一轮对话，返回 gateway_request_id ----
+    def submit(self, prompt, session_id=None):
+        payload = {
+            "presentation_request_id": "pr_spawn_v3_" + uuid.uuid4().hex[:12],
+            "session_id": session_id or ("spawn_v3_s_" + uuid.uuid4().hex[:12]),
+            "message_id": "msg_spawn_v3_" + uuid.uuid4().hex[:12],
+            "text": prompt,
+            "attachments": [],
+            "submitted_at_ms": int(time.time() * 1000),
+        }
+        resp = self._http("POST", "/api/v1/gateway/desktop/inbound", body=payload)
+        rid = resp.get("gateway_request_id")
+        if not rid:
+            raise SpawnV3Error(f"inbound 响应缺少 gateway_request_id: {resp}")
+        return rid, payload["session_id"]
+
+    # ---- 查一次状态 ----
+    def status(self, request_id):
+        resp = self._http("GET", "/api/v1/gateway/desktop/status", query={"request_id": request_id})
+        run = resp.get("run") or {}
+        return {
+            "generation": run.get("generation"),
+            "status": run.get("status"),
+            "reply": run.get("final_response") or "",
+            "steps": run.get("steps") or [],
+        }
+
+    # ---- 对外主入口：提交 + 轮询到终态 ----
+    def ask(self, prompt, session_id=None, timeout=120):
+        rid, sid = self.submit(prompt, session_id)
+        deadline = time.monotonic() + timeout
+        result = {"generation": None, "status": "PENDING", "reply": ""}
+        while True:
+            result = self.status(rid)
+            if result["status"] in TERMINAL_STATUS:
+                return {"generation": result["generation"], "status": result["status"], "reply": result["reply"]}
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"v3 run 未在 {timeout}s 内到终态: request_id={rid} session_id={sid} "
+                    f"last_status={result['status']} generation={result['generation']}"
+                )
+            time.sleep(self.poll_interval)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="把 v3 当 spawn 子 agent 调一次（单行 JSON 输出）")
+    ap.add_argument("--prompt", required=True, help="发给 v3 的任务文本")
+    ap.add_argument("--session-id", default=None, help="会话 id（续会话时传，默认新建")
+    ap.add_argument("--timeout", type=float, default=120, help="等待终态的超时秒数（默认 120）")
+    ap.add_argument("--base-url", default=None, help="v3 网关地址（默认 http://127.0.0.1:17173）")
+    ap.add_argument("--token", default=None, help="X-Tiangong-Token（默认内置测试 token）")
+    args = ap.parse_args()
+    try:
+        result = SpawnV3(base_url=args.base_url, token=args.token).ask(
+            args.prompt, session_id=args.session_id, timeout=args.timeout
+        )
+    except Exception as e:  # CLI 层：错误也输出单行 JSON（stderr），退出码 1
+        print(json.dumps({"error": f"{type(e).__name__}: {e}"}, ensure_ascii=False), file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/runtime_security/model_endpoint.py
+++ b/src/runtime_security/model_endpoint.py
@@ -32,7 +32,8 @@ _OFFICIAL_HOSTS: dict[str, frozenset[str]] = {
     "minimax_m3": frozenset({"api.minimaxi.com"}),
     "minimax": frozenset({"api.minimaxi.com"}),
     "google": frozenset({"generativelanguage.googleapis.com"}),
-    "mimo": frozenset({"api.xiaomimimo.com"}),
+    # bug-fix: MiMo Token Plan endpoint 支持（2026-08-25）
+    "mimo": frozenset({"api.xiaomimimo.com", "token-plan-cn.xiaomimimo.com"}),
 }
 
 

--- a/tests/test_p0_safety_batch1.py
+++ b/tests/test_p0_safety_batch1.py
@@ -296,6 +296,12 @@ def test_execute_streaming_turn_sends_to_pinned_ip(monkeypatch: pytest.MonkeyPat
         def iter_lines(self):
             return iter([])
 
+        # bug-fix: httpx 0.28 取消 client.send(stream=True) context manager 协议，
+        # 凌霜在 model_transport_executor.py 改为 try/finally 显式 response.close()。
+        # 测试 stub 必须同步支持（2026-08-25）。
+        def close(self) -> None:
+            return None
+
     class _StubClient:
         def build_request(self, method, url, **kwargs):
             captured["method"] = method

--- a/tests/test_simple_chain_loop_budget.py
+++ b/tests/test_simple_chain_loop_budget.py
@@ -160,6 +160,10 @@ class SimpleChainLoopBudgetTests(unittest.TestCase):
             def iter_lines(self):
                 yield 'data: {"choices":[{"delta":{"content":"keepalive"}}]}'
 
+            # bug-fix: 同 _StubResponse，httpx 0.28 兼容（2026-08-25，凌霜）。
+            def close(self) -> None:
+                return None
+
         class _FakeClient:
             def build_request(self, method, url, **kwargs):
                 return object()


### PR DESCRIPTION
## 背景

今日在 v3 沙盒跑出 4 类改动一并提交：

### 1. chore: .gitignore 扩展（commit `f98b79b`）
- `/.tiangong-release-hash-cache.json` 与 `.in/` 规则从根级扩展为 `**/`，覆盖子目录。

### 2. fix(v3): 多次思考路径修法 P1+P2+P3（commit `2886a54`）
**根因双层**：
- `simple_chain/_runtime_detects_work_intent` markers 过宽，弱信号（「你好」「写代码好累啊」「几点了」）被误判为 work → `completion_correction` 强插续写 3 次
- 流式 `<think>...</think>` 标签未闭合 → `reply_sanitizer` 白名单不含 think → 整轮 markup 重发

**修法**：
- **P1a** simple_chain/kernel.py：markers 收紧，弱信号不再单判 work
- **P1b** zongdiaodu.py：completion_correction 加"通顺文本+无 tool_call"短路
- **P2** jineng/http_kehuduan.py：`_qingli_sikao` 重写，支持成对删除 + 未闭合开标签删到文末 + 孤立闭标签清理；新建流式过滤类 `_LiushiSikaoGuolvqi`
- **P3** 接通 `execute_streaming_turn` 流式 `on_text_chunk` 回调，包 `_baozhuang_liushi_sikao_guolv`；流结束 flush；修 Kimi 残留 2 bug（`_chouqu` 死循环缺 break / 前缀 `[^>]*$` 误判普通 `a < b`）

**验证**：
- pytest 3207 passed / 36 skipped（121s）
- e2e 5 场景（弱信号/期望路径混合）generation 全 = 1

### 3. feat(v3): MiMo Token Plan endpoint 支持 + httpx 0.28 API 兼容（commit `b81cf35`）
- endpoint_security.py: mimo 白名单加 `token-plan-cn.xiaomimimo.com`
- model_endpoint.py: mimo ServicePreset 加 `mimo_token_plan` 端点
- src/runtime_security/model_endpoint.py: 同步加白名单
- **附带修 httpx 0.28 API 兼容性 bug**：`model_transport_executor.py` 的 `with client.send(stream=True)` 在 httpx 0.28 起不再支持 context manager → 改为直接 send + try-finally `response.close()`，否则真实 LLM 调用立刻抛 "Response object does not support the context manager protocol"

**验证**：
- pytest 2656 passed
- e2e 5 场景（A 几点了 / B 你会写代码吗 / C 写 hello.py / D 写代码好累啊 / E 查 URL）generation 全 = 1，A/B/D 真实 LLM 回复正确

### 4. feat(scripts): spawn_v3.py 封装 spawn runner（commit `1c0c378`）
- `SpawnV3.ask(prompt, session_id=None, timeout=120) -> dict`
- HTTP 502/503/504 自动重试 1 次
- 状态轮询兼容 ACTIVE(generation=0) 排队态
- argparse CLI + 环境变量覆盖
- 纯标准库 urllib，零额外依赖
- 冒烟测试：「1+1=?」→ COMPLETED gen=1

## Test plan
- [x] pytest 3207 passed（修法） + 2656 passed（MiMo 改动）
- [x] e2e 5 场景（v3 + MiMo 真实 LLM）generation 全 = 1
- [x] spawn_v3.py 冒烟通过

🤖 Generated with [Claude Code](https://claude.ai/code)
