### PR TITLE
fix(p19): M1.1 identity integrity — derived-id binding at both trust boundaries

### DIFF
--- a/app/life-service/runtime314/contracts/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/contracts/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "shared-contracts",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/contracts",
-  "tree_sha256": "2034e661cf6b0a31a367c862df045f693f1e6f336175a1bb82971d4afc4a6479",
+  "tree_sha256": "32aebdcead730a809149904b3311e40aa2175ebb8b42ac0877a3370684ab8acf",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/contracts/verification.py
+++ b/app/life-service/runtime314/contracts/verification.py
@@ -215,6 +215,17 @@ class RegistrySnapshot(ContractModel):
     def has_valid_snapshot_sha256(self) -> bool:
         return self.snapshot_sha256 == self.computed_snapshot_sha256()
 
+    def has_valid_identity(self) -> bool:
+        """Identity binding: derived id must match the (valid) hash.
+
+        Pure method only — real trust boundaries (Recorder/Store) must
+        re-verify, because ``model_copy(update=...)`` bypasses validation.
+        """
+        return self.has_valid_snapshot_sha256() and (
+            self.registry_snapshot_id
+            == derive_registry_snapshot_id(snapshot_sha256=self.snapshot_sha256)
+        )
+
     def with_computed_sha256(self) -> RegistrySnapshot:
         return self.model_copy(
             update={"snapshot_sha256": self.computed_snapshot_sha256()}
@@ -303,6 +314,17 @@ class VerificationRecord(ContractModel):
 
     def has_valid_result_sha256(self) -> bool:
         return self.result_sha256 == self.computed_result_sha256()
+
+    def has_valid_identity(self) -> bool:
+        """Identity binding: derived id must match the (valid) hash.
+
+        Pure method only — real trust boundaries (Recorder/Store) must
+        re-verify, because ``model_copy(update=...)`` bypasses validation.
+        """
+        return self.has_valid_result_sha256() and (
+            self.verification_record_id
+            == derive_verification_record_id(result_sha256=self.result_sha256)
+        )
 
     def with_computed_sha256(self) -> VerificationRecord:
         return self.model_copy(update={"result_sha256": self.computed_result_sha256()})

--- a/docs/p19-r2/M1_1_IDENTITY_INTEGRITY.txt
+++ b/docs/p19-r2/M1_1_IDENTITY_INTEGRITY.txt
@@ -1,0 +1,63 @@
+P19-R2 M1.1｜Identity Integrity 修正说明（M1_1_IDENTITY_INTEGRITY）
+======================================================================
+分支：glm53/p19-r2-m1.1-verification-identity-integrity（自 21e3cdf）
+性质：零功能、零 schema 变更、零迁移。STORE_SCHEMA_VERSION 保持 23，
+enforcement 保持 RECORD ONLY，未触碰任何完成行为。
+
+----------------------------------------------------------------------
+四个不变量与落点
+----------------------------------------------------------------------
+I-1 VerificationRecord 身份绑定
+    verification_record_id == derive_verification_record_id(
+        result_sha256=record.result_sha256)
+    落点（双层 fail-closed）：
+    - contracts.verification.VerificationRecord.has_valid_identity()
+      （纯方法，hash 有效 AND 派生 ID 匹配）
+    - VerificationRecorder._validate（model_copy 旁路后重验）
+    - GatewayStateStore.put_verification_record（显式比对派生 ID）
+
+I-2 RegistrySnapshot 身份绑定
+    registry_snapshot_id == derive_registry_snapshot_id(
+        snapshot_sha256=snapshot.snapshot_sha256)
+    落点：
+    - RegistrySnapshot.has_valid_identity()（纯方法）
+    - VerificationRecorder.__init__
+    - GatewayStateStore.put_registry_snapshot
+
+I-3 嵌套描述符完整性
+    Recorder 初始化时执行 VerifierRegistry(snapshot.verifiers)——
+    直接复用注册表全部 fail-closed 规则（descriptor_sha256 可复算、
+    verifier_id 去重、predicate allowlist、坏哈希拒绝），不复制逻辑。
+    失败包装为 VerificationRecordRejected（cause 链保留原 ValueError）。
+
+I-4 model_copy 旁路回归
+    所有 trust boundary 自行重验派生身份，不依赖构造器纪律。
+    测试矩阵 A-I 全部落测试锁定（见下）。
+
+----------------------------------------------------------------------
+测试矩阵对照（tests/test_p19_m1_1_identity_integrity.py + store 扩展）
+----------------------------------------------------------------------
+A  错误但格式合法 record_id → Recorder 拒绝        RecordIdentityTests
+B  同情况直呼 store.put → store 拒绝               IdentityIntegrityStoreTests
+C  placeholder vrs_000... + 合法 hash → 双层拒绝    A/C 两处
+D  合法 snapshot hash + 错误 snapshot_id → 双层拒绝  SnapshotIdentityTests + store
+E  描述符被改、内层哈希失效、外层重算合法 → Recorder 拒绝
+F  描述符声明 allowlist 外 predicate、全部外层哈希重算合法 → Recorder 拒绝
+G  Registry.snapshot → store → reopen → recorder 全链路通过
+H  相同内容 deterministic identity 稳定
+I  captured_at_ms 改变不改变 snapshot identity
+
+附带修正：
+- test_p19_m1_registry.py 的 __import__ hack 清理为正规导入；
+- test_same_identity_different_content_conflicts 语义更新：
+  M1.1 后「同 ID 不同内容」在边界即被 ValueError 拦截
+  （同 ID 结构上蕴含同 hash）；DB 冲突分支保留为纵深防御。
+
+----------------------------------------------------------------------
+验证
+----------------------------------------------------------------------
+- targeted：M1 全部 65 passed（contracts/registry/store/M1.1）
+- contract bundle digest 不变（纯方法不进 JSON Schema，
+  test_contract_artifacts 19 passed 锁定 P19 digest）
+- source-authority PASS / sync --check-committed ok / 全文 LF
+- 全量回归：见 PR 描述

--- a/src/contracts/verification.py
+++ b/src/contracts/verification.py
@@ -215,6 +215,17 @@ class RegistrySnapshot(ContractModel):
     def has_valid_snapshot_sha256(self) -> bool:
         return self.snapshot_sha256 == self.computed_snapshot_sha256()
 
+    def has_valid_identity(self) -> bool:
+        """Identity binding: derived id must match the (valid) hash.
+
+        Pure method only — real trust boundaries (Recorder/Store) must
+        re-verify, because ``model_copy(update=...)`` bypasses validation.
+        """
+        return self.has_valid_snapshot_sha256() and (
+            self.registry_snapshot_id
+            == derive_registry_snapshot_id(snapshot_sha256=self.snapshot_sha256)
+        )
+
     def with_computed_sha256(self) -> RegistrySnapshot:
         return self.model_copy(
             update={"snapshot_sha256": self.computed_snapshot_sha256()}
@@ -303,6 +314,17 @@ class VerificationRecord(ContractModel):
 
     def has_valid_result_sha256(self) -> bool:
         return self.result_sha256 == self.computed_result_sha256()
+
+    def has_valid_identity(self) -> bool:
+        """Identity binding: derived id must match the (valid) hash.
+
+        Pure method only — real trust boundaries (Recorder/Store) must
+        re-verify, because ``model_copy(update=...)`` bypasses validation.
+        """
+        return self.has_valid_result_sha256() and (
+            self.verification_record_id
+            == derive_verification_record_id(result_sha256=self.result_sha256)
+        )
 
     def with_computed_sha256(self) -> VerificationRecord:
         return self.model_copy(update={"result_sha256": self.computed_result_sha256()})

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -63,7 +63,12 @@ from contracts import (
     new_state_snapshot,
     renew_candidate_owner,
 )
-from contracts.verification import RegistrySnapshot, VerificationRecord
+from contracts.verification import (
+    RegistrySnapshot,
+    VerificationRecord,
+    derive_registry_snapshot_id,
+    derive_verification_record_id,
+)
 from contracts.state_machine import ATTEMPT_RECONCILIATION_VERDICTS
 from .coordination import FencedResultDecision, GenerationLeaseView
 from .coordination_events import CoordinationEvent, CoordinationRecord, CoordinationResolution
@@ -9241,8 +9246,18 @@ class GatewayStateStore:
         """
         if not isinstance(record, VerificationRecord):
             raise ValueError("verification record payload has the wrong type")
+        # Trust boundary: model_copy(update=...) bypasses pydantic validation,
+        # so the derived identity is re-verified here instead of trusting the
+        # caller's constructor discipline.
         if not record.has_valid_result_sha256():
             raise ValueError("verification record result hash mismatch")
+        if (
+            record.verification_record_id
+            != derive_verification_record_id(result_sha256=record.result_sha256)
+        ):
+            raise ValueError(
+                "verification record identity does not match its result hash"
+            )
         if record.enforcement != "RECORD":
             raise ValueError("M1 verification records must be enforcement=RECORD")
         payload_json = json.dumps(
@@ -9364,8 +9379,17 @@ class GatewayStateStore:
         """Persist a registry snapshot; returns True when newly created."""
         if not isinstance(snapshot, RegistrySnapshot):
             raise ValueError("registry snapshot payload has the wrong type")
+        # Trust boundary: derived identity must match the (valid) hash;
+        # model_copy(update=...) payloads cannot rely on constructor checks.
         if not snapshot.has_valid_snapshot_sha256():
             raise ValueError("registry snapshot hash mismatch")
+        if (
+            snapshot.registry_snapshot_id
+            != derive_registry_snapshot_id(snapshot_sha256=snapshot.snapshot_sha256)
+        ):
+            raise ValueError(
+                "registry snapshot identity does not match its snapshot hash"
+            )
         payload_json = json.dumps(
             snapshot.model_dump(mode="json"), ensure_ascii=False,
             allow_nan=False, sort_keys=True, separators=(",", ":"),

--- a/src/total_gateway/verification_recording.py
+++ b/src/total_gateway/verification_recording.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from contracts.verification import RegistrySnapshot, VerificationRecord
-from total_gateway.verification_registry import UnknownVerifierError
+from total_gateway.verification_registry import (
+    UnknownVerifierError,
+    VerifierRegistry,
+)
 
 
 class VerificationRecordRejected(ValueError):
@@ -37,8 +40,19 @@ class VerificationRecorder:
     """Binding between a pinned registry snapshot and the store."""
 
     def __init__(self, *, snapshot: RegistrySnapshot, store) -> None:
-        if not snapshot.has_valid_snapshot_sha256():
-            raise VerificationRecordRejected("registry snapshot hash mismatch")
+        # Trust boundary: model_copy(update=...) bypasses pydantic
+        # validation, so identity binding and nested descriptor integrity
+        # are re-verified here instead of trusting the constructor path.
+        if not snapshot.has_valid_identity():
+            raise VerificationRecordRejected("registry snapshot identity binding is invalid")
+        try:
+            # Reuse the registry's fail-closed rules (descriptor hashes,
+            # duplicates, predicate allowlist) instead of duplicating them.
+            VerifierRegistry(snapshot.verifiers)
+        except ValueError as exc:
+            raise VerificationRecordRejected(
+                "registry snapshot contains invalid verifier descriptors"
+            ) from exc
         object.__setattr__(self, "_snapshot", snapshot)
         object.__setattr__(self, "_store", store)
 
@@ -62,8 +76,14 @@ class VerificationRecorder:
             raise VerificationRecordRejected(
                 f"M1 records must be enforcement=RECORD, got {record.enforcement}"
             )
-        if not record.has_valid_result_sha256():
-            raise VerificationRecordRejected("record result hash mismatch")
+        # Trust boundary re-verification: a model_copy(update=...) payload
+        # with a valid-looking result hash but a mismatched derived id must
+        # fail closed here, not depend on the caller's constructor discipline.
+        if not record.has_valid_identity():
+            raise VerificationRecordRejected(
+                "record identity binding is invalid (derived id does not"
+                " match its result hash)"
+            )
         if record.registry_snapshot_sha256 != self._snapshot.snapshot_sha256:
             raise VerificationRecordRejected(
                 "record was produced against a different registry snapshot"

--- a/tests/test_p19_m1_1_identity_integrity.py
+++ b/tests/test_p19_m1_1_identity_integrity.py
@@ -1,0 +1,196 @@
+"""P19-R2 M1.1 identity-integrity regression tests (review matrix A/C/E/F/H/I).
+
+model_copy(update=...) bypasses pydantic validation, so every trust
+boundary must re-verify derived identity and nested descriptor
+integrity instead of trusting the constructor path.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+from contracts.verification import (
+    RegistrySnapshot,
+    VerificationRecord,
+    derive_registry_snapshot_id,
+    derive_verification_record_id,
+)
+from total_gateway.verification_recording import (
+    VerificationRecordRejected,
+    VerificationRecorder,
+)
+from total_gateway.verification_registry import VerifierRegistry
+
+from tests.test_p19_m1_registry import _FakeStore
+
+
+WRONG_BUT_VALID_ID = "vrs_" + "e" * 64
+PLACEHOLDER_ID = "vrs_" + "0" * 64
+WRONG_BUT_VALID_SNAPSHOT_ID = "vrg_" + "e" * 64
+
+
+def _good_record(snapshot_sha: str) -> VerificationRecord:
+    payload = dict(
+        verification_record_id=PLACEHOLDER_ID,
+        request_id="req_" + "a" * 64,
+        run_id="run_" + "b" * 64,
+        generation=1,
+        verifier_id="verifier.effect_state",
+        verifier_version="1",
+        registry_snapshot_sha256=snapshot_sha,
+        predicate_id="vpd_m11",
+        predicate_type="effect.terminal_succeeded",
+        subject_kind="effect",
+        subject_identity="eff_" + "c" * 64,
+        evaluation_phase="POST_EXECUTION",
+        status="FAIL",
+        enforcement="RECORD",
+        reason_codes=("effect.not_terminal",),
+        evidence_refs=("ev_1",),
+        evidence_sha256="d" * 64,
+        producer_component_id="tiangong-gateway",
+        model_generated=False,
+        evaluated_at_ms=1_234,
+        result_sha256="0" * 64,
+    )
+    record = VerificationRecord(**payload).with_computed_sha256()
+    return record.model_copy(
+        update={
+            "verification_record_id": derive_verification_record_id(
+                result_sha256=record.result_sha256
+            )
+        }
+    )
+
+
+def _snapshot_with_descriptors(descriptors) -> RegistrySnapshot:
+    """Build a snapshot whose OUTER hashes and derived id are fully valid."""
+    partial = RegistrySnapshot(
+        registry_snapshot_id="vrg_" + "0" * 64,
+        verifiers=tuple(sorted(descriptors, key=lambda d: d.verifier_id)),
+        captured_at_ms=1,
+        snapshot_sha256="0" * 64,
+    ).with_computed_sha256()
+    return partial.model_copy(
+        update={
+            "registry_snapshot_id": derive_registry_snapshot_id(
+                snapshot_sha256=partial.snapshot_sha256
+            )
+        }
+    )
+
+
+class RecordIdentityTests(unittest.TestCase):
+    """A / C: wrong-but-valid-format or placeholder ids must fail closed."""
+
+    def setUp(self) -> None:
+        self.snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+        self.store = _FakeStore()
+        self.recorder = VerificationRecorder(
+            snapshot=self.snapshot, store=self.store
+        )
+
+    def test_a_wrong_but_valid_format_id_rejected_by_recorder(self) -> None:
+        good = _good_record(self.snapshot.snapshot_sha256)
+        bad_id = good.model_copy(update={"verification_record_id": WRONG_BUT_VALID_ID})
+        # hash stays valid; only the derived identity is wrong
+        self.assertTrue(bad_id.has_valid_result_sha256())
+        self.assertFalse(bad_id.has_valid_identity())
+        with pytest.raises(VerificationRecordRejected):
+            self.recorder.record(bad_id, recorded_at_ms=2_000)
+        self.assertEqual(self.store.records, [])
+
+    def test_c_placeholder_id_rejected_by_recorder(self) -> None:
+        good = _good_record(self.snapshot.snapshot_sha256)
+        placeholder = good.model_copy(update={"verification_record_id": PLACEHOLDER_ID})
+        self.assertTrue(placeholder.has_valid_result_sha256())
+        with pytest.raises(VerificationRecordRejected):
+            self.recorder.record(placeholder, recorded_at_ms=2_000)
+        self.assertEqual(self.store.records, [])
+
+    def test_valid_record_still_passes(self) -> None:
+        good = _good_record(self.snapshot.snapshot_sha256)
+        self.assertTrue(good.has_valid_identity())
+        outcome = self.recorder.record(good, recorded_at_ms=2_000)
+        self.assertTrue(outcome.created_by_this_call)
+
+
+class SnapshotIdentityTests(unittest.TestCase):
+    """D / E / F: snapshot identity + nested descriptor integrity."""
+
+    def setUp(self) -> None:
+        self.store = _FakeStore()
+
+    def test_d_wrong_snapshot_id_rejected_by_recorder(self) -> None:
+        snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+        bad = snapshot.model_copy(
+            update={"registry_snapshot_id": WRONG_BUT_VALID_SNAPSHOT_ID}
+        )
+        self.assertTrue(bad.has_valid_snapshot_sha256())
+        self.assertFalse(bad.has_valid_identity())
+        with pytest.raises(VerificationRecordRejected):
+            VerificationRecorder(snapshot=bad, store=self.store)
+
+    def test_e_tampered_descriptor_with_valid_outer_hashes_rejected(self) -> None:
+        descriptors = list(VerifierRegistry.with_defaults().descriptors)
+        # Tamper WITHOUT recomputing descriptor_sha256 -> stale inner hash,
+        # then rebuild the outer snapshot hash + derived id so the outer
+        # layer is fully self-consistent.
+        tampered = descriptors[0].model_copy(update={"timeout_ms": 999_999})
+        descriptors[0] = tampered
+        snapshot = _snapshot_with_descriptors(descriptors)
+        self.assertTrue(snapshot.has_valid_snapshot_sha256())
+        self.assertTrue(snapshot.has_valid_identity())
+        with pytest.raises(VerificationRecordRejected):
+            VerificationRecorder(snapshot=snapshot, store=self.store)
+
+    def test_f_allowlist_escape_with_all_hashes_valid_rejected(self) -> None:
+        descriptors = list(VerifierRegistry.with_defaults().descriptors)
+        malicious = descriptors[0].model_copy(
+            update={
+                "supported_predicate_types": (
+                    "artifact.nonempty",
+                    "factuality.correct",
+                )
+            }
+        ).with_computed_sha256()  # descriptor hash is valid for the bad content
+        descriptors[0] = malicious
+        snapshot = _snapshot_with_descriptors(descriptors)
+        self.assertTrue(snapshot.has_valid_identity())
+        # descriptor itself passes model-level rules; only the registry
+        # allowlist catches it — through the recorder trust boundary.
+        with pytest.raises(VerificationRecordRejected):
+            VerificationRecorder(snapshot=snapshot, store=self.store)
+
+    def test_legitimate_snapshot_accepted(self) -> None:
+        snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+        recorder = VerificationRecorder(snapshot=snapshot, store=self.store)
+        self.assertTrue(recorder.snapshot.has_valid_identity())
+
+
+class DeterministicIdentityTests(unittest.TestCase):
+    """H / I: identity stability."""
+
+    def test_h_same_descriptors_same_identity(self) -> None:
+        first = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+        second = VerifierRegistry.with_defaults().snapshot(captured_at_ms=2)
+        self.assertEqual(first.snapshot_sha256, second.snapshot_sha256)
+        self.assertEqual(
+            first.registry_snapshot_id, second.registry_snapshot_id
+        )
+
+    def test_i_captured_at_change_does_not_change_identity(self) -> None:
+        base = VerifierRegistry.with_defaults().snapshot(captured_at_ms=100)
+        later = base.model_copy(update={"captured_at_ms": 999_999})
+        self.assertEqual(later.snapshot_sha256, base.snapshot_sha256)
+        self.assertEqual(
+            later.registry_snapshot_id, base.registry_snapshot_id
+        )
+        # ...and the derived id still matches after the metadata change
+        self.assertTrue(later.has_valid_identity())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_p19_m1_registry.py
+++ b/tests/test_p19_m1_registry.py
@@ -15,7 +15,13 @@ from dataclasses import dataclass
 
 import pytest
 
-from contracts.verification import VerificationRecord, VerifierDescriptor
+from contracts.verification import (
+    RegistrySnapshot,
+    VerificationRecord,
+    VerifierDescriptor,
+    derive_registry_snapshot_id,
+    derive_verification_record_id,
+)
 from total_gateway.verification_recording import (
     RecordOutcome,
     VerificationRecordRejected,
@@ -161,10 +167,8 @@ class RecorderTests(unittest.TestCase):
         record = VerificationRecord(**payload).with_computed_sha256()
         return record.model_copy(
             update={
-                "verification_record_id": (
-                    "vrs_"
-                    + __import__("contracts.verification", fromlist=["x"])
-                    .derive_verification_record_id(result_sha256=record.result_sha256)
+                "verification_record_id": derive_verification_record_id(
+                    result_sha256=record.result_sha256
                 )
             }
         )

--- a/tests/test_p19_m1_store.py
+++ b/tests/test_p19_m1_store.py
@@ -229,17 +229,25 @@ class RecordLifecycleTests(P19M1StoreTestBase):
         self.assertEqual(second.recorded_at_ms, 2_000)
 
     def test_same_identity_different_content_conflicts(self) -> None:  # 10
+        # M1.1: forcing the same derived id onto different content is now
+        # rejected at the trust boundary (identity != result hash) before
+        # the store-level conflict path; the DB conflict branch remains as
+        # defense in depth (a shared id structurally implies a shared hash).
         record = self._record()
         self.recorder.record(record, recorded_at_ms=2_000)
         other = self._record(
             subject_identity="obj_" + "9" * 64
         )
-        # force the same identity with different content
-        other = other.model_copy(
+        self.assertNotEqual(
+            other.result_sha256, record.result_sha256
+        )  # different content -> different hash -> different derived id
+        forced = other.model_copy(
             update={"verification_record_id": record.verification_record_id}
         )
-        with self.assertRaises(StoreConflictError):
-            self.store.put_verification_record(other, recorded_at_ms=2_200)
+        with self.assertRaises(ValueError):
+            self.store.put_verification_record(forced, recorded_at_ms=2_200)
+        with self.assertRaises(VerificationRecordRejected):
+            self.recorder.record(forced, recorded_at_ms=2_200)
 
     def test_binding_mismatch_rejected(self) -> None:  # 7
         wrong_run = self._record(run_id="run_" + "f" * 64)
@@ -320,6 +328,61 @@ class RecordLifecycleTests(P19M1StoreTestBase):
         fetched = self.store.get_registry_snapshot(self.snapshot.registry_snapshot_id)
         assert fetched is not None
         self.assertEqual(fetched, self.snapshot)
+
+
+class IdentityIntegrityStoreTests(P19M1StoreTestBase):
+    """M1.1 review matrix B / C / D / G at the store trust boundary."""
+
+    def _wrong_id_record(self) -> VerificationRecord:
+        good = self._record()
+        return good.model_copy(
+            update={"verification_record_id": "vrs_" + "e" * 64}
+        )
+
+    def test_b_wrong_record_id_rejected_by_store(self) -> None:
+        bad = self._wrong_id_record()
+        self.assertTrue(bad.has_valid_result_sha256())  # hash fine, id wrong
+        with self.assertRaises(ValueError):
+            self.store.put_verification_record(bad, recorded_at_ms=2_000)
+
+    def test_c_placeholder_record_id_rejected_by_store(self) -> None:
+        good = self._record()
+        placeholder = good.model_copy(
+            update={"verification_record_id": "vrs_" + "0" * 64}
+        )
+        with self.assertRaises(ValueError):
+            self.store.put_verification_record(placeholder, recorded_at_ms=2_000)
+
+    def test_d_wrong_snapshot_id_rejected_by_store(self) -> None:
+        bad = self.snapshot.model_copy(
+            update={"registry_snapshot_id": "vrg_" + "e" * 64}
+        )
+        self.assertTrue(bad.has_valid_snapshot_sha256())
+        with self.assertRaises(ValueError):
+            self.store.put_registry_snapshot(bad, recorded_at_ms=2_000)
+
+    def test_g_full_chain_snapshot_store_reopen_recorder(self) -> None:
+        # Registry.snapshot -> store persist -> close -> reopen -> fetch
+        # -> recorder built from the fetched snapshot -> record succeeds.
+        fetched = self.store.get_registry_snapshot(
+            self.snapshot.registry_snapshot_id
+        )
+        assert fetched is not None
+        recorder = VerificationRecorder(snapshot=fetched, store=self.store)
+        record = self._record()
+        outcome = recorder.record(record, recorded_at_ms=2_000)
+        self.assertTrue(outcome.created_by_this_call)
+        self.store.close()
+        self.store = GatewayStateStore.open(self.path, now_ms=2_500)
+        listed = self.store.list_verification_records(
+            request_id=self.request_id, run_id=self.run_id, generation=1
+        )
+        self.assertEqual(listed, (record,))
+        refetched = self.store.get_registry_snapshot(
+            self.snapshot.registry_snapshot_id
+        )
+        assert refetched is not None
+        self.assertTrue(refetched.has_valid_identity())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## M1.1｜按审核四不变量逐条落实

**零功能 / 零 schema 字段 / 零迁移（v23 保持）/ RECORD ONLY 不变。**

### 四个不变量
1. **Record 身份绑定**：`verification_record_id == derive(result_sha256)` —— Recorder.\_validate 与 `store.put_verification_record` **双层 fail-closed**；契约新增纯方法 `has_valid_identity()`
2. **Snapshot 身份绑定**：`registry_snapshot_id == derive(snapshot_sha256)` —— Recorder.\_\_init 与 `put_registry_snapshot` 双层拒绝「hash 正确但派生 ID 错误」
3. **嵌套描述符完整性**：Recorder 初始化直接执行 `VerifierRegistry(snapshot.verifiers)` **复用**既有 fail-closed 规则（描述符哈希复算/verifier_id 去重/allowlist/坏哈希），零逻辑复制，失败包装为 VerificationRecordRejected（cause 链保留）
4. **model_copy 旁路**：所有 trust boundary 自行重验，不依赖构造器纪律

### 测试矩阵 A–I 对照
| 项 | 内容 | 落点 |
|---|---|---|
| A | 合法 hash + 错误格式合法 ID → Recorder 拒 | RecordIdentityTests |
| B | 同情况直呼 store → 拒 | IdentityIntegrityStoreTests |
| C | placeholder vrs_000… → 双层拒 | 两处 |
| D | 合法 snapshot hash + 错 snapshot_id → 双层拒 | SnapshotIdentityTests + store |
| E | 内层描述符失效+外层哈希重算合法 → Recorder 拒 | 同上 |
| F | allowlist 逃逸+全部外层哈希合法 → Recorder 拒 | 同上 |
| G | snapshot→store→reopen→recorder 全链路通过 | store 测试 |
| H/I | 确定性身份 + captured_at 不变性 | DeterministicIdentityTests |

附带：清理 registry 测试 `__import__` hack；「同ID不同内容」测试语义更新为边界拦截（DB 冲突分支保留纵深防御）。

### 验证
- M1 targeted：**65 passed**；bundle digest **不变**（纯方法不进 JSON Schema，19 项基线测试锁定）
- **全量回归 3334 passed / 0 failures**；source-authority / sync / LF 全过