### PR TITLE
fix(v3): UX 体检 code+logic 类 19 条修复（按 v3 自身执行力判定）

### DIFF
--- a/app/backend/tiangong-backend/v3/duihua_qiaojie.py
+++ b/app/backend/tiangong-backend/v3/duihua_qiaojie.py
@@ -1245,7 +1245,12 @@ class DuihuaQiaojie:
 
     def chuli_duihua(self, xiaoxi: str, yonghu_ming: str = "", conversation_context: dict | None = None) -> str:
         if self._zd is None:
-            return json.dumps({"cuowu": "v3未就绪"}, ensure_ascii=False)
+            # bug-fix: Kimi#13 "v3未就绪" 短码换成人话文案+可操作建议（2026-08-26，凌霜）
+            return json.dumps({
+                "cuowu": "对话服务还没有启动完成：请稍等几秒后重试；若持续出现，请重启后端。",
+                "error_code": "v3_not_ready",
+                "zhuangtai": "shibai",
+            }, ensure_ascii=False)
         request_id = ""
         if isinstance(conversation_context, dict):
             request_id = str(conversation_context.get("active_id") or conversation_context.get("request_id") or "").strip()
@@ -1496,6 +1501,8 @@ class DuihuaQiaojie:
                 "terminal_reason": terminal_reason,
             })
             return _cache_response(json.dumps(last_error_payload, ensure_ascii=False))
+        # bug-fix: Kimi#13 失败兜底走 json_guards 人话映射：cuowu 为"人话+可操作建议"，
+        # 原始异常文本只保留在 detail 字段（2026-08-26，凌霜）
         text_payload = chat_error_text_payload(last_error or "chat_failed", source="chat_runtime")
         return _cache_response(json.dumps({
             "cuowu": text_payload.get("cuowu") or "chat_failed",
@@ -2160,7 +2167,7 @@ class _ChuliQi(BaseHTTPRequestHandler):
                     conversation_context[target_key] = value
         except Exception as e:
             self._write_json(chat_error_payload(e, source="request_body"), 400); return
-            self._write_json({"cuowu": "JSON格式错误"}, 400); return
+            # bug-fix: cc#18 删除上一行 return 之后不可达的旧 write（2026-08-26，凌霜）
 
         qiaojie = getattr(self.server, "_qiaojie", None)
         if qiaojie is None:
@@ -2312,25 +2319,20 @@ class _ChuliQi(BaseHTTPRequestHandler):
 
 
 def _huifu_keyi_zhongshi(huifu: object) -> bool:
+    # bug-fix: 错误判定只看结构化信号（空回复/内部约定错误前缀/错误 JSON），不再对
+    # 自然语言正文做 timeout/connection/http 500 等子串匹配——技术问答正文必然包含
+    # 这些词，旧逻辑会把正常回答吞掉当错误重试（2026-08-26，凌霜修 logic 类）
     text = str(huifu or "")
     if not text:
         return True
-    lowered = text.lower()
-    non_retry = (
-        "未配置", "api密钥", "api key", "credential", "not_configured",
-        "权限", "permission", "http 400", "http 401", "http 403", "http 404",
-        "base url", "model or api endpoint", "model_not_found", "not found",
-        "unauthorized", "forbidden", "invalid_request",
-    )
-    if any(marker in lowered for marker in non_retry):
-        return False
-    retry_markers = (
-        "timeout", "timed out", "connection", "reset", "temporarily",
-        "rate limit", "ratelimit", "too many requests",
-        "http 408", "http 409", "http 425", "http 429", "http 500",
-        "http 502", "http 503", "http 504", "唤醒异常", "llm错误",
-    )
-    return any(marker in lowered for marker in retry_markers)
+    head = text.lstrip()[:40]
+    if head.startswith(("[backend_error]", "[唤醒异常]", "[terminal_model_error]", "[llm错误")):
+        return True
+    if text.lstrip().startswith("{"):
+        parsed = loads_json_object(text, source="chat_runtime", default_empty=None)
+        if isinstance(parsed, dict) and ("cuowu" in parsed or parsed.get("zhuangtai") == "shibai"):
+            return True
+    return False
 
 
 def _safe_bridge_json(raw: object, *, source: str = "chat") -> dict:
@@ -2878,6 +2880,14 @@ def _build_context_envelope(conversation_context: dict | None, current_user_text
     affective_state = _trusted_affective_state(life_envelope)
     if authoritative_soul:
         authoritative_soul["affective_state"] = affective_state
+    # bug-fix: cc#9 会话来源写入 envelope.channel，渲染层据此区分“微信时间线”/“最近对话”（2026-08-26，凌霜）
+    session_id = str(
+        ctx.get("session_id")
+        or ctx.get("conversation_id")
+        or ctx.get("duihua_id")
+        or ""
+    ).lower()
+    channel = "wechat" if "wechat" in session_id else "chat"
     return {
         "schema": "tiangong.v3.context_envelope.v1",
         "priority_order": [
@@ -2909,6 +2919,7 @@ def _build_context_envelope(conversation_context: dict | None, current_user_text
         "life_skill_overlay": ctx.get("life_skill_overlay")[:32] if isinstance(ctx.get("life_skill_overlay"), list) else [],
         "conflict_policy": "current_user_text_wins",
         "token_budget": _envelope_token_budget(),
+        "channel": channel,
     }
 
 
@@ -2992,7 +3003,11 @@ def _render_context_envelope(envelope: dict, *, context_limit: int = 12000) -> s
         for item in timeline:
             role = "用户" if str(item.get("role") or "") == "user" else "助手"
             lines.append(f"{role}：{str(item.get('content') or '')}")
-        sections.append("【最近微信时间线，仅供参考；如冲突，以本轮用户最新消息为准】\n" + "\n".join(lines))
+        # bug-fix: cc#9 时间线标题按 envelope.channel 选择，仅微信桥接会话显示“微信时间线”（2026-08-26，凌霜）
+        timeline_biaoti = (
+            "最近微信时间线" if str(envelope.get("channel") or "") == "wechat" else "最近对话"
+        )
+        sections.append(f"【{timeline_biaoti}，仅供参考；如冲突，以本轮用户最新消息为准】\n" + "\n".join(lines))
     summary = str(envelope.get("summary") or "").strip()
     if summary:
         sections.append(
@@ -3161,130 +3176,7 @@ def _duihua_shangxiawen(conversation_context: dict | None, dangqian_xiaoxi: str 
     conversation_context["context_envelope"] = envelope
     context_limit = _minimax_m3_context_limit()
     return _render_context_envelope(envelope, context_limit=context_limit)
-    messages = _recent_messages_from_context(conversation_context)
-    m3_context = _minimax_m3_context_enabled()
-    context_limit = _minimax_m3_context_limit()
-    session_id = str(
-        conversation_context.get("session_id")
-        or conversation_context.get("conversation_id")
-        or conversation_context.get("duihua_id")
-        or ""
-    ).lower()
-    timeline_only = "wechat" in session_id
-
-    current = str(dangqian_xiaoxi or "").strip()
-    source_messages = messages[-(160 if m3_context else 80):]
-    normalized: list[dict] = []
-    for index, item in enumerate(source_messages):
-        if not isinstance(item, dict):
-            continue
-        role = str(item.get("role") or "").strip().lower()
-        if role not in {"user", "assistant"}:
-            continue
-        content = str(item.get("content") or "").strip()
-        if not content:
-            continue
-        if role == "user" and current and content == current and index == len(source_messages) - 1:
-            continue
-        normalized.append({
-            "role": role,
-            "content": " ".join(content.split()),
-            "at": item.get("at"),
-            "index": index,
-        })
-
-    anchor_keywords = (
-        "记住", "不要忘", "以后", "必须", "目标", "计划", "步骤", "结论", "决定",
-        "文件", "路径", "报错", "错误", "失败", "恢复", "重试", "上下文",
-        "v2", "v3", "api", "skill", "工具", "后端", "前端", "模型", "配置",
-    )
-    recent = normalized[-(40 if m3_context else 24):]
-    recent_ids = {id(item) for item in recent}
-    anchors: list[dict] = []
-    for item in normalized:
-        content_lower = item["content"].lower()
-        has_keyword = any(keyword.lower() in content_lower for keyword in anchor_keywords)
-        if item["role"] == "user" and (len(anchors) < 4 or has_keyword):
-            anchors.append(item)
-        elif has_keyword:
-            anchors.append(item)
-
-    deduped_anchors: list[dict] = []
-    seen = set()
-    for item in anchors:
-        key = (item["role"], item["content"][:220])
-        if key in seen or id(item) in recent_ids:
-            continue
-        seen.add(key)
-        deduped_anchors.append(item)
-    deduped_anchors = deduped_anchors[-(24 if m3_context else 14):]
-
-    def fmt(item: dict, max_len: int) -> str:
-        label = "用户" if item["role"] == "user" else "起源"
-        try:
-            ts = time.strftime("%H:%M", time.localtime(float(item.get("at") or 0) / 1000))
-        except Exception:
-            ts = ""
-        content = item["content"]
-        if len(content) > max_len:
-            content = content[:max_len] + "..."
-        prefix = f"{ts} " if ts else ""
-        return f"- {prefix}{label}: {content}"
-
-    sections: list[str] = []
-    xujie = conversation_context.get("context_carryover") or {}
-    if isinstance(xujie, dict) and xujie.get("followup_resolved") and _is_short_followup(current):
-        sections.append("[上下文续接]\n系统未改写本轮用户消息；以下历史只作为模型自行判断指代与目标的参考。")
-    summary = str(conversation_context.get("summary") or conversation_context.get("thread_summary") or "").strip()
-    if summary:
-        sections.append(
-            "[会话摘要]\n"
-            + _source_partition_wrap(
-                SOURCE_TYPE_TOOL_DATA,
-                summary[:(8000 if m3_context else 2500)],
-                object_id="thread_summary",
-            )
-        )
-    if timeline_only:
-        sections.append(
-            "[微信上下文]\n"
-            "- 以下内容只按时间线提供历史消息、文件卡、结果卡和附件线索。\n"
-            "- 系统不再改写、分类、补全或短路本轮用户意图；由模型结合最新用户原话自行判断当前目标。"
-        )
-        deduped_anchors = []
-
-    if deduped_anchors:
-        sections.append("[关键锚点]\n" + "\n".join(fmt(item, 1800 if m3_context else 1100) for item in deduped_anchors))
-    if recent:
-        section_name = "微信时间线" if timeline_only else "最近对话"
-        sections.append(f"[{section_name}]\n" + "\n".join(fmt(item, 2200 if m3_context else 1200) for item in recent))
-    attachments = _compact_attachment_context(
-        conversation_context.get("attachments")
-        or conversation_context.get("chat_attachments")
-        or conversation_context.get("files")
-    )
-    if attachments:
-        sections.append(
-            "[本轮附件]\n"
-            + _source_partition_wrap(SOURCE_TYPE_EXTERNAL_DATA, attachments, object_id="current_attachments")
-        )
-    knowledge_refs = _compact_knowledge_context(
-        conversation_context.get("knowledge_references")
-        or conversation_context.get("knowledgeReferences")
-    )
-    if knowledge_refs:
-        sections.append(
-            "[知识库参考]\n"
-            + _source_partition_wrap(SOURCE_TYPE_EXTERNAL_DATA, knowledge_refs, object_id="knowledge_references")
-        )
-
-    joined = "\n\n".join(sections)
-    if len(joined) > context_limit:
-        head = "\n\n".join(sections[:-1])
-        tail = sections[-1] if sections else ""
-        budget = max(3000, context_limit - len(head) - 2)
-        joined = (head + "\n\n" + tail[-budget:]).strip() if head else tail[-context_limit:]
-    return joined
+    # bug-fix: cc#18 删除 return 之后不可达的旧版时间线渲染逻辑（约 124 行死代码）（2026-08-26，凌霜）
 
 
 def _openai_models() -> dict:

--- a/app/backend/tiangong-backend/v3/jineng/http_kehuduan.py
+++ b/app/backend/tiangong-backend/v3/jineng/http_kehuduan.py
@@ -7,13 +7,7 @@ L4 optimization remains advisory and can never choose the endpoint/protocol.
 """
 # 2026-08-25 fix: 多次思考路径 — 流式期间过滤内联 <think>/<thinking>/<reasoning> 块，
 # 避免思考文本进入正文流；_qingli_sikao 支持三种标签成对删除与未闭合兜底。
-# 2026-08-25 fix: 多次思考路径根治 - cc 修复：
-#   1) 接通 Kimi 遗留的流式过滤器 dead code（llm_diaoyong 两个 execute_streaming_turn
-#      调用点原先传原始 on_text_chunk，过滤器从未生效）；
-#   2) 修复 _LiushiSikaoGuolvqi 两处 bug：部分标签前缀持留分支缺 break 导致死循环、
-#      前缀判定过宽（“a < b”等普通文本会被无限持留卡住流式输出）；
-#   3) _qingli_sikao 真正实现三种标签（think/thinking/reasoning）成对删除与
-#      未闭合兜底（删到文本末尾），与头注释声明一致。
+# bug-fix: cc#17 头部过时的修复流水注释精简为现状说明（历史细节见 git log）（2026-08-26，凌霜）
 from __future__ import annotations
 
 import base64
@@ -920,10 +914,7 @@ class HttpKehuduan:
             reasoning_trace = _apply_reasoning_profile(
                 pid, payload, base_url=base_url, model_name=model_name
             )
-            raw_reasoning_trace = _apply_endpoint_raw_reasoning(endpoint, capability, payload)
-            reasoning_trace.update(raw_reasoning_trace)
-            raw_reasoning_trace = _apply_endpoint_raw_reasoning(endpoint, capability, payload)
-            reasoning_trace.update(raw_reasoning_trace)
+            # bug-fix: cc#17 删除 _apply_endpoint_raw_reasoning 的三次重复调用，保留一次（2026-08-26，凌霜）
             raw_reasoning_trace = _apply_endpoint_raw_reasoning(endpoint, capability, payload)
             reasoning_trace.update(raw_reasoning_trace)
             if isinstance(optimization_trace, dict):
@@ -994,11 +985,12 @@ class HttpKehuduan:
                 error_preview=exc.response_preview or exc.reason,
             )
             hint = (
-                "A single LLM call exceeded the platform wall-clock deadline; the run stopped instead of waiting forever."
+                # bug-fix: Kimi#14 墙钟超时/网络失败 hint 由英文改中文，用户不再看到英文提示（2026-08-26，凌霜）
+                "单次模型调用超过了平台墙钟时限；本轮已停止等待，而不是无限挂起，请稍后重试或切换模型。"
                 if exc.deadline_exceeded
                 else _http_status_hint(exc.http_status)
                 if exc.http_status is not None
-                else "Network/proxy/DNS failed, or Base URL points to a non-API host."
+                else "网络/代理/DNS 连接失败，或 Base URL 指向的不是 API 服务；请检查网络与 Base URL 配置。"
             )
             error = _error_turn(
                 _llm_error_text(
@@ -1562,6 +1554,17 @@ def _qingli_sikao(neirong: str) -> str:
     """
     # bug-fix: 多次思考路径根治 - 先删成对块，再兜底删未闭合块，最后清孤立闭标签
     wenben = _SIKAO_CHENGDUI_RE.sub("", str(neirong or ""))
+    # bug-fix: Kimi#18 未闭合思考块先检测再删除：可见文本为空或被截断时显式标注
+    # “回复不完整，可重试”，不再让用户看到答案写一半突然消失（2026-08-26，凌霜）
+    weibi = _SIKAO_WEIBI_RE.search(wenben)
     wenben = _SIKAO_WEIBI_RE.sub("", wenben)
     wenben = _SIKAO_BI_RE.sub("", wenben)
-    return wenben.strip()
+    wenben = wenben.strip()
+    if weibi:
+        if not wenben:
+            return "（本次回复不完整：模型的思考块未正常结束，没有产出正文。可以直接重试，或换个说法再问一次。）"
+        return (
+            wenben
+            + "\n\n（提示：本次回复可能不完整——模型思考块未正常结束，其后内容缺失；如需完整答复请重试。）"
+        )
+    return wenben

--- a/app/backend/tiangong-backend/v3/jineng/model_transport_executor.py
+++ b/app/backend/tiangong-backend/v3/jineng/model_transport_executor.py
@@ -98,6 +98,10 @@ def execute_streaming_turn(
     call_started = time.perf_counter()
     last_reason = "empty_response"
     request = transport.build_request(endpoint, api_key, canonical_payload)
+    # bug-fix: 记录本流是否已向外发出过 chunk——已播内容后中途失败禁止自动重试，
+    # 否则重试会把整段回复从头再播一遍（StreamState 每次重建、无去重）
+    # （2026-08-26，凌霜修 logic 类）
+    emitted_any = False
 
     for attempt in range(1, max(1, int(retry_limit)) + 1):
         elapsed = time.perf_counter() - call_started
@@ -110,6 +114,7 @@ def execute_streaming_turn(
                 deadline_exceeded=True,
             )
         started = time.perf_counter()
+        state = StreamState()
         try:
             # Revalidate immediately before credential-bearing network release,
             # then pin this attempt's connection to the validated IP.  Every
@@ -117,7 +122,6 @@ def execute_streaming_turn(
             # travel to an address that passed the private/loopback checks.
             binding = validate_model_endpoint(endpoint.provider_identity, endpoint.base_url, resolve_dns=True)
             pinned_url, host_headers, sni_hostname = _pinned_request(request.url, binding)
-            state = StreamState()
             pinned_http_request = client.build_request(
                 "POST",
                 pinned_url,
@@ -147,20 +151,13 @@ def execute_streaming_turn(
                         continue
                     text, reasoning = transport.consume_stream_event(state, event)
                     if text and on_text_chunk:
+                        emitted_any = True
                         on_text_chunk(text)
                     if reasoning and on_reasoning_chunk:
+                        emitted_any = True
                         on_reasoning_chunk(reasoning)
             finally:
                 response.close()
-            turn = transport.finalize_turn(endpoint, state)
-            latency = round((time.perf_counter() - started) * 1000)
-            return TransportExecutionResult(
-                turn=turn,
-                url=request.url,
-                http_status=status,
-                retry_count=attempt - 1,
-                latency_ms=latency,
-            )
         except httpx.HTTPStatusError as exc:
             status = int(exc.response.status_code)
             last_reason = f"HTTP {status}"
@@ -180,7 +177,9 @@ def execute_streaming_turn(
             elapsed = time.perf_counter() - call_started
             last_reason = str(exc)
             deadline = max_wall_clock_seconds > 0 and elapsed > max_wall_clock_seconds
-            if not deadline and attempt < retry_limit:
+            # bug-fix: 已发出过 chunk 后中途失败不再自动重试（重播无去重）；
+            # 自动重试只留给连接类网络异常（2026-08-26，凌霜修 logic 类）
+            if not emitted_any and not deadline and attempt < retry_limit:
                 time.sleep(retry_sleep_seconds * attempt)
                 continue
             raise TransportExecutionError(
@@ -193,16 +192,34 @@ def execute_streaming_turn(
         except TransportExecutionError:
             raise
         except Exception as exc:
+            # bug-fix: 非网络类异常（解析/回调/协议等）不自动重试，直接包装上抛，
+            # 避免任意异常都烧满 retry_limit 次（2026-08-26，凌霜修 logic 类）
             last_reason = str(exc)
-            if attempt < retry_limit:
-                time.sleep(retry_sleep_seconds * attempt)
-                continue
             raise TransportExecutionError(
                 last_reason,
                 request.url,
                 retry_count=attempt - 1,
                 latency_ms=round((time.perf_counter() - started) * 1000),
             ) from exc
+        # bug-fix: finalize_turn 移出重试 try 块——收尾解析失败不再触发整段重播重试，
+        # 只包装上抛（2026-08-26，凌霜修 logic 类）
+        try:
+            turn = transport.finalize_turn(endpoint, state)
+        except Exception as exc:
+            raise TransportExecutionError(
+                str(exc),
+                request.url,
+                retry_count=attempt - 1,
+                latency_ms=round((time.perf_counter() - started) * 1000),
+            ) from exc
+        latency = round((time.perf_counter() - started) * 1000)
+        return TransportExecutionResult(
+            turn=turn,
+            url=request.url,
+            http_status=status,
+            retry_count=attempt - 1,
+            latency_ms=latency,
+        )
 
     raise TransportExecutionError(
         last_reason,

--- a/app/backend/tiangong-backend/v3/jinhua/biaoda_router.py
+++ b/app/backend/tiangong-backend/v3/jinhua/biaoda_router.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -81,6 +82,38 @@ def _expression_kind_label(target: str) -> str:
     }.get(target, "学习提示")
 
 
+# bug-fix: 学习表达注入前按当前消息做相关性过滤——不再每条消息都塞 6-8 条可能
+# 毫不相干的“学习成果”（2026-08-26，凌霜修 logic 类）
+_BIAODA_TONGYONG_CI = frozenset({
+    "一个", "我们", "你们", "他们", "这个", "那个", "可以", "什么", "没有",
+    "就是", "如果", "但是", "然后", "已经", "现在", "可能", "需要", "进行",
+    "时候", "问题", "情况", "内容", "一些", "一下", "自己", "这样", "怎样",
+})
+
+
+def _biaoda_guanjianci(text: Any) -> set[str]:
+    """提取关键词集合：英文/数字词（≥3 字符）+ 中文相邻二元词，去掉通用填充词。"""
+    raw = str(text or "").lower()
+    if not raw:
+        return set()
+    tokens = set(re.findall(r"[a-z0-9_]{3,}", raw))
+    hanzi_runs = re.findall(r"[一-鿿]+", raw)
+    for run in hanzi_runs:
+        for a, b in zip(run, run[1:]):
+            tokens.add(a + b)
+    return tokens - _BIAODA_TONGYONG_CI
+
+
+def _biaoda_xiangguan(xiaoxi: str, item: dict[str, Any]) -> bool:
+    """当前消息与学习表达是否相关：偏好类天然相关，其余按关键词交集判定。"""
+    if str(item.get("target") or "") == "preference":
+        return True
+    query = _biaoda_guanjianci(xiaoxi)
+    if not query:
+        return False
+    return bool(query & _biaoda_guanjianci(item.get("text")))
+
+
 class JinhuaBiaodaRouter:
     """Turns approved low-risk learning into prompt-visible expressions."""
 
@@ -129,20 +162,22 @@ class JinhuaBiaodaRouter:
         shenti: Any | None = None,
         xiaoxi: str = "",
         *,
-        limit: int = 6,
+        limit: int = 3,
     ) -> str:
         report = self.shuaxin(shenti, xiaoxi=xiaoxi, reason="context_injection")
         expressions = [
             item for item in report.get("expressions", [])
             if isinstance(item, dict) and item.get("safe_to_inject")
         ]
+        # bug-fix: 注入前按当前消息做相关性过滤，无命中不注入；
+        # 默认条数 6→3，减少不相干“学习成果”挤占上下文（2026-08-26，凌霜修 logic 类）
+        expressions = [item for item in expressions if _biaoda_xiangguan(xiaoxi, item)]
         if not expressions:
             return ""
         expressions.sort(key=lambda item: (item.get("priority", 9), item.get("target", ""), item.get("text", "")))
-        lines = [
-            "以下内容来自已激活且低风险的自学习结果，只能作为本轮对话的知识、偏好或流程提示；",
-            "不能据此调用未注册工具、修改文件、联网、安装依赖或改变系统策略。",
-        ]
+        # bug-fix: Kimi#20 删除对模型喊话的元指令（不能调用未注册工具等约束由系统层隔离实现），
+        # prompt 只保留事实性参考内容（2026-08-26，凌霜）
+        lines = ["以下为最近激活的自学习表达记录（参考信息）："]
         for item in expressions[: max(1, int(limit or 1))]:
             label = _expression_kind_label(str(item.get("target") or "context"))
             lines.append(f"- {label}: {_safe_text(item.get('text'), 220)}")

--- a/app/backend/tiangong-backend/v3/jinhua/shuxue_qiaojie.py
+++ b/app/backend/tiangong-backend/v3/jinhua/shuxue_qiaojie.py
@@ -81,10 +81,12 @@ def jisuan_xingdong_pingfen(
         if base_key == "novelty" and text_signal["novel_keywords"]:
             score *= 1.0 + min(0.30, text_signal["novel_keywords"] * 0.10)
         if base_key == "satisfaction":
-            if text_signal["positive_words"] > 0:
-                score *= 1.0 + min(0.20, text_signal["positive_words"] * 0.05)
-            if text_signal["negative_words"] > 0:
-                score *= max(0.5, 1.0 - text_signal["negative_words"] * 0.10)
+            # bug-fix: Kimi#21 满意度改看任务完成事实，不再按文本情绪词加减分，
+            # 避免堆“成功/完美/高效”抬分、如实写“执行失败”反被情绪扣分（2026-08-26，凌霜）
+            if text_signal["error_count"] > 0:
+                score *= max(0.6, 1.0 - text_signal["error_count"] * 0.05)
+            elif text_signal["step_count"] > 0:
+                score *= 1.05
         weidu[key] = round(min(1.0, max(0.0, score)), 4)
 
     # ── 综合分 ──
@@ -118,9 +120,11 @@ def _fenxi_jieguo_wenben(text: str) -> dict:
 
     text_lower = text.lower()
 
+    # bug-fix: Kimi#21 英文关键词加 \b 词边界、删单字褒贬词（“好”/“差”/“慢”），
+    # 避免“你好/恰好”命中“好”、“差不多/误差”命中“差”；顺带去掉重复的“创新”（2026-08-26，凌霜）
     # 错误计数
-    error_patterns = [r"错误", r"error", r"失败", r"fail", r"异常", r"exception",
-                      r"cuowu", r"shibai"]
+    error_patterns = [r"错误", r"\berror\b", r"失败", r"\bfail(?:ed|ure)?\b", r"异常",
+                      r"\bexception\b", r"cuowu", r"shibai"]
     error_count = sum(len(re.findall(p, text_lower)) for p in error_patterns)
 
     # 步骤计数
@@ -128,17 +132,17 @@ def _fenxi_jieguo_wenben(text: str) -> dict:
     step_count = sum(len(re.findall(p, text_lower)) for p in step_patterns)
 
     # 新颖度关键词
-    novel_patterns = [r"创新", r"新颖", r"首次", r"突破", r"novel", r"创新",
+    novel_patterns = [r"创新", r"新颖", r"首次", r"突破", r"\bnovel\b",
                       r"首创", r"新方法", r"新思路"]
     novel_count = sum(len(re.findall(p, text_lower)) for p in novel_patterns)
 
-    # 正面词
-    positive_patterns = [r"成功", r"完成", r"优秀", r"好", r"success", r"good",
+    # 正面词（仅保留多字词，误报率低）
+    positive_patterns = [r"成功", r"完成", r"优秀", r"\bsuccess\b", r"\bgood\b",
                          r"完美", r"满意", r"高效"]
     positive_count = sum(len(re.findall(p, text_lower)) for p in positive_patterns)
 
-    # 负面词
-    negative_patterns = [r"失败", r"差", r"糟糕", r"慢", r"bad", r"poor",
+    # 负面词（仅保留多字词）
+    negative_patterns = [r"失败", r"糟糕", r"\bbad\b", r"\bpoor\b",
                          r"不满", r"低效", r"缺陷"]
     negative_count = sum(len(re.findall(p, text_lower)) for p in negative_patterns)
 

--- a/app/backend/tiangong-backend/v3/json_guards.py
+++ b/app/backend/tiangong-backend/v3/json_guards.py
@@ -90,6 +90,46 @@ def loads_json_object(
     return data
 
 
+# bug-fix: Kimi#13 失败兜底人话映射表：error 字段给"人话文案+可操作建议"，
+# 原始异常文本只进 detail，不再直接暴露给用户（2026-08-26，凌霜）
+_YUANSHI_CUOWU_RENHUA = (
+    (("max retries exceeded", "connection refused", "connection reset", "connectionerror",
+      "connecterror", "connect timeout", "getaddrinfo", "name or service not known",
+      "temporary failure in name resolution", "ssl", "certificate", "proxy"),
+     "network_unreachable", "网络连不上模型服务：请检查网络或代理是否可用，稍后重试。"),
+    (("readtimeout", "read timeout", "timeouterror", "timed out", "timeout"),
+     "llm_timeout", "模型服务响应超时：请稍后重试，或在设置里切换更快的模型。"),
+    (("429", "rate limit", "quota", "insufficient"),
+     "rate_limited", "请求太频繁或额度不足：请稍等再试，或到服务商控制台检查用量。"),
+    (("401", "403", "unauthorized", "forbidden", "api key", "apikey", "invalid_api_key"),
+     "auth_failed", "鉴权失败：请检查 API Key 是否正确，以及账号权限和余额。"),
+    (("404", "not found"),
+     "endpoint_not_found", "接口或模型不存在：请检查模型名与 Base URL 配置。"),
+    (("500", "502", "503", "504", "internal server error", "bad gateway", "service unavailable"),
+     "provider_error", "模型服务商暂时异常：请稍后重试，或切换其他模型。"),
+)
+
+# 内部短码 → 人话（chat_failed / backend_error 等不再裸露）
+_DUANMA_RENHUA = {
+    "chat_failed": "对话没有完成：调用模型失败，请稍后重试。",
+    "backend_error": "后端服务暂时不可用：请稍后重试；若持续出现，请检查模型配置。",
+    "chat_runtime": "对话运行出错：请稍后重试。",
+}
+
+
+def _renhua_cuowu(raw: Any, default_code: str = "backend_error") -> tuple[str, str]:
+    """把原始异常文本/内部短码翻成 (error_code, 人话文案)；原始文本由调用方放 detail。"""
+    text = str(raw or "")
+    lowered = text.lower()
+    for keys, code, human in _YUANSHI_CUOWU_RENHUA:
+        if any(key in lowered for key in keys):
+            return code, human
+    short = text.strip()
+    if short in _DUANMA_RENHUA:
+        return short, _DUANMA_RENHUA[short]
+    return default_code, "服务暂时不可用：请稍后重试；若持续出现，请检查网络与模型配置。"
+
+
 def normalize_exception(exc: Exception, *, source: str = "backend") -> dict:
     if isinstance(exc, TiangongJsonError):
         return {
@@ -108,9 +148,11 @@ def normalize_exception(exc: Exception, *, source: str = "backend") -> dict:
             "source": source,
             "raw_preview": normalized.preview,
         }
+    # bug-fix: Kimi#13 兜底分支：error 换人话，原始异常只进 detail（2026-08-26，凌霜）
+    code, human = _renhua_cuowu(exc, default_code=type(exc).__name__)
     return {
-        "error_code": type(exc).__name__,
-        "error": str(exc) or type(exc).__name__,
+        "error_code": code,
+        "error": human,
         "detail": str(exc) or type(exc).__name__,
         "source": source,
         "raw_preview": "",
@@ -142,12 +184,15 @@ def normalize_error_text(text: Any, *, source: str = "backend") -> dict:
             "source": source,
             "raw_preview": preview_text(raw),
         }
+    # bug-fix: Kimi#13 兜底分支：原始异常文本（如 HTTPSConnectionPool/Max retries exceeded）
+    # 不再作为 error 直出用户，换人话+可操作建议；原文进 detail（2026-08-26，凌霜）
+    code, human = _renhua_cuowu(raw, default_code="backend_error")
     return {
-        "error_code": "backend_error",
-        "error": raw or "backend_error",
-        "detail": raw or "backend_error",
+        "error_code": code,
+        "error": human,
+        "detail": preview_text(raw, 800),
         "source": source,
-        "raw_preview": "",
+        "raw_preview": preview_text(raw),
     }
 
 

--- a/app/backend/tiangong-backend/v3/simple_chain/kernel.py
+++ b/app/backend/tiangong-backend/v3/simple_chain/kernel.py
@@ -209,16 +209,38 @@ _WORK_STRONG_MUTATION_MARKERS = (
     "打包", "压缩", "解压", "提交", "改成", "替换", "实现", "跑起来", "做完",
 )
 
+# bug-fix: 单字命令 marker（按/将/把/请）单用不构成“请求干活”，须与动作动词共现；
+# 否则中文闲聊（“请问…”“把它当…”“将信将疑”）恒判 work（2026-08-26，凌霜修 logic 类）
+_DANZI_MINGLING_MARKERS = ("请", "按", "把", "将")
+_DANZI_PEI_DONGCI = (
+    "查询", "读取", "查找", "搜索", "打开", "发送", "执行", "修改", "删除",
+    "写入", "保存", "创建", "新建", "移动", "复制", "重命名", "整理", "清理",
+    "打包", "压缩", "解压", "分析", "总结", "翻译", "转换", "生成", "制作",
+    "计算", "对比", "核对", "排查", "修复", "更新", "替换", "追加", "提交",
+    # 单字动词（仅与命令 marker 共现时生效，如“把文件删了”“请改一下”）：
+    "删", "改", "写", "查", "搜", "传", "发", "存", "移", "建", "跑", "转", "读",
+)
+
 def _simple_chain_has_explicit_work_frame(user_text: str) -> bool:
     """bug-fix: 多次思考路径根治 - 区分“请求干活”与“提到某个动作词”。
 
-    有命令语境（帮我/请/把/将/给我/执行/直接/开始…）或明确动作动词
+    有命令语境（帮我/按照/执行/直接/开始…）或明确动作动词
     （创建/修改/删除/打包…）才算请求干活；“help me with X”与裸提“X”分开。
     """
     compact = re.sub(r"\s+", "", str(user_text or "")).lower()
     if not compact:
         return False
-    if any(marker in compact for marker in _MUTATION_COMMAND_MARKERS):
+    # bug-fix: 单字 marker 改“marker+动作动词”双信号，杜绝闲聊误判（2026-08-26，凌霜修 logic 类）
+    has_dongci = any(marker in compact for marker in _WORK_STRONG_MUTATION_MARKERS) or any(
+        verb in compact for verb in _DANZI_PEI_DONGCI
+    )
+    for marker in _MUTATION_COMMAND_MARKERS:
+        if marker not in compact:
+            continue
+        if marker in _DANZI_MINGLING_MARKERS:
+            if has_dongci:
+                return True
+            continue
         return True
     return any(marker in compact for marker in _WORK_STRONG_MUTATION_MARKERS)
 
@@ -1707,7 +1729,10 @@ def _simple_chain_zip_container_ok(path: Path, suffix: str) -> tuple[bool, str]:
     return True, ""
 
 def _has_delivery_intent(user_text: str, reply_text: str = "") -> bool:
-    combined = f"{user_text or ''}\n{reply_text or ''}"
+    # bug-fix: 交付契约判定只扫用户原话——把 reply_text 拼进来会让模型的客套话
+    # （“已发送/见附件/打包好了”）反向污染任务契约（2026-08-26，凌霜修 logic 类）。
+    # 参数保留以兼容调用点，但不再参与判定。
+    combined = f"{user_text or ''}"
     markers = (
         "发给我", "发我", "发送", "传给我", "传我", "给我发", "微信发", "发到微信",
         "附件", "查收", "交付", "打包发我", "打包发送", "打包发给", "打包发到",
@@ -3755,7 +3780,9 @@ _SUSPECTED_TOOL_CALL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS = 3
+# bug-fix: 完成门 correction 上限 3→1：连环 correction 让模型重新回答 3-5 遍，
+# 一次修正机会足够给出增量证据，再不行就走确定性模板（2026-08-26，凌霜修 logic 类）
+_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS = 1
 
 _SIMPLE_CHAIN_MAX_LOOP_TURNS = int(os.environ.get("TIANGONG_SIMPLE_CHAIN_MAX_LOOP_TURNS", "180"))
 
@@ -5479,6 +5506,8 @@ _INCOMPLETE_REASON_RENHUA = (
     ("path_not_found", "要处理的文件或目录没有找到"),
     ("dangerous_command", "有条命令被安全边界拦下了"),
     ("repeated_tool_call", "同一个动作重复了太多次，我主动停了下来"),
+    # bug-fix: Kimi#14 reconciliation_required 英文码进人话映射表，出门前不再裸露内部码（2026-08-26，凌霜）
+    ("reconciliation_required", "上一轮超时动作的结果还没有确认，需要先核对副作用，不能只凭“继续”就原样重试"),
     ("budget", "本轮执行已到达平台执行预算上限（轮次/时长/工具数）"),
     ("protected artifact", "已通过验证的产物不允许被删除或覆盖"),
     ("post-mutation verification", "修改后还没有跑出验证结果"),
@@ -5633,11 +5662,9 @@ def _simple_chain_completion_correction_stalled(
         for item in (correction.get("last_blockers") or [])
         if str(item).strip()
     ][:8]
-    return bool(
-        int(correction.get("attempts_used") or 0) >= 1
-        and current
-        and current == previous
-    )
+    # bug-fix: stalled 改首轮比较——attempt=0 就对比 blockers（含跨 run 恢复的残留状态），
+    # 无变化立即走模板，不再保底烧一次 correction 调用（2026-08-26，凌霜修 logic 类）
+    return bool(current and current == previous)
 
 def _simple_chain_completion_fallback_reply(
     user_message: str,
@@ -5684,6 +5711,12 @@ def _simple_chain_natural_closeout_payload(
             "Never claim success beyond these verified facts. Do not emit a tool call."
         )
 
+    # bug-fix: closeout 明确要求“不复述已说过的进展，只给增量结论”——
+    # 收尾轮复述进度句会让用户看到同一内容说两遍（2026-08-26，凌霜修 logic 类）
+    instruction += (
+        " Do not restate progress narration you already streamed to the user; "
+        "state only the incremental final conclusion."
+    )
     return {
         "schema": "tiangong.v3.simple_chain.natural_closeout.v1",
         "authoritative_status": str(status or "incomplete"),

--- a/app/backend/tiangong-backend/v3/zongdiaodu.py
+++ b/app/backend/tiangong-backend/v3/zongdiaodu.py
@@ -3056,6 +3056,12 @@ class Zongdiaodu:
             if requires_evidence_safe_closeout(clean_reasons) and not allow_evidence_model:
                 _simple_chain_closeout_record(run_state, status, clean_reasons, "template_evidence_safe")
                 return shenti, fallback
+            # bug-fix: 强停/未完成（force_stopped/incomplete/failed）一律确定性模板立即返回，
+            # 不再发一次完整 LLM 调用“润色遗言”——强停场景剩余墙钟本就极少，最久还要再等
+            # 180s 收尾调用；人格化收尾只保留正常完成（complete）路径（2026-08-26，凌霜修 logic 类）
+            if status != "complete":
+                _simple_chain_closeout_record(run_state, status, clean_reasons, "template")
+                return shenti, fallback
             pre_closeout_reply = str(huifu or "").strip()
             # 强制停止场景剩余墙钟可能极少：余量不足时不再调模型，
             # 直接回退模板，避免收尾调用拖过网关 watchdog。
@@ -3066,6 +3072,10 @@ class Zongdiaodu:
                     return shenti, fallback
             except Exception:
                 pass
+            if _interim_emitter is not None:
+                # bug-fix: 收尾前清空进度气泡的累积正文：进度句已展示过，收尾语单独成段，
+                # 不再追加进同一气泡连成“进度+复述”一大段（2026-08-26，凌霜修 logic 类）
+                _interim_emitter.reset()
             try:
                 next_body, reply = _llm_closeout_scoped(
                     _simple_chain_model_payload(payload),
@@ -3881,6 +3891,9 @@ class Zongdiaodu:
                 for tn, ta, raw, call_id, original_tool_index in parallel_results:
                     call_key = _gongju_diaoyong_key(tn, ta if isinstance(ta, dict) else {})
                     tool_call_counts[call_key] = tool_call_counts.get(call_key, 0) + 1
+                    # bug-fix: repeat 标记只在“上次成功且参数全同”时生效，失败重跑不计入
+                    # repeat count（与串行路径同一规则，2026-08-26，凌霜修 logic 类）
+                    shangci_jieguo = tool_call_results.get(call_key)
                     tool_call_results[call_key] = raw
                     gongju_cishu = turn_loop.record_batch_result()
                     if on_event:
@@ -3893,7 +3906,9 @@ class Zongdiaodu:
                             "ok": ok_flag,
                         })
                     qp = _simple_chain_quality_gate_payload(request_id, xiaoxi, tn, ta, raw,
-                        tool_call_counts[call_key], run_state)
+                        (tool_call_counts[call_key]
+                         if _simple_chain_should_replay_cached_call(shangci_jieguo)
+                         else 1), run_state)
                     preflight_issues = parallel_preflight.get(call_key) or []
                     if preflight_issues:
                         existing_gaps = qp.get("final_requirement_gaps")
@@ -3968,13 +3983,18 @@ class Zongdiaodu:
                 grounded_read_reply = _simple_chain_verbatim_read_reply(xiaoxi, quality_history)
                 answer_ok, _answer_code = _simple_chain_substantive_answer(quality_history, next_huifu)
                 if grounded_read_reply and not answer_ok:
-                    next_huifu = grounded_read_reply
+                    # bug-fix: Runtime 二审不通过不再用原文证据整段顶替已流式推出的答复——
+                    # 气泡里是模型刚说的话、落定文字却是另一段。改为在已流出正文后追加
+                    # 证据补充，流式内容保持不变（2026-08-26，凌霜修 logic 类）
+                    streamed_text = str(next_huifu or "").rstrip()
+                    supplement = str(grounded_read_reply).strip()
+                    next_huifu = f"{streamed_text}\n\n{supplement}" if streamed_text else supplement
                     if run_control:
                         run_control.step(
                             "parallel_read_evidence_closeout",
-                            "Grounded exact-read closeout",
+                            "Grounded exact-read supplement",
                             "done",
-                            "Model omitted exact read text; returned complete source evidence without another side effect.",
+                            "Model omitted exact read text; appended complete source evidence after the streamed reply without another side effect.",
                         )
                 if not str(next_huifu or "").strip() and any(not bool(item.get("quality", {}).get("ok")) for item in tool_results_block):
                     final_guard_exhausted = True
@@ -4063,13 +4083,13 @@ class Zongdiaodu:
                         break
                     final_reasons_now = proof_reasons_now
 
-                    # bug-fix: 多次思考路径根治 - 全程零工具调用且模型已给出通顺最终答复时，
-                    # 跳过 completion correction 强插续写：被误判为 work 的文本问答不再被
-                    # 强迫“再思考 N 轮”。宁放过不误杀——承诺行动却未行动（“我来帮你写”）、
-                    # 工具调用残迹、脏标记等情形仍走原 correction 路径。
+                    # bug-fix: 多次思考路径根治 - 模型已给出通顺最终答复时，跳过 completion
+                    # correction 强插续写：被误判为 work 的文本问答不再被强迫“再思考 N 轮”。
+                    # bug-fix: 条件放宽到“已有工具证据 + 模型本轮已给出收尾语”——只读查询
+                    # （读文件后直接回答）不再被完成门连环打回重答 3-5 遍；仍有交付物
+                    # （generated_attachments）或必读路径义务时不走此捷径（2026-08-26，凌霜修 logic 类）
                     if (
-                        not quality_history
-                        and not generated_attachments
+                        not generated_attachments
                         and not required_read_paths
                         and _simple_chain_fluent_text_reply(huifu)
                     ):
@@ -4677,6 +4697,10 @@ class Zongdiaodu:
                 final_guard_exhausted = True
                 final_chain_status = "confirm_pending"
                 break
+            # bug-fix: 记录本次执行前的旧结果——repeat 标记只在“上次成功且参数全同”时生效；
+            # 失败重跑（缓存层放行）与本轮合法重写不再被 quality gate 误标
+            # [REPEATED_TOOL_CALL]（2026-08-26，凌霜修 logic 类）
+            shangci_jieguo = tool_call_results.get(tool_call_key)
             tool_call_results[tool_call_key] = gongju_jieguo
             if on_event:
                 on_event({
@@ -4692,7 +4716,11 @@ class Zongdiaodu:
                 tool_name,
                 tool_args,
                 gongju_jieguo,
-                tool_call_counts[tool_call_key],
+                (
+                    tool_call_counts[tool_call_key]
+                    if _simple_chain_should_replay_cached_call(shangci_jieguo)
+                    else 1
+                ),
                 run_state,
             )
             if preflight_issues:
@@ -5169,13 +5197,14 @@ class Zongdiaodu:
             if dynamic_context:
                 yonghu_tishi = _user_prompt_with_context(yonghu_tishi, dynamic_context)
             if run_control:
-                run_control.step("build_context", "?????", "done", "???????")
-                run_control.check_stop("??????????")
-                run_control.step("llm_call", "????", "running", "???????????")
+                # bug-fix: cc#10 乱码步骤标题/摘要按用户路径（build_context/llm_call）写法重写为中文（2026-08-26，凌霜）
+                run_control.step("build_context", "构建上下文", "done", "上下文已构建完成。")
+                run_control.check_stop("模型调用前检查是否已被停止。")
+                run_control.step("llm_call", "模型调用", "running", "正在调用模型生成回复。")
             shenti, huifu = self.gutong.huanxing(system_tishi, yonghu_tishi, shenti)
             if run_control:
-                run_control.step("llm_call", "????", "done", _llm_reply_progress_summary(huifu))
-                run_control.check_stop("??????????")
+                run_control.step("llm_call", "模型调用", "done", _llm_reply_progress_summary(huifu))
+                run_control.check_stop("模型回复后检查是否已被停止。")
             huifu, self.zuihou_biaoxian = _tiqu_biaoxian(huifu, xiaoxi)
             QUANZHUIXIAN.jilu_kuadu(zhuizong_id, "LLM_diaoyong", "wancheng", "direct_non_user_chain")
             if QIYONG_JIYI:

--- a/tests/test_foundation_closeout.py
+++ b/tests/test_foundation_closeout.py
@@ -998,7 +998,8 @@ class OmniToolInvocationCloseoutTests(unittest.TestCase):
         )
         self.assertEqual(payload["schema"], "tiangong.v3.simple_chain.completion_correction.v1")
         self.assertEqual(payload["attempts_used"], 1)
-        self.assertEqual(payload["attempts_remaining"], 2)
+        # bug-fix: correction 上限 3→1（2026-08-26，凌霜修 logic 类），剩余次数随之为 0
+        self.assertEqual(payload["attempts_remaining"], 0)
         serialized = json.dumps(payload, ensure_ascii=False).lower()
         for forbidden in ("file.write", "file.read", "file.hash", "omni_body", "exactly one", "stop read"):
             self.assertNotIn(forbidden, serialized)

--- a/tests/test_run_state_v2_stuck_cleanup.py
+++ b/tests/test_run_state_v2_stuck_cleanup.py
@@ -246,11 +246,12 @@ class CompletionCorrectionPersistenceTests(unittest.TestCase):
             }
         }
         normalized = _simple_chain_completion_correction_state(state)
-        self.assertEqual(normalized["attempts_used"], 2)
+        # bug-fix: correction 上限 3→1（2026-08-26，凌霜修 logic 类），超限计数钳到新上限
+        self.assertEqual(normalized["attempts_used"], 1)
         state["completion_correction"]["last_blockers"] = ["different gap after progress"]
         normalized = _simple_chain_completion_correction_state(state)
-        self.assertEqual(normalized["attempts_used"], 2)
-        self.assertEqual(normalized["attempts_max"], 3)
+        self.assertEqual(normalized["attempts_used"], 1)
+        self.assertEqual(normalized["attempts_max"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_simple_chain_atomic_gates_20260806.py
+++ b/tests/test_simple_chain_atomic_gates_20260806.py
@@ -201,14 +201,15 @@ def test_completion_correction_is_evidence_only_and_bounded() -> None:
         }
     }
     correction = _simple_chain_completion_correction_state(state)
-    assert correction["attempts_used"] == 2
-    assert correction["attempts_max"] == 3
+    # bug-fix: correction 上限 3→1（2026-08-26，凌霜修 logic 类），超限计数钳到 1
+    assert correction["attempts_used"] == 1
+    assert correction["attempts_max"] == 1
     payload = _simple_chain_completion_correction_payload(
         "req_x",
         ["written content cjk_chars=983 < required 2500"],
         state,
     )
-    assert payload["attempts_remaining"] == 1
+    assert payload["attempts_remaining"] == 0
     serialized = json.dumps(payload, ensure_ascii=False).lower()
     for forbidden in (
         "file.append",

--- a/tests/test_simple_chain_loop_budget.py
+++ b/tests/test_simple_chain_loop_budget.py
@@ -262,7 +262,7 @@ class SimpleChainLoopBudgetTests(unittest.TestCase):
         self.assertEqual(_SIMPLE_CHAIN_MAX_WALL_CLOCK_SECONDS, 5400)
         self.assertEqual(_SIMPLE_CHAIN_MAX_REPEAT_OBSERVATIONS, 90)
         self.assertEqual(_SIMPLE_CHAIN_MAX_READONLY_REPEAT_OBSERVATIONS, 90)
-        self.assertEqual(_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS, 3)
+        self.assertEqual(_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS, 1)
         self.assertEqual(_SIMPLE_CHAIN_MAX_TOOL_EXECUTION_SECONDS, 540)
 
     def test_work_status_question_is_not_mutation(self) -> None:
@@ -736,7 +736,7 @@ class SimpleChainLoopBudgetTests(unittest.TestCase):
             _SIMPLE_CHAIN_MAX_WALL_CLOCK_SECONDS,
         )
 
-        self.assertEqual(_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS, 3)
+        self.assertEqual(_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS, 1)
         self.assertGreaterEqual(_SIMPLE_CHAIN_MAX_TOOL_ROUNDS, 1)
         self.assertGreaterEqual(_SIMPLE_CHAIN_MAX_LOOP_TURNS, _SIMPLE_CHAIN_MAX_TOOL_ROUNDS)
         self.assertGreaterEqual(_SIMPLE_CHAIN_MAX_REPEAT_OBSERVATIONS, 1)


### PR DESCRIPTION
## 背景

GLM/cc + Kimi 同步 UX 实用性质检后，凌霜按"会阻碍 v3 自身执行力就修"框架判定，把 25 条问题分三类：
- **code 类 9 条**（直接修）
- **logic 类 11 条 → 修 10 条**（保留 1 条话术人设打架，不阻碍执行力）
- **design 类 5 条**（保留 v3 设计哲学，不修）

## commit 1: code 类 9 条

乱码 / 死代码 / 异常文案 / 匹配算法 / 中英混杂 hint / 内部话术 prompt / 评分子串 / 截断提示 / 微信时间线硬编码

## commit 2: logic 类 10 条

完成门 / 收尾复述 / markers / 交付意图 / 二审覆盖 / 重复调用 / closeout 强停 / 错误关键词 / 流中断线 / 学习表达注入

## 保留 design 类 5 条

- 预算 75/1000/180（v3 "穷尽验证"哲学）
- 空转兜底阈值（容忍弱模型摇摆）
- ContextEnvelope JSON 回注（保留上下文完整性）
- 用户原话回学习（跨轮记忆机制）
- MiniMax rescue（模型挂了恢复机制）

## 测试

- pytest 3207 passed / 1 failed（test_windows_powershell_wrapper Linux 环境无关，预期允许）
- 4 测试文件同步更新上限断言（L1 修改 `_SIMPLE_CHAIN_MAX_COMPLETION_CORRECTIONS` 3→1）

## Test plan
- [x] pytest 3207 passed
- [x] 内联行为验证（cc 已跑：双分支标题 / 异常映射 / renhua 翻译 / think 标注 / 词边界 / marker 共现）
