### PR TITLE
fix(p19): M2.2 artifact trust-boundary closure

### DIFF
--- a/app/life-service/runtime314/contracts/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/contracts/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "shared-contracts",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/contracts",
-  "tree_sha256": "3b292ac57c027b8b6d22fec6d84958d8c57a0ac82d5f1c27152df7f2a1e76524",
+  "tree_sha256": "72c5fdfaa06f0159d3fedfec1f249815e5b432fbe871f2bb0b9ab0ac41796360",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/contracts/compatibility.py
+++ b/app/life-service/runtime314/contracts/compatibility.py
@@ -56,11 +56,16 @@ P17_LIFE_P10_ATOMIC_CONTEXT_SCHEMA_BASELINE_SHA256 = (
 P18_G1_VNEXT_CONTRACT_SCHEMA_BASELINE_SHA256 = (
     "09e24fbd4d36333dd63b62f10af1fef7316a4263513b9b539ce598b69fbd875c"
 )
-# P19-R2 M1 验证平面合同（VerifierDescriptor/RegistrySnapshot/VerificationRecord）后的当前包 digest。
+# P19-R2 M1 验证平面合同（VerifierDescriptor/RegistrySnapshot/VerificationRecord）阶段的包 digest。
 P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256 = (
+    "502be945ad687f75a3eb085cdd569fb50aaef3d3876e11993fff79cde73b0965"
+)
+# P19-R2 M2.1 起 AcceptancePredicate 加入合同包后的当前阶段 digest。
+# JSON Schema 形状在 M2.2 未变（M2.2 只改验证器语义与边界行为）。
+P19_R2_M2_VERIFICATION_SCHEMA_BASELINE_SHA256 = (
     "d46cd149db4cc37883270f4e91e5592dc2dc2b34765283b5759f680f8ad1609a"
 )
-REVIEWED_SCHEMA_BASELINE_SHA256 = P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256
+REVIEWED_SCHEMA_BASELINE_SHA256 = P19_R2_M2_VERIFICATION_SCHEMA_BASELINE_SHA256
 CompatibilityDirection = Literal["backward", "forward"]
 
 

--- a/app/life-service/runtime314/contracts/verification.py
+++ b/app/life-service/runtime314/contracts/verification.py
@@ -358,15 +358,33 @@ class AcceptancePredicateSpecError(ValueError):
 
 #: Exact parameter rules for every predicate type that may be instantiated
 #: today. Types outside this mapping have no rules yet and therefore cannot
-#: be instantiated (fail-closed instead of guessed).
-PREDICATE_PARAM_RULES: Mapping[str, frozenset[str]] = {
-    "artifact.nonempty": frozenset(),
-    "artifact.min_visible_text_chars": frozenset({"min_chars"}),
-    "xlsx.required_columns": frozenset({"columns"}),
-    "xlsx.min_data_rows": frozenset({"min_rows"}),
-    "text.required_markers": frozenset({"markers"}),
-    "pptx.min_nonempty_slides": frozenset({"min_slides"}),
-}
+#: be instantiated (fail-closed instead of guessed). Immutable mapping.
+PREDICATE_PARAM_RULES: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "artifact.nonempty": frozenset(),
+        "artifact.min_visible_text_chars": frozenset({"min_chars"}),
+        "xlsx.required_columns": frozenset({"columns"}),
+        "xlsx.min_data_rows": frozenset({"min_rows"}),
+        "text.required_markers": frozenset({"markers"}),
+        "pptx.min_nonempty_slides": frozenset({"min_slides"}),
+    }
+)
+
+#: predicate-type prefix -> the ONLY subject kind it may ever target.
+#: A predicate whose subject_kind violates its domain is semantically
+#: invalid no matter how correct its hashes are.
+PREDICATE_SUBJECT_KINDS: Mapping[str, str] = MappingProxyType(
+    {
+        "artifact": "artifact",
+        "docx": "artifact",
+        "xlsx": "artifact",
+        "pptx": "artifact",
+        "csv": "artifact",
+        "text": "artifact",
+        "effect": "effect",
+        "repository": "repository",
+    }
+)
 
 #: Bounds applied to list-shaped params before hashing. They also bound the
 #: number of per-item reason codes a single predicate can produce.
@@ -497,6 +515,17 @@ class AcceptancePredicate(ContractModel):
                         "predicate list params must be sorted, deduplicated"
                         " string tuples"
                     )
+        # Trust-boundary seal: the stored params must be EXACTLY what
+        # normalize_predicate_params produces for this type. This rejects
+        # non-normalized payloads regardless of how they were built
+        # (direct construction, model_validate_json, model_copy).
+        expected = normalize_predicate_params(
+            self.predicate_type, dict(self.params)
+        )
+        if self.params != expected:
+            raise ValueError(
+                "predicate params are not in canonical normalized form"
+            )
         return self
 
     @classmethod
@@ -551,6 +580,25 @@ class AcceptancePredicate(ContractModel):
         return self.predicate_sha256 == self.computed_predicate_sha256()
 
     def has_valid_identity(self) -> bool:
+        """Full semantic + cryptographic identity check (M2.2 seal).
+
+        Verifies predicate_sha256 recomputation, derived predicate_id,
+        canonical params form, AND the predicate_type/subject_kind domain
+        correspondence. Trust boundaries call this — never a bare hash
+        check — because model_copy(update=...) bypasses the validator.
+        """
+        expected_kind = PREDICATE_SUBJECT_KINDS.get(
+            self.predicate_type.split(".", 1)[0]
+        )
+        if expected_kind is None or self.subject_kind != expected_kind:
+            return False
+        try:
+            if self.params != normalize_predicate_params(
+                self.predicate_type, dict(self.params)
+            ):
+                return False
+        except AcceptancePredicateSpecError:
+            return False
         if not self.has_valid_predicate_sha256():
             return False
         return self.predicate_id == "vpd_" + canonical_sha256(

--- a/docs/p19-r2/M2_2_DESIGN.txt
+++ b/docs/p19-r2/M2_2_DESIGN.txt
@@ -1,0 +1,99 @@
+P19-R2 M2.2｜Trust-Boundary Closure（M2_2_DESIGN）
+======================================================================
+分支：glm53/p19-r2-m2.2-artifact-trust-boundary-closure（自 78477b3 第一步创建）
+性质：对 2026-08-30 M2.1 审核裁决的逐节落实。零迁移（v23）、
+RECORD ONLY、不接 CompletionGate/Compiler/delivery。
+
+状态口径（§7 审核规定）：implementation-present /
+descriptor-registered / production-unwired。
+
+----------------------------------------------------------------------
+八节落实对照
+----------------------------------------------------------------------
+§1 create() 旁路封死
+    - 模型验证器重跑 normalize_predicate_params 并要求逐字节相等
+      → 直接构造 / model_validate_json / 未规范化 params 全部拒绝
+    - has_valid_identity() 全语义：predicate_sha256 复算 + 派生 ID +
+      规范化 params 相等 + PREDICATE_SUBJECT_KINDS 领域对应
+      （xlsx 谓词 + effect subject → False；model_copy+重算哈希的
+      非法谓词在 trust boundary 被拒）
+    - PREDICATE_PARAM_RULES / PREDICATE_SUBJECT_KINDS 改 MappingProxyType
+    - filler 参数（strict）、字符串/bool min_rows 全部拒绝（测试 A2）
+
+§2 描述符 v3 + 精确绑定
+    - ARTIFACT_INSPECTOR_SEMANTIC_VERSION 2→3（权威先行顺序 +
+      解析器分类学 + 固定机器码 + 公式/规范化语义 = 行为变更）
+    - _validate_artifact_descriptor：verifier_id/version/config_sha256/
+      supported_predicate_types/supported_subject_kinds/
+      accepted_authorities/max_input_bytes/implementation_ref/
+      producer_component_id/deterministic/layer/default_enforcement
+      十二项精确比对；同 id/version 异 config/能力 → OracleSnapshotInvalid
+      （测试 D1/D2）
+    - v1/v2 快照可解析不可实例化 v3 Oracle（find@3 失败）
+    - 配置映射全部 MappingProxyType
+
+§3 权威先于任何状态
+    固定顺序：①谓词全语义验证 → ②VerifiedArtifactContentSource 构造
+    → ③verify_artifact_revision（manifest hash/QC facts/object 绑定）
+    → ④applicability → ⑤descriptor capability → ⑥format inspectable
+    → ⑦已验证 manifest.size_bytes 上限 → ⑧超限 INCONCLUSIVE 不读
+    → ⑨read_verified_artifact → ⑩inspect/evaluate。
+    NOT_APPLICABLE/INCONCLUSIVE 的 subject 全部经过权威验证。
+
+§4 确定性语义修正
+    - text marker 双侧 NFKC+casefold（haystack 存 _text_norm；
+      测试 T1：ABC/abc/ＡＢＣ 互配）
+    - XLSX 单趟 data_only=False：公式文本计入 visible chars、
+      nonempty cells、data rows（测试 X1/X2）
+    - PPTX：MSO_SHAPE_TYPE 枚举（PICTURE/LINKED_PICTURE/MEDIA/GROUP）
+      + has_table/has_chart；表格单元格文本计入 visible text；
+      无法分类内容（有 shape 但零 meaningful）→ INCONCLUSIVE 不假 FAIL
+    - 解析器分类学：zipfile.BadZipFile/ElementTree.ParseError →
+      INCONCLUSIVE；ImportError → ERROR；RuntimeError/未知 → ERROR
+      （测试 P1）
+    - reason_codes 固定机器码：xlsx.required_columns_missing /
+      text.required_markers_missing（不拼列名/marker，测试 E1）；
+      缺失明细只进 observation digest（missing_count +
+      missing_items_sha256）
+
+§5 基线链修复
+    - P19_R2_M1 常量恢复 502be945…
+    - 新增 P19_R2_M2 阶段常量 = d46cd149…（JSON Schema 形状未变），
+      REVIEWED 指向当前阶段
+    - 推导测试改两级：当前−AcceptancePredicate→M1 digest；
+      M1−三契约→P18 digest（不得跨级）
+
+§6 测试矩阵（test_p19_m2_2_trust_boundary.py 13 项 + 既有矩阵更新）
+    A1 同产物同时刻不同 params → predicate_id 与 record_id 均不同
+    A2 非法谓词五类构造全拒（含 model_copy+重算哈希）
+    D1 错误 config_sha256 → OracleSnapshotInvalid
+    D2 缺谓词/改上限 → OracleSnapshotInvalid
+    O1 篡改超大 manifest → ERROR + 权威基线零额外读取
+    O2 权威有效超大 → INCONCLUSIVE/input_too_large + 零额外读取
+       （Gate 对象上限<64MiB，生产限值下权威有效超限不可达——
+        等价构造：同源补丁配置至 8 字节上限，语义逐阈值等价）
+    N1 64 条 QC evidence → refs≤8、全集 digest、改任一条 digest 变
+    T1/X1/X2/P1/E1 见 §4
+    既有 M2.1 矩阵更新：版本断言 v3、新 reason 码、O 拆 O1/O2
+
+§7 边界保持：v23 / RECORD ONLY / 无 CompletionGate / 无 delivery /
+    无状态机 / 无 ALERT/BLOCK / 无 Compiler / 无 Effect/Repo Oracle /
+    无第二 Runtime/Gateway/Store。文档与 docstring 全部改为
+    implementation-present 口径（含 verification_registry）。
+
+§8 完成条件：targeted 13 + P19 全回归 127 passed；基线链 19 passed
+    两级锁定；authority/sync/LF 见提交；双平台全量见 PR。
+
+----------------------------------------------------------------------
+关键发现（如实记录）
+----------------------------------------------------------------------
+F1 QC 事实核验会读取产物 blob（integrity QC 的证据载荷即产物字节）
+   ——「超限零读取」只能承诺检查阶段零额外读取（权威基线对比），
+   O1/O2 断言据此实现。
+F2 Gate 自身对象上限低于 64MiB → 生产限值下「权威有效且超限」的
+   manifest 在真实链上不可达；O2 用同源配置补丁做等价构造。
+F3 单源常量被 registry 与 oracle 模块分别 from-import 各自绑定，
+   测试补丁需覆盖两处（生产代码无此问题——两处读同一模块源）。
+
+----------------------------------------------------------------------
+回滚：revert 本 PR 即回到 M2.1 状态。

--- a/src/contracts/compatibility.py
+++ b/src/contracts/compatibility.py
@@ -56,11 +56,16 @@ P17_LIFE_P10_ATOMIC_CONTEXT_SCHEMA_BASELINE_SHA256 = (
 P18_G1_VNEXT_CONTRACT_SCHEMA_BASELINE_SHA256 = (
     "09e24fbd4d36333dd63b62f10af1fef7316a4263513b9b539ce598b69fbd875c"
 )
-# P19-R2 M1 验证平面合同（VerifierDescriptor/RegistrySnapshot/VerificationRecord）后的当前包 digest。
+# P19-R2 M1 验证平面合同（VerifierDescriptor/RegistrySnapshot/VerificationRecord）阶段的包 digest。
 P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256 = (
+    "502be945ad687f75a3eb085cdd569fb50aaef3d3876e11993fff79cde73b0965"
+)
+# P19-R2 M2.1 起 AcceptancePredicate 加入合同包后的当前阶段 digest。
+# JSON Schema 形状在 M2.2 未变（M2.2 只改验证器语义与边界行为）。
+P19_R2_M2_VERIFICATION_SCHEMA_BASELINE_SHA256 = (
     "d46cd149db4cc37883270f4e91e5592dc2dc2b34765283b5759f680f8ad1609a"
 )
-REVIEWED_SCHEMA_BASELINE_SHA256 = P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256
+REVIEWED_SCHEMA_BASELINE_SHA256 = P19_R2_M2_VERIFICATION_SCHEMA_BASELINE_SHA256
 CompatibilityDirection = Literal["backward", "forward"]
 
 

--- a/src/contracts/verification.py
+++ b/src/contracts/verification.py
@@ -358,15 +358,33 @@ class AcceptancePredicateSpecError(ValueError):
 
 #: Exact parameter rules for every predicate type that may be instantiated
 #: today. Types outside this mapping have no rules yet and therefore cannot
-#: be instantiated (fail-closed instead of guessed).
-PREDICATE_PARAM_RULES: Mapping[str, frozenset[str]] = {
-    "artifact.nonempty": frozenset(),
-    "artifact.min_visible_text_chars": frozenset({"min_chars"}),
-    "xlsx.required_columns": frozenset({"columns"}),
-    "xlsx.min_data_rows": frozenset({"min_rows"}),
-    "text.required_markers": frozenset({"markers"}),
-    "pptx.min_nonempty_slides": frozenset({"min_slides"}),
-}
+#: be instantiated (fail-closed instead of guessed). Immutable mapping.
+PREDICATE_PARAM_RULES: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "artifact.nonempty": frozenset(),
+        "artifact.min_visible_text_chars": frozenset({"min_chars"}),
+        "xlsx.required_columns": frozenset({"columns"}),
+        "xlsx.min_data_rows": frozenset({"min_rows"}),
+        "text.required_markers": frozenset({"markers"}),
+        "pptx.min_nonempty_slides": frozenset({"min_slides"}),
+    }
+)
+
+#: predicate-type prefix -> the ONLY subject kind it may ever target.
+#: A predicate whose subject_kind violates its domain is semantically
+#: invalid no matter how correct its hashes are.
+PREDICATE_SUBJECT_KINDS: Mapping[str, str] = MappingProxyType(
+    {
+        "artifact": "artifact",
+        "docx": "artifact",
+        "xlsx": "artifact",
+        "pptx": "artifact",
+        "csv": "artifact",
+        "text": "artifact",
+        "effect": "effect",
+        "repository": "repository",
+    }
+)
 
 #: Bounds applied to list-shaped params before hashing. They also bound the
 #: number of per-item reason codes a single predicate can produce.
@@ -497,6 +515,17 @@ class AcceptancePredicate(ContractModel):
                         "predicate list params must be sorted, deduplicated"
                         " string tuples"
                     )
+        # Trust-boundary seal: the stored params must be EXACTLY what
+        # normalize_predicate_params produces for this type. This rejects
+        # non-normalized payloads regardless of how they were built
+        # (direct construction, model_validate_json, model_copy).
+        expected = normalize_predicate_params(
+            self.predicate_type, dict(self.params)
+        )
+        if self.params != expected:
+            raise ValueError(
+                "predicate params are not in canonical normalized form"
+            )
         return self
 
     @classmethod
@@ -551,6 +580,25 @@ class AcceptancePredicate(ContractModel):
         return self.predicate_sha256 == self.computed_predicate_sha256()
 
     def has_valid_identity(self) -> bool:
+        """Full semantic + cryptographic identity check (M2.2 seal).
+
+        Verifies predicate_sha256 recomputation, derived predicate_id,
+        canonical params form, AND the predicate_type/subject_kind domain
+        correspondence. Trust boundaries call this — never a bare hash
+        check — because model_copy(update=...) bypasses the validator.
+        """
+        expected_kind = PREDICATE_SUBJECT_KINDS.get(
+            self.predicate_type.split(".", 1)[0]
+        )
+        if expected_kind is None or self.subject_kind != expected_kind:
+            return False
+        try:
+            if self.params != normalize_predicate_params(
+                self.predicate_type, dict(self.params)
+            ):
+                return False
+        except AcceptancePredicateSpecError:
+            return False
         if not self.has_valid_predicate_sha256():
             return False
         return self.predicate_id == "vpd_" + canonical_sha256(

--- a/src/total_gateway/outcome_oracles/artifact_content.py
+++ b/src/total_gateway/outcome_oracles/artifact_content.py
@@ -1,4 +1,4 @@
-"""P19-R2 M2.1 Gateway ArtifactContentOracle — RECORD ONLY.
+"""P19-R2 M2.2 Gateway ArtifactContentOracle — RECORD ONLY.
 
 Evaluates one explicit ``AcceptancePredicate`` against one bound
 ``ArtifactManifest`` by reading immutable object-store bytes through the
@@ -7,41 +7,40 @@ never opens host paths and never derives predicates from the raw user
 message — that heuristic layer stays in the V3 local preflight
 (``v3/simple_chain/content_preflight.py``) with no final authority.
 
-M2.1 review hardening:
-* constructed from a full validated ``RegistrySnapshot`` — the verifier
-  version, producer id, input limit and supported predicate set are read
-  from the pinned v2 descriptor (single source:
-  ``verification_oracle_config``), never hardcoded here;
-* record lineage is taken from the manifest itself
-  (request_id/run_id/generation) — there is nothing to rebind;
-* applicability is decided BEFORE implementation, so an unimplemented
-  xlsx predicate on a docx subject is NOT_APPLICABLE, not INCONCLUSIVE;
-* deterministic metrics exist per format (xlsx counts formula text via a
-  data_only=False pass; pptx counts meaningful slides: text, pictures,
-  tables, charts — not mere slide presence);
-* evidence refs are a small typed set including qc-evidence-set,
-  predicate and observation digests (never 64 raw QC fact ids);
-* resource discipline: manifest.size_bytes is checked against the
-  descriptor limit BEFORE any blob read; ImportError/dependency failures
-  are ERROR, known-unparseable containers are INCONCLUSIVE;
-* reason codes are stable machine codes — no raw exception text.
+Status: implementation-present / descriptor-registered /
+production-unwired. Nothing consumes its records to gate completion.
 
-Status discipline (strict):
-    PASS / FAIL        deterministic evidence either way
-    INCONCLUSIVE       cannot reliably judge (unsupported format,
-                       unparseable container, size beyond limit, missing
-                       per-format metric, capability not implemented)
-    ERROR              authority/readback/dependency/runtime failure
-    NOT_APPLICABLE     predicate does not apply to this subject at all
+M2.2 hardening (review 2026-08-30):
+* predicate trust boundary runs the FULL semantic identity check
+  (hashes + canonical params + type/subject domain), never a bare hash;
+* AUTHORITY BEFORE ANY STATUS: manifest/QC-facts/object-reference
+  verification happens before applicability/capability/format/size
+  decisions — even NOT_APPLICABLE and INCONCLUSIVE subjects carry an
+  authority-verified manifest;
+* resource discipline: the verified manifest's size_bytes is checked
+  against the descriptor limit BEFORE any blob read;
+* determinism: xlsx formula text counts as content everywhere (single
+  data_only=False pass); pptx meaningful content uses the official shape
+  enum (picture/media/group/table/chart) plus table-cell text; text
+  marker matching normalizes BOTH sides (NFKC + casefold);
+* parser taxonomy: known zip/XML container corruption -> INCONCLUSIVE,
+  ImportError/dependency -> ERROR, unknown runtime bugs -> ERROR;
+* reason codes are fixed machine codes (no user strings); missing-item
+  details live only in the observation digest (missing_count +
+  missing_items_sha256);
+* the pinned descriptor is validated EXACTLY against the oracle config —
+  same id/version with a different config or capability is rejected.
 
-RECORD ONLY: this module produces ``VerificationRecord``s; persisting
-them changes no CompletionDecision, no request state, no delivery.
+RECORD ONLY: produced records change no CompletionDecision, no request
+state, no delivery.
 """
 
 from __future__ import annotations
 
 import csv as _csv
 import io
+import zipfile
+import xml.etree.ElementTree as _etree
 from typing import Any
 
 from contracts import ArtifactManifest, canonical_sha256
@@ -60,9 +59,14 @@ from total_gateway.fact_ledger import FactLedger
 from total_gateway.object_store import ContentAddressedObjectStore
 from total_gateway.verification_oracle_config import (
     ARTIFACT_APPLICABLE_FORMATS,
+    ARTIFACT_DESCRIPTOR_EXPECTATIONS,
+    ARTIFACT_IMPLEMENTED_PREDICATE_TYPES,
     ARTIFACT_INSPECTABLE_FORMATS,
     ARTIFACT_INSPECTOR_SEMANTIC_VERSION,
+    ARTIFACT_MAX_INPUT_BYTES,
+    IMPLEMENTATION_REF,
     VERIFIER_ID,
+    artifact_oracle_config_sha256,
 )
 from total_gateway.verification_registry import (
     UnknownVerifierError,
@@ -75,11 +79,68 @@ class OracleSnapshotInvalid(ValueError):
 
 
 class ContentUnparseable(Exception):
-    """Deterministically detected "cannot reliably inspect" signal."""
+    """Known container/zip/XML corruption — cannot reliably inspect."""
 
 
 class _InspectorDependencyMissing(Exception):
     """ImportError from an inspector dependency (ERROR, not INCONCLUSIVE)."""
+
+
+#: Exception types that mean "known corrupted container" -> INCONCLUSIVE.
+_KNOWN_CORRUPTION_TYPES: tuple[type[BaseException], ...] = (
+    zipfile.BadZipFile,
+    _etree.ParseError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Descriptor binding (§2)
+# ---------------------------------------------------------------------------
+
+def _validate_artifact_descriptor(descriptor) -> None:
+    """Exact-match the pinned descriptor against the oracle config.
+
+    A same-id/same-version descriptor whose config hash, capability set,
+    limits or authority claims differ from what THIS implementation reads
+    is rejected — no silent drift.
+    """
+    expectations = ARTIFACT_DESCRIPTOR_EXPECTATIONS
+    problems: list[str] = []
+    if descriptor.verifier_id != VERIFIER_ID:
+        problems.append("verifier_id")
+    if descriptor.verifier_version != ARTIFACT_INSPECTOR_SEMANTIC_VERSION:
+        problems.append("verifier_version")
+    if descriptor.config_sha256 != artifact_oracle_config_sha256():
+        problems.append("config_sha256")
+    if list(descriptor.supported_predicate_types) != sorted(
+        ARTIFACT_IMPLEMENTED_PREDICATE_TYPES
+    ):
+        problems.append("supported_predicate_types")
+    if tuple(descriptor.supported_subject_kinds) != expectations[
+        "supported_subject_kinds"
+    ]:
+        problems.append("supported_subject_kinds")
+    if set(descriptor.accepted_authorities) != set(
+        expectations["accepted_authorities"]
+    ):
+        problems.append("accepted_authorities")
+    if descriptor.max_input_bytes != ARTIFACT_MAX_INPUT_BYTES:
+        problems.append("max_input_bytes")
+    if descriptor.implementation_ref != IMPLEMENTATION_REF:
+        problems.append("implementation_ref")
+    if descriptor.producer_component_id != expectations["producer_component_id"]:
+        problems.append("producer_component_id")
+    if descriptor.layer != expectations["layer"]:
+        problems.append("layer")
+    if descriptor.deterministic is not expectations["deterministic"]:
+        problems.append("deterministic")
+    if descriptor.default_enforcement != expectations["default_enforcement"]:
+        problems.append("default_enforcement")
+    if problems:
+        raise OracleSnapshotInvalid(
+            "artifact descriptor does not match the oracle config:"
+            f" {', '.join(problems)}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -111,52 +172,52 @@ def _inspect_docx(data: bytes) -> dict[str, Any]:
         }
     except _InspectorDependencyMissing:
         raise
-    except Exception as exc:
-        raise ContentUnparseable(f"docx container unparseable: {type(exc).__name__}") from exc
+    except BaseException as exc:
+        if isinstance(exc, _KNOWN_CORRUPTION_TYPES):
+            raise ContentUnparseable("docx container corrupted") from exc
+        raise  # unknown runtime bug -> ERROR by the dispatcher
 
 
 def _inspect_xlsx(data: bytes) -> dict[str, Any]:
+    """Single data_only=False pass: formula text is content everywhere.
+
+    Formula cells carry no cached value in this mode, so their formula
+    string is what we see — it counts toward visible chars, non-empty
+    cells AND data rows (M2.2 review rule).
+    """
     try:
         import openpyxl
     except ImportError as exc:
         raise _InspectorDependencyMissing("openpyxl") from exc
-    values_book = None
-    formulas_book = None
+    workbook = None
     try:
-        # Pass 1 (data_only=True): cached values for header/data-row shape.
-        values_book = openpyxl.load_workbook(
-            io.BytesIO(data), read_only=True, data_only=True
+        workbook = openpyxl.load_workbook(
+            io.BytesIO(data), read_only=True, data_only=False
         )
-        sheet = values_book.active
+        sheet = workbook.active
         if sheet is None:
             raise ContentUnparseable("xlsx workbook has no active sheet")
         header: list[str] = []
         data_row_count = 0
         nonempty_cell_count = 0
-        for row_index, row in enumerate(sheet.iter_rows(values_only=True)):
-            cells = ["" if cell is None else str(cell).strip() for cell in row]
-            nonempty = [cell for cell in cells if cell]
-            nonempty_cell_count += len(nonempty)
-            if row_index == 0:
-                header = cells
-                continue  # header is not a data row (oracle semantics)
-            if nonempty:
-                data_row_count += 1
-        sheet_names = list(values_book.sheetnames)
-        # Pass 2 (data_only=False): formula text is content too — a cell
-        # holding "=SUM(A1:A9)" is not empty just because its cached
-        # value is missing.
-        formulas_book = openpyxl.load_workbook(
-            io.BytesIO(data), read_only=True, data_only=False
-        )
-        formula_sheet = formulas_book.active
         visible_text_chars = 0
-        if formula_sheet is not None:
-            for row in formula_sheet.iter_rows(values_only=True):
-                for cell in row:
-                    if cell is None:
-                        continue
-                    visible_text_chars += len(str(cell).strip())
+        for row_index, row in enumerate(sheet.iter_rows(values_only=True)):
+            row_nonempty = 0
+            for cell in row:
+                if cell is None:
+                    continue
+                text = str(cell).strip()
+                if not text:
+                    continue
+                nonempty_cell_count += 1
+                row_nonempty += 1
+                visible_text_chars += len(text)
+            if row_index == 0:
+                header = ["" if cell is None else str(cell).strip() for cell in row]
+                continue  # header is not a data row (oracle semantics)
+            if row_nonempty:
+                data_row_count += 1
+        sheet_names = list(workbook.sheetnames)
         return {
             "measured_format": "xlsx",
             "header": header,
@@ -169,31 +230,45 @@ def _inspect_xlsx(data: bytes) -> dict[str, Any]:
         raise
     except ContentUnparseable:
         raise
-    except Exception as exc:
-        raise ContentUnparseable(f"xlsx container unparseable: {type(exc).__name__}") from exc
+    except BaseException as exc:
+        if isinstance(exc, _KNOWN_CORRUPTION_TYPES):
+            raise ContentUnparseable("xlsx container corrupted") from exc
+        raise  # unknown runtime bug -> ERROR by the dispatcher
     finally:
-        if values_book is not None:
-            values_book.close()
-        if formulas_book is not None:
-            formulas_book.close()
+        if workbook is not None:
+            workbook.close()
 
 
 def _inspect_pptx(data: bytes) -> dict[str, Any]:
     try:
         from pptx import Presentation
+        from pptx.enum.shapes import MSO_SHAPE_TYPE
     except ImportError as exc:
         raise _InspectorDependencyMissing("pptx") from exc
+    # Shape types that are meaningful content even without text.
+    meaningful_shape_types = {
+        member
+        for member in (
+            getattr(MSO_SHAPE_TYPE, "PICTURE", None),
+            getattr(MSO_SHAPE_TYPE, "LINKED_PICTURE", None),
+            getattr(MSO_SHAPE_TYPE, "MEDIA", None),
+            getattr(MSO_SHAPE_TYPE, "GROUP", None),
+        )
+        if member is not None
+    }
     try:
         presentation = Presentation(io.BytesIO(data))
         slide_count = 0
         meaningful_slide_count = 0
         text_bearing_slide_count = 0
         slide_text_chars = 0
+        total_shape_count = 0
         for slide in presentation.slides:
             slide_count += 1
             has_text = False
             has_other_content = False
             for shape in slide.shapes:
+                total_shape_count += 1
                 if getattr(shape, "has_text_frame", False):
                     text = shape.text_frame.text.strip()
                     if text:
@@ -201,11 +276,14 @@ def _inspect_pptx(data: bytes) -> dict[str, Any]:
                         slide_text_chars += len(text)
                 if getattr(shape, "has_table", False):
                     has_other_content = True
+                    for row in shape.table.rows:
+                        for cell in row.cells:
+                            cell_text = cell.text.strip()
+                            if cell_text:
+                                slide_text_chars += len(cell_text)
                 if getattr(shape, "has_chart", False):
                     has_other_content = True
-                if shape.shape_type is not None and str(shape.shape_type).startswith(
-                    "PICTURE"
-                ):
+                if shape.shape_type in meaningful_shape_types:
                     has_other_content = True
             if has_text:
                 text_bearing_slide_count += 1
@@ -217,11 +295,14 @@ def _inspect_pptx(data: bytes) -> dict[str, Any]:
             "text_bearing_slide_count": text_bearing_slide_count,
             "meaningful_slide_count": meaningful_slide_count,
             "slide_text_chars": slide_text_chars,
+            "total_shape_count": total_shape_count,
         }
     except _InspectorDependencyMissing:
         raise
-    except Exception as exc:
-        raise ContentUnparseable(f"pptx container unparseable: {type(exc).__name__}") from exc
+    except BaseException as exc:
+        if isinstance(exc, _KNOWN_CORRUPTION_TYPES):
+            raise ContentUnparseable("pptx container corrupted") from exc
+        raise  # unknown runtime bug -> ERROR by the dispatcher
 
 
 def _inspect_text(data: bytes, *, filename: str) -> dict[str, Any]:
@@ -230,8 +311,10 @@ def _inspect_text(data: bytes, *, filename: str) -> dict[str, Any]:
     except UnicodeDecodeError as exc:
         raise ContentUnparseable("text not decodable as utf-8") from exc
     metrics: dict[str, Any] = {
-        "_text": text,
         "measured_format": "text",
+        # Marker matching normalizes BOTH sides: haystack here, needles in
+        # the predicate params (both NFKC + casefold).
+        "_text_norm": normalize_predicate_text(text),
         "char_count": len(text),
         "non_whitespace_chars": sum(1 for ch in text if not ch.isspace()),
         "line_count": sum(1 for line in text.splitlines() if line.strip()),
@@ -262,12 +345,12 @@ def _inspect(format_id: str, data: bytes, *, filename: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Deterministic checks (stable machine reason codes only)
+# Deterministic checks — fixed machine reason codes only (§4)
 # ---------------------------------------------------------------------------
 
 #: Per-format metric key used by artifact.min_visible_text_chars. A format
-#: without a reliable metric key in the observation raises
-#: ContentUnparseable (INCONCLUSIVE) — never a fake 0.
+#: without a reliable metric key raises ContentUnparseable (INCONCLUSIVE)
+#: — never a fake 0.
 _VISIBLE_TEXT_METRIC_KEYS: dict[str, str] = {
     "docx": "visible_text_chars",
     "xlsx": "visible_text_chars",
@@ -288,28 +371,47 @@ def _visible_text_metric(format_id: str, metrics: dict[str, Any]) -> int:
     return value
 
 
+def _pptx_emptiness_is_unreliable(metrics: dict[str, Any]) -> bool:
+    """Slides carry shapes we cannot classify: not provably empty."""
+    return (
+        metrics["slide_count"] > 0
+        and metrics["meaningful_slide_count"] == 0
+        and metrics["total_shape_count"] > 0
+    )
+
+
 def _check_predicate(
     predicate: AcceptancePredicate,
     format_id: str,
     metrics: dict[str, Any],
-) -> tuple[bool, tuple[str, ...]]:
-    """Return (holds, reason_codes). Only called with implemented types."""
+) -> tuple[bool, tuple[str, ...], dict[str, Any]]:
+    """Return (holds, reason_codes, observation_extra).
+
+    Reason codes are FIXED machine codes — user strings (column/marker
+    names) never appear; their detail goes into observation_extra which
+    feeds only the observation digest (missing_count + items digest).
+    """
     kind = predicate.predicate_type
     params = predicate.param_mapping()
     if kind == "artifact.nonempty":
         if format_id == "xlsx":
             holds = metrics["nonempty_cell_count"] > 0
         elif format_id == "pptx":
+            if _pptx_emptiness_is_unreliable(metrics):
+                raise ContentUnparseable(
+                    "pptx slides carry unclassifiable content; emptiness"
+                    " cannot be judged reliably"
+                )
             holds = metrics["meaningful_slide_count"] > 0
         else:
             holds = _visible_text_metric(format_id, metrics) > 0
-        return holds, () if holds else ("artifact.content_empty",)
+        return holds, () if holds else ("artifact.content_empty",), {}
     if kind == "artifact.min_visible_text_chars":
         minimum = params["min_chars"]
         assert isinstance(minimum, int)
         visible = _visible_text_metric(format_id, metrics)
         holds = visible >= minimum
-        return holds, () if holds else ("artifact.visible_text_below_minimum",)
+        return holds, () if holds else ("artifact.visible_text_below_minimum",), {}
     if kind == "xlsx.required_columns":
         requested = params["columns"]
         assert isinstance(requested, tuple)
@@ -319,24 +421,50 @@ def _check_predicate(
             if isinstance(cell, str) and cell.strip()
         }
         missing = [column for column in requested if column not in header]
-        return not missing, tuple(f"xlsx.column_missing:{c}" for c in missing)
+        return (
+            not missing,
+            () if not missing else ("xlsx.required_columns_missing",),
+            {}
+            if not missing
+            else {
+                "missing_count": len(missing),
+                "missing_items_sha256": canonical_sha256(list(missing)),
+            },
+        )
     if kind == "xlsx.min_data_rows":
         minimum = params["min_rows"]
         assert isinstance(minimum, int)
         holds = metrics["data_row_count"] >= minimum
-        return holds, () if holds else ("xlsx.data_rows_below_minimum",)
+        return holds, () if holds else ("xlsx.data_rows_below_minimum",), {}
     if kind == "text.required_markers":
         markers = params["markers"]
         assert isinstance(markers, tuple)
-        missing = tuple(
-            f"text.marker_missing:{m}" for m in markers if m not in metrics["_text"]
+        haystack = metrics.get("_text_norm", "")
+        missing = [marker for marker in markers if marker not in haystack]
+        return (
+            not missing,
+            () if not missing else ("text.required_markers_missing",),
+            {}
+            if not missing
+            else {
+                "missing_count": len(missing),
+                "missing_items_sha256": canonical_sha256(list(missing)),
+            },
         )
-        return not missing, missing
     if kind == "pptx.min_nonempty_slides":
         minimum = params["min_slides"]
         assert isinstance(minimum, int)
+        if _pptx_emptiness_is_unreliable(metrics):
+            raise ContentUnparseable(
+                "pptx slides carry unclassifiable content; meaningful"
+                " slide count cannot be judged reliably"
+            )
         holds = metrics["meaningful_slide_count"] >= minimum
-        return holds, () if holds else ("pptx.meaningful_slides_below_minimum",)
+        return (
+            holds,
+            () if holds else ("pptx.meaningful_slides_below_minimum",),
+            {},
+        )
     raise AssertionError(
         f"predicate type declared implemented but has no check: {kind}"
     )
@@ -349,9 +477,8 @@ def _check_predicate(
 class ArtifactContentOracle:
     """Deterministic content oracle over immutable, QC-passed artifacts.
 
-    Bound to one validated ``RegistrySnapshot``; the v2 descriptor inside
-    that snapshot supplies the verifier version, producer component,
-    input limit and supported predicate set (no hardcoded drift).
+    Bound to one validated ``RegistrySnapshot`` whose artifact descriptor
+    is EXACTLY the one this implementation reads its config from.
     """
 
     def __init__(
@@ -364,13 +491,13 @@ class ArtifactContentOracle:
         if not snapshot.has_valid_identity():
             raise OracleSnapshotInvalid("registry snapshot identity binding is invalid")
         try:
-            VerifierRegistry(snapshot.verifiers)
+            registry = VerifierRegistry(snapshot.verifiers)
         except ValueError as exc:
             raise OracleSnapshotInvalid(
                 "registry snapshot contains invalid verifier descriptors"
             ) from exc
         try:
-            descriptor = VerifierRegistry(snapshot.verifiers).find(
+            descriptor = registry.find(
                 VERIFIER_ID, ARTIFACT_INSPECTOR_SEMANTIC_VERSION
             )
         except UnknownVerifierError as exc:
@@ -378,6 +505,7 @@ class ArtifactContentOracle:
                 f"snapshot does not carry {VERIFIER_ID}@"
                 f"{ARTIFACT_INSPECTOR_SEMANTIC_VERSION}"
             ) from exc
+        _validate_artifact_descriptor(descriptor)
         object.__setattr__(self, "_snapshot", snapshot)
         object.__setattr__(self, "_descriptor", descriptor)
         object.__setattr__(self, "_object_store", object_store)
@@ -395,13 +523,9 @@ class ArtifactContentOracle:
         evaluated_at_ms: int,
         evaluation_phase: str = "POST_EXECUTION",
     ) -> VerificationRecord:
-        if predicate.subject_kind != "artifact":
-            raise ValueError(
-                "artifact oracle only evaluates artifact-subject predicates:"
-                f" {predicate.subject_kind}"
-            )
-        if not predicate.has_valid_identity():
-            raise ValueError("predicate identity binding is invalid")
+        # 1. Predicate semantic identity — FULL check, never a bare hash.
+        if predicate.subject_kind != "artifact" or not predicate.has_valid_identity():
+            raise ValueError("predicate failed full semantic identity validation")
         status, reason_codes, observation = self._evaluate_to_status(
             manifest, predicate
         )
@@ -422,8 +546,24 @@ class ArtifactContentOracle:
     ) -> tuple[str, tuple[str, ...], dict[str, Any]]:
         format_id = manifest.format_id
 
-        # 1. Applicability FIRST: a predicate that can never apply to this
-        # subject/format is NOT_APPLICABLE regardless of implementation.
+        # 2-3. AUTHORITY BEFORE ANY STATUS: manifest PASSED + hash, QC
+        # facts, object reference binding. Every downstream verdict —
+        # including NOT_APPLICABLE and INCONCLUSIVE — is bound to a
+        # subject that passed this verification. ArtifactContentError
+        # messages ARE stable machine codes (artifact.content.*).
+        try:
+            source = VerifiedArtifactContentSource(
+                self._object_store, self._fact_ledger, (manifest,)  # type: ignore[attr-defined]
+            )
+            source.verify_artifact_revision(manifest.artifact_revision_id)
+        except ArtifactContentError as exc:
+            return "ERROR", (f"authority:{exc}",), {"authority_error": str(exc)}
+        except Exception as exc:  # object-store corruption, IO, runtime
+            return "ERROR", ("authority_failure",), {
+                "authority_error": type(exc).__name__
+            }
+
+        # 4. Applicability (subject already authority-verified above).
         prefix = predicate.predicate_type.split(".", 1)[0]
         applicable = ARTIFACT_APPLICABLE_FORMATS.get(prefix)
         if applicable is not None and format_id not in applicable:
@@ -432,19 +572,20 @@ class ArtifactContentOracle:
                 "format_id": format_id,
             }
 
-        # 2. Implementation: declared capability comes from the pinned
-        # descriptor (single source), not from a parallel list here.
+        # 5. Descriptor capability — from the pinned descriptor.
         if predicate.predicate_type not in self._descriptor.supported_predicate_types:  # type: ignore[attr-defined]
             return "INCONCLUSIVE", ("predicate_not_implemented",), {
                 "predicate_type": predicate.predicate_type
             }
+
+        # 6. Format inspectability.
         if format_id not in ARTIFACT_INSPECTABLE_FORMATS:
             return "INCONCLUSIVE", ("format_not_inspectable",), {
                 "format_id": format_id
             }
 
-        # 3. Resource pre-check against the descriptor limit BEFORE any
-        # blob read: oversize manifests never touch object-store bytes.
+        # 7-8. Size pre-check on the VERIFIED manifest — oversize never
+        # touches object-store bytes.
         max_input_bytes = self._descriptor.max_input_bytes  # type: ignore[attr-defined]
         if manifest.size_bytes > max_input_bytes:
             return "INCONCLUSIVE", ("input_too_large",), {
@@ -452,44 +593,41 @@ class ArtifactContentOracle:
                 "max_input_bytes": max_input_bytes,
             }
 
-        # 4. Authority chain: manifest PASSED + QC facts + object binding +
-        # immutable readback with hash recomputation. Any failure here is
-        # ERROR; nothing may escape or pass silently. ArtifactContentError
-        # messages ARE stable machine codes (artifact.content.*).
+        # 9. Immutable readback (re-verifies on the way in).
         try:
-            source = VerifiedArtifactContentSource(
-                self._object_store, self._fact_ledger, (manifest,)  # type: ignore[attr-defined]
-            )
             data = source.read_verified_artifact(manifest.artifact_revision_id)
         except ArtifactContentError as exc:
             return "ERROR", (f"authority:{exc}",), {"authority_error": str(exc)}
-        except Exception as exc:  # object-store corruption, IO, runtime
+        except Exception as exc:
             return "ERROR", ("authority_failure",), {
                 "authority_error": type(exc).__name__
             }
 
-        # 5. Inspection: dependency failures are ERROR; known-unparseable
-        # containers are INCONCLUSIVE.
+        # 10. Inspection + deterministic check.
         try:
             metrics = _inspect(format_id, data, filename=manifest.filename)
         except _InspectorDependencyMissing:
             return "ERROR", ("inspector_dependency_missing",), {}
         except ContentUnparseable:
             return "INCONCLUSIVE", ("content_unparseable",), {}
-        except Exception:  # unexpected runtime bug — never silent
+        except Exception:  # unknown runtime bug — never silent
             return "ERROR", ("inspector_failure",), {}
 
-        # 6. Deterministic check (stable machine codes only).
         try:
-            holds, reason_codes = _check_predicate(predicate, format_id, metrics)
+            holds, reason_codes, extra = _check_predicate(
+                predicate, format_id, metrics
+            )
         except ContentUnparseable:
             return "INCONCLUSIVE", ("content_unparseable",), {}
-        except Exception:  # unexpected runtime bug — never silent
+        except Exception:  # unknown runtime bug — never silent
             return "ERROR", ("check_failure",), {}
 
         observation = {
-            key: value for key, value in metrics.items() if key != "_text"
+            key: value
+            for key, value in metrics.items()
+            if key not in ("_text_norm", "_text")
         }
+        observation.update(extra)
         observation["inspector_version"] = self._descriptor.verifier_version  # type: ignore[attr-defined]
         return ("PASS" if holds else "FAIL"), reason_codes, observation
 
@@ -534,8 +672,7 @@ class ArtifactContentOracle:
         )
         payload = dict(
             verification_record_id="vrs_" + "0" * 64,
-            # Lineage is taken from the manifest itself — there is no
-            # caller-supplied request/run/generation to rebind.
+            # Lineage is taken from the manifest itself.
             request_id=manifest.request_id,
             run_id=manifest.run_id,
             generation=manifest.generation,

--- a/src/total_gateway/verification_oracle_config.py
+++ b/src/total_gateway/verification_oracle_config.py
@@ -1,23 +1,29 @@
 """Single source of truth for the artifact content oracle configuration.
 
-Both the ``VerifierRegistry`` (descriptor v2 + its ``config_sha256``) and
+Both the ``VerifierRegistry`` (descriptor + its ``config_sha256``) and
 the oracle itself consume THESE constants, so the declared capability and
-the implemented dispatch can never drift apart silently. The M2.1 review
+the implemented dispatch can never drift apart silently. The M2.2 review
 invariant ``descriptor.supported_predicate_types == oracle dispatch set``
 holds by construction — both sides read this module.
 
 The config digest covers exactly what the review requires:
 implemented predicate set, params normalization version, inspector
 semantic version, max input bytes, and the format applicability rules.
+
+All exported mappings are deeply immutable (MappingProxyType).
 """
 
 from __future__ import annotations
+
+from types import MappingProxyType
 
 from contracts.canonical import canonical_sha256
 
 #: Inspector semantic version. Bump on ANY behavioural change of an
 #: inspector, a normalization rule, or this config (M1_DESIGN D7).
-ARTIFACT_INSPECTOR_SEMANTIC_VERSION = "2"
+#: v3 (M2.2): authority-before-status ordering, parser-failure taxonomy,
+#: deterministic reason codes, formula/text normalization semantics.
+ARTIFACT_INSPECTOR_SEMANTIC_VERSION = "3"
 
 #: Version of the predicate-params normalization contract in use.
 ARTIFACT_PARAMS_NORMALIZATION_VERSION = "1"
@@ -42,19 +48,36 @@ ARTIFACT_IMPLEMENTED_PREDICATE_TYPES: frozenset[str] = frozenset(
 #: Absent prefixes (e.g. ``artifact.*``) have NO format restriction —
 #: they apply to every artifact subject, and formats without an inspector
 #: then yield INCONCLUSIVE (format_not_inspectable), not NOT_APPLICABLE.
-ARTIFACT_APPLICABLE_FORMATS: dict[str, frozenset[str]] = {
-    "docx": frozenset({"docx"}),
-    "xlsx": frozenset({"xlsx"}),
-    "pptx": frozenset({"pptx"}),
-    "text": frozenset({"text"}),
-    # csv.* has no gate format policy in this repository — csv manifests
-    # cannot reach the oracle with authority, so csv predicates stay
-    # unimplemented (INCONCLUSIVE), never fake-verified.
-    "csv": frozenset(),
-}
+ARTIFACT_APPLICABLE_FORMATS: MappingProxyType = MappingProxyType(
+    {
+        "docx": frozenset({"docx"}),
+        "xlsx": frozenset({"xlsx"}),
+        "pptx": frozenset({"pptx"}),
+        "text": frozenset({"text"}),
+        # csv.* has no gate format policy in this repository — csv manifests
+        # cannot reach the oracle with authority, so csv predicates stay
+        # unimplemented (INCONCLUSIVE), never fake-verified.
+        "csv": frozenset(),
+    }
+)
 
 ARTIFACT_INSPECTABLE_FORMATS: frozenset[str] = frozenset(
     {"docx", "xlsx", "pptx", "text"}
+)
+
+#: Expected descriptor facts. The oracle's constructor compares the
+#: pinned descriptor against these EXACTLY — a same-id/same-version
+#: descriptor with a different config or capability is rejected.
+ARTIFACT_DESCRIPTOR_EXPECTATIONS = MappingProxyType(
+    {
+        "verifier_id": "verifier.artifact_content",
+        "accepted_authorities": ("ARTIFACT_MANIFEST", "ARTIFACT_QC", "OBJECT_STORE"),
+        "supported_subject_kinds": ("artifact",),
+        "producer_component_id": "tiangong-gateway",
+        "layer": "L0_DETERMINISTIC",
+        "deterministic": True,
+        "default_enforcement": "RECORD",
+    }
 )
 
 VERIFIER_ID = "verifier.artifact_content"

--- a/src/total_gateway/verification_registry.py
+++ b/src/total_gateway/verification_registry.py
@@ -64,10 +64,11 @@ def _dormant_descriptor(
 
 
 def default_descriptors() -> tuple[VerifierDescriptor, ...]:
-    """Artifact oracle is ACTIVE at v2 (M2.1); effect/repository stay dormant.
+    """Artifact oracle descriptor: implementation-present /
+    descriptor-registered / production-unwired (M2.2 wording).
 
-    The artifact v2 descriptor declares EXACTLY the dispatch set implemented
-    by ``outcome_oracles/artifact_content.py`` — both read
+    The artifact descriptor carries the EXACT dispatch set implemented by
+    ``outcome_oracles/artifact_content.py`` — both read
     ``verification_oracle_config`` so they cannot drift. Its config digest
     covers the implemented predicate set, params normalization version,
     inspector semantic version, max input bytes and format applicability.

--- a/tests/test_contract_artifacts.py
+++ b/tests/test_contract_artifacts.py
@@ -30,6 +30,7 @@ from contracts.compatibility import (
     P17_LIFE_P10_ATOMIC_CONTEXT_SCHEMA_BASELINE_SHA256,
     P18_G1_VNEXT_CONTRACT_SCHEMA_BASELINE_SHA256,
     P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256,
+    P19_R2_M2_VERIFICATION_SCHEMA_BASELINE_SHA256,
     REVIEWED_SCHEMA_BASELINE_SHA256,
     assert_schema_bundles_compatible,
     compare_schema_bundles,
@@ -115,10 +116,10 @@ class ContractCompatibilityTests(unittest.TestCase):
             contract_schema_bundle_sha256(),
             REVIEWED_SCHEMA_BASELINE_SHA256,
         )
-        # P19-R2 M1 验证平面合同后当前基线推进到 P19；P18 及以下作为历史基线保留兼容性校验。
+        # 当前阶段：AcceptancePredicate 在包中（M2 起）；历史基线逐级保留。
         self.assertEqual(
             REVIEWED_SCHEMA_BASELINE_SHA256,
-            P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256,
+            P19_R2_M2_VERIFICATION_SCHEMA_BASELINE_SHA256,
         )
         bundle = contract_schema_bundle()
         assert_schema_bundles_compatible(bundle, copy.deepcopy(bundle))
@@ -149,17 +150,27 @@ class ContractCompatibilityTests(unittest.TestCase):
                 for item in node:
                     _restore_version_shape(item)
 
-        # P19 → P18 推导：剥离 M1 新增的三个验证平面根合同（对既有合同零改动）。
-        p18_bundle = {
+        # 两级历史链（不得跨级）：
+        # 第一步：当前包剥离 AcceptancePredicate -> M1 阶段包 digest。
+        m1_bundle = {
             name: copy.deepcopy(schema)
             for name, schema in bundle.items()
-            if name
-            not in {
-                "AcceptancePredicate",
-                "RegistrySnapshot",
-                "VerificationRecord",
-                "VerifierDescriptor",
-            }
+            if name != "AcceptancePredicate"
+        }
+        self.assertEqual(
+            hashlib.sha256(
+                json.dumps(
+                    m1_bundle, ensure_ascii=False, allow_nan=False,
+                    sort_keys=True, separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest(),
+            P19_R2_M1_VERIFICATION_SCHEMA_BASELINE_SHA256,
+        )
+        # 第二步：M1 包剥离三个验证平面根合同 -> P18 阶段包 digest。
+        p18_bundle = {
+            name: copy.deepcopy(schema)
+            for name, schema in m1_bundle.items()
+            if name not in {"RegistrySnapshot", "VerificationRecord", "VerifierDescriptor"}
         }
         self.assertEqual(
             hashlib.sha256(

--- a/tests/test_p19_m1_store.py
+++ b/tests/test_p19_m1_store.py
@@ -106,8 +106,8 @@ class P19M1StoreTestBase(unittest.TestCase):
             run_id=self.run_id,
             generation=1,
             verifier_id="verifier.artifact_content",
-            # M2.1: 默认快照携带 v2 描述符（历史 @1 由 legacy 构造器保留）
-            verifier_version="2",
+            # M2.2: 默认快照携带 v3 描述符（历史版本由 legacy 构造器保留）
+            verifier_version="3",
             registry_snapshot_sha256=self.snapshot.snapshot_sha256,
             predicate_id="vpd_p19_m1",
             predicate_type="artifact.nonempty",

--- a/tests/test_p19_m2_1_artifact_oracle.py
+++ b/tests/test_p19_m2_1_artifact_oracle.py
@@ -348,7 +348,7 @@ class DescriptorV2Tests(unittest.TestCase):
         snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
         descriptor = snapshot.find("verifier.artifact_content")
         assert descriptor is not None
-        self.assertEqual(descriptor.verifier_version, "2")
+        self.assertEqual(descriptor.verifier_version, "3")
         self.assertNotEqual(descriptor.config_sha256, "0" * 64)
         self.assertEqual(
             set(descriptor.supported_predicate_types),
@@ -451,7 +451,7 @@ class OracleVerdictTests(M21OracleTestBase):
             ),
         )
         self.assertEqual(record.status, "FAIL")
-        self.assertIn("xlsx.column_missing:姓名", record.reason_codes)
+        self.assertIn("xlsx.required_columns_missing", record.reason_codes)
 
         rows = self._evaluate(
             manifest,
@@ -606,23 +606,42 @@ class OracleDisciplineTests(M21OracleTestBase):
         )
         self.assertEqual(record.status, "ERROR")
 
-    def test_o_size_precheck_reads_nothing(self) -> None:
+    def test_o1_tampered_oversized_manifest_is_error_and_reads_nothing(self) -> None:
+        # O1: an oversized manifest whose size was forged fails AUTHORITY
+        # first (QC facts were registered against the original manifest)
+        # -> ERROR, and the blob is never read.
         manifest = self._text_manifest()
-        oversized = manifest.model_copy(
+        tampered_oversized = manifest.model_copy(
             update={"size_bytes": 10 * 1024 * 1024 * 1024}
         ).with_computed_manifest_sha256()
         with mock.patch.object(
             self.object_store, "read_bytes", wraps=self.object_store.read_bytes
         ) as read_spy:
             record = self._evaluate(
-                oversized,
+                tampered_oversized,
                 AcceptancePredicate.create(
                     predicate_type="artifact.nonempty", subject_kind="artifact"
                 ),
             )
-        self.assertEqual(record.status, "INCONCLUSIVE")
-        self.assertIn("input_too_large", record.reason_codes)
-        read_spy.assert_not_called()
+        self.assertEqual(record.status, "ERROR")
+        # The authority chain legitimately reads payload objects (QC
+        # evidence). What must hold: the oracle adds ZERO reads beyond
+        # the authority baseline — no inspection-phase read happens.
+        from total_gateway.artifact_content import VerifiedArtifactContentSource
+
+        baseline_source = VerifiedArtifactContentSource(
+            self.object_store, self.fact_ledger, (manifest,)
+        )
+        with mock.patch.object(
+            self.object_store, "read_bytes", wraps=self.object_store.read_bytes
+        ) as baseline_spy:
+            try:
+                baseline_source.verify_artifact_revision(
+                    tampered_oversized.artifact_revision_id
+                )
+            except Exception:
+                pass  # expected to fail on the tampered manifest
+        self.assertEqual(read_spy.call_count, baseline_spy.call_count)
 
     def test_m_dependency_missing_is_error_and_unparseable_is_inconclusive(self) -> None:
         manifest = self._text_manifest()

--- a/tests/test_p19_m2_2_trust_boundary.py
+++ b/tests/test_p19_m2_2_trust_boundary.py
@@ -1,0 +1,447 @@
+"""P19-R2 M2.2 trust-boundary closure tests — review matrix.
+
+A1/A2: predicate identity under param variation and illegal construction.
+D1/D2: exact descriptor binding (config hash / capability / limits).
+O1/O2: oversized manifests (tampered -> ERROR; authority-valid oversized
+-> INCONCLUSIVE) with zero inspection-phase reads beyond the authority
+baseline.
+N1: 64 QC evidences fold into one set digest.
+T1/X1/X2/P1/E1: normalization, formula-only content, parser taxonomy,
+reason-code hygiene.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from contracts import canonical_sha256
+from contracts.verification import (
+    AcceptancePredicate,
+    AcceptancePredicateSpecError,
+)
+from total_gateway.artifact_content import VerifiedArtifactContentSource
+from total_gateway.outcome_oracles.artifact_content import (
+    ArtifactContentOracle,
+    OracleSnapshotInvalid,
+)
+from total_gateway.verification_oracle_config import (
+    ARTIFACT_INSPECTOR_SEMANTIC_VERSION,
+)
+from total_gateway.verification_registry import VerifierRegistry
+
+from tests.test_p19_m2_1_artifact_oracle import (
+    M21OracleTestBase,
+    XLSX_MIME,
+    xlsx_bytes,
+)
+
+
+def _authority_read_baseline(test: M21OracleTestBase, manifest) -> int:
+    """Object-store reads performed by the authority chain alone."""
+    source = VerifiedArtifactContentSource(
+        test.object_store, test.fact_ledger, (manifest,)
+    )
+    with mock.patch.object(
+        test.object_store, "read_bytes", wraps=test.object_store.read_bytes
+    ) as spy:
+        try:
+            source.verify_artifact_revision(manifest.artifact_revision_id)
+        except Exception:
+            pass
+    return spy.call_count
+
+
+class PredicateBypassTests(unittest.TestCase):
+    """A1 / A2: create() bypass must be sealed at every layer."""
+
+    def _columns(self, columns):
+        return AcceptancePredicate.create(
+            predicate_type="xlsx.required_columns",
+            subject_kind="artifact",
+            params={"columns": columns},
+        )
+
+    def test_a1_param_variation_changes_predicate_and_record_ids(self) -> None:
+        first = self._columns(["姓名", "分数"])
+        second = self._columns(["姓名", "等级"])
+        self.assertNotEqual(first.predicate_id, second.predicate_id)
+        # record ids derive from result hashes which embed
+        # predicate_sha256:<hash> evidence — differing predicate hashes
+        # must produce differing record identities (verified end-to-end
+        # in OracleA1Tests below with the real oracle).
+
+    def test_a2_illegal_predicates_rejected_everywhere(self) -> None:
+        good = self._columns(["姓名"])
+        # 1) direct construction with unknown params
+        with self.assertRaises(Exception):
+            AcceptancePredicate(
+                predicate_id=good.predicate_id,
+                predicate_type="artifact.nonempty",
+                subject_kind="artifact",
+                params=(("strict", True),),
+                predicate_sha256=good.predicate_sha256,
+            )
+        # 2) model_validate_json with non-normalized params
+        raw = json.dumps(
+            {
+                "predicate_id": good.predicate_id,
+                "predicate_type": "xlsx.required_columns",
+                "subject_kind": "artifact",
+                "params": [["columns", ["姓名", "姓名"]]],
+                "predicate_sha256": good.predicate_sha256,
+            }
+        )
+        with self.assertRaises(Exception):
+            AcceptancePredicate.model_validate_json(raw)
+        # 3) model_copy + recomputed hash/id with FILLER params -> the
+        #    validator is bypassed, but has_valid_identity re-validates
+        #    semantics and must reject.
+        forged = good.model_copy(update={"params": (("columns", ("姓名",)),)})
+        self.assertTrue(forged.has_valid_identity())  # legal shape by chance
+        filler = good.model_copy(
+            update={"params": (("columns", ("姓名",)), ("strict", True))}
+        )
+        self.assertFalse(filler.has_valid_identity())
+        # recompute hashes for the filler variant — still illegal
+        payload = {
+            "schema_version": "tiangong.acceptance_predicate.v1",
+            "predicate_type": filler.predicate_type,
+            "subject_kind": filler.subject_kind,
+            "params": [
+                [k, list(v) if isinstance(v, tuple) else v] for k, v in filler.params
+            ],
+        }
+        sha = canonical_sha256(payload)
+        pid = "vpd_" + canonical_sha256(
+            {"domain": "tiangong.acceptance_predicate.v1", "predicate_sha256": sha}
+        )
+        fully_forged = filler.model_copy(
+            update={"predicate_sha256": sha, "predicate_id": pid}
+        )
+        self.assertFalse(fully_forged.has_valid_identity())
+        # 4) filler on artifact.nonempty via create()
+        with self.assertRaises(AcceptancePredicateSpecError):
+            AcceptancePredicate.create(
+                predicate_type="artifact.nonempty",
+                subject_kind="artifact",
+                params={"strict": True},
+            )
+        # 5) domain mismatch: xlsx predicate with effect subject
+        wrong_domain = AcceptancePredicate.create(
+            predicate_type="artifact.nonempty", subject_kind="effect"
+        )
+        self.assertFalse(wrong_domain.has_valid_identity())
+        # 6) min_rows as string / bool
+        for bad in ("3", True):
+            with self.assertRaises(AcceptancePredicateSpecError):
+                AcceptancePredicate.create(
+                    predicate_type="xlsx.min_data_rows",
+                    subject_kind="artifact",
+                    params={"min_rows": bad},
+                )
+
+
+class DescriptorBindingTests(unittest.TestCase):
+    """D1 / D2: same id/version, different config or capability."""
+
+    def _oracle_with_artifact_descriptor(self, descriptor):
+        snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+        others = tuple(
+            d for d in snapshot.verifiers if d.verifier_id != "verifier.artifact_content"
+        )
+        from contracts.verification import RegistrySnapshot, derive_registry_snapshot_id
+
+        partial = RegistrySnapshot(
+            registry_snapshot_id="vrg_" + "0" * 64,
+            verifiers=tuple(sorted((descriptor, *others), key=lambda d: d.verifier_id)),
+            captured_at_ms=1,
+            snapshot_sha256="0" * 64,
+        ).with_computed_sha256()
+        rebuilt = partial.model_copy(
+            update={
+                "registry_snapshot_id": derive_registry_snapshot_id(
+                    snapshot_sha256=partial.snapshot_sha256
+                )
+            }
+        )
+        return ArtifactContentOracle(
+            snapshot=rebuilt, object_store=mock.Mock(), fact_ledger=mock.Mock()
+        )
+
+    def _artifact_descriptor(self):
+        snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+        descriptor = snapshot.find("verifier.artifact_content")
+        assert descriptor is not None
+        return descriptor
+
+    def test_d1_wrong_config_sha256_rejected(self) -> None:
+        descriptor = self._artifact_descriptor()
+        tampered = descriptor.model_copy(
+            update={"config_sha256": "e" * 64}
+        ).with_computed_sha256()
+        with self.assertRaises(OracleSnapshotInvalid):
+            self._oracle_with_artifact_descriptor(tampered)
+
+    def test_d2_missing_predicate_or_changed_limit_rejected(self) -> None:
+        descriptor = self._artifact_descriptor()
+        missing_one = descriptor.model_copy(
+            update={
+                "supported_predicate_types": tuple(
+                    t
+                    for t in descriptor.supported_predicate_types
+                    if t != "xlsx.min_data_rows"
+                )
+            }
+        ).with_computed_sha256()
+        with self.assertRaises(OracleSnapshotInvalid):
+            self._oracle_with_artifact_descriptor(missing_one)
+
+        changed_limit = descriptor.model_copy(
+            update={"max_input_bytes": descriptor.max_input_bytes * 2}
+        ).with_computed_sha256()
+        with self.assertRaises(OracleSnapshotInvalid):
+            self._oracle_with_artifact_descriptor(changed_limit)
+
+    def test_version_is_v3(self) -> None:
+        descriptor = self._artifact_descriptor()
+        self.assertEqual(
+            descriptor.verifier_version, ARTIFACT_INSPECTOR_SEMANTIC_VERSION
+        )
+        self.assertEqual(ARTIFACT_INSPECTOR_SEMANTIC_VERSION, "3")
+
+
+class OracleBoundaryTests(M21OracleTestBase):
+    """O2 / N1 / T1 / X1 / X2 / P1 / E1 / A1(end-to-end)."""
+
+    def _nonempty(self):
+        return AcceptancePredicate.create(
+            predicate_type="artifact.nonempty", subject_kind="artifact"
+        )
+
+    def test_a1_same_artifact_same_time_different_params_different_records(self) -> None:
+        manifest = self._passed_manifest(
+            xlsx_bytes(["姓名", "分数"], [["甲", 1], ["乙", 2]]),
+            filename="a1.xlsx",
+            format_id="xlsx",
+            declared_mime=XLSX_MIME,
+        )
+        first = self.oracle.evaluate(
+            manifest,
+            AcceptancePredicate.create(
+                predicate_type="xlsx.min_data_rows",
+                subject_kind="artifact",
+                params={"min_rows": 1},
+            ),
+            evaluated_at_ms=21_000,
+        )
+        second = self.oracle.evaluate(
+            manifest,
+            AcceptancePredicate.create(
+                predicate_type="xlsx.min_data_rows",
+                subject_kind="artifact",
+                params={"min_rows": 2},
+            ),
+            evaluated_at_ms=21_000,
+        )
+        self.assertEqual(first.status, "PASS")
+        self.assertEqual(second.status, "PASS")  # 2 data rows satisfy both
+        self.assertNotEqual(first.predicate_id, second.predicate_id)
+        self.assertNotEqual(
+            first.verification_record_id, second.verification_record_id
+        )
+
+    def test_o2_authority_valid_oversized_is_inconclusive_no_extra_reads(self) -> None:
+        # The artifact gate rejects objects near 64MiB, so an
+        # authority-valid oversized manifest is unreachable through the
+        # real chain at the production limit. Equivalent construction:
+        # rebuild descriptor + oracle from the SAME (patched) config with
+        # an 8-byte limit — the size branch runs after full authority
+        # verification with identical semantics at any threshold.
+        from total_gateway.verification_oracle_config import ARTIFACT_MAX_INPUT_BYTES
+
+        manifest = self._text_manifest("tiny but oversized for this config")
+        with mock.patch(
+            "total_gateway.verification_oracle_config.ARTIFACT_MAX_INPUT_BYTES", 8
+        ), mock.patch(
+            # the oracle module binds the constant at import time too
+            "total_gateway.outcome_oracles.artifact_content.ARTIFACT_MAX_INPUT_BYTES",
+            8,
+        ):
+            snapshot = VerifierRegistry.with_defaults().snapshot(captured_at_ms=1)
+            small_oracle = ArtifactContentOracle(
+                snapshot=snapshot,
+                object_store=self.object_store,
+                fact_ledger=self.fact_ledger,
+            )
+            baseline = _authority_read_baseline(self, manifest)
+            with mock.patch.object(
+                self.object_store, "read_bytes", wraps=self.object_store.read_bytes
+            ) as spy:
+                record = small_oracle.evaluate(
+                    manifest, self._nonempty(), evaluated_at_ms=21_000
+                )
+        self.assertEqual(record.status, "INCONCLUSIVE")
+        self.assertIn("input_too_large", record.reason_codes)
+        # No inspection-phase read beyond the authority baseline.
+        self.assertEqual(spy.call_count, baseline)
+        self.assertEqual(ARTIFACT_MAX_INPUT_BYTES, 64 * 1024 * 1024)  # unpatched
+
+    def test_n1_64_qc_evidences_fold_into_one_digest(self) -> None:
+        manifest = self._text_manifest()
+        # Equivalent construction: rebuild the manifest with 64 fabricated
+        # QC evidence entries (hash recomputed). QC-fact verification is
+        # NOT the target here — evidence binding of _build_record is.
+        base_evidence = manifest.qc_evidence[0]
+        many = tuple(
+            base_evidence.model_copy(
+                update={
+                    "check_id": f"qc.check.{index}",
+                    "tool_fact_id": f"fact_bulk_{index}",
+                    "evidence_sha256": f"{index:064x}",
+                }
+            )
+            for index in range(64)
+        )
+        bulk_manifest = manifest.model_copy(
+            update={"qc_evidence": many}
+        ).with_computed_manifest_sha256()
+        record = self.oracle._build_record(
+            manifest=bulk_manifest,
+            predicate=self._nonempty(),
+            evaluated_at_ms=21_000,
+            evaluation_phase="POST_EXECUTION",
+            status="PASS",
+            reason_codes=(),
+            observation={"measured_format": "text", "inspector_version": "3"},
+        )
+        refs = record.evidence_refs
+        self.assertLessEqual(len(refs), 8)
+        set_digest_ref = next(
+            ref for ref in refs if ref.startswith("qc_evidence_set_sha256:")
+        )
+        # changing ANY single evidence entry must change the digest
+        changed = bulk_manifest.model_copy(
+            update={
+                "qc_evidence": many[:63]
+                + (
+                    many[63].model_copy(
+                        update={"tool_fact_id": "fact_bulk_TAMPERED"}
+                    ),
+                )
+            }
+        ).with_computed_manifest_sha256()
+        changed_record = self.oracle._build_record(
+            manifest=changed,
+            predicate=self._nonempty(),
+            evaluated_at_ms=21_000,
+            evaluation_phase="POST_EXECUTION",
+            status="PASS",
+            reason_codes=(),
+            observation={"measured_format": "text", "inspector_version": "3"},
+        )
+        changed_ref = next(
+            ref
+            for ref in changed_record.evidence_refs
+            if ref.startswith("qc_evidence_set_sha256:")
+        )
+        self.assertNotEqual(set_digest_ref, changed_ref)
+
+    def test_t1_marker_normalization_matches_both_sides(self) -> None:
+        manifest = self._text_manifest("Document mentions ABC in the body.")
+        predicate = AcceptancePredicate.create(
+            predicate_type="text.required_markers",
+            subject_kind="artifact",
+            # "abc" (case) and "ＡＢＣ" (fullwidth) must both match "ABC"
+            # after NFKC + casefold on both sides.
+            params={"markers": ["abc", "ＡＢＣ"]},
+        )
+        record = self.oracle.evaluate(
+            manifest, predicate, evaluated_at_ms=21_000
+        )
+        self.assertEqual(record.status, "PASS", record.reason_codes)
+
+    def test_x1_formula_only_xlsx_is_nonempty(self) -> None:
+        manifest = self._passed_manifest(
+            xlsx_bytes(["合计"], [], formulas=[("B1", "=SUM(A1:A9)")]),
+            filename="formula_only.xlsx",
+            format_id="xlsx",
+            declared_mime=XLSX_MIME,
+        )
+        record = self.oracle.evaluate(
+            manifest, self._nonempty(), evaluated_at_ms=21_000
+        )
+        self.assertEqual(record.status, "PASS", record.reason_codes)
+
+    def test_x2_formula_only_data_rows_count(self) -> None:
+        manifest = self._passed_manifest(
+            xlsx_bytes(
+                ["合计"],
+                [],
+                formulas=[("A2", "=1+1"), ("A3", "=2+2")],
+            ),
+            filename="formula_rows.xlsx",
+            format_id="xlsx",
+            declared_mime=XLSX_MIME,
+        )
+        two = self.oracle.evaluate(
+            manifest,
+            AcceptancePredicate.create(
+                predicate_type="xlsx.min_data_rows",
+                subject_kind="artifact",
+                params={"min_rows": 2},
+            ),
+            evaluated_at_ms=21_000,
+        )
+        self.assertEqual(two.status, "PASS", two.reason_codes)
+        three = self.oracle.evaluate(
+            manifest,
+            AcceptancePredicate.create(
+                predicate_type="xlsx.min_data_rows",
+                subject_kind="artifact",
+                params={"min_rows": 3},
+            ),
+            evaluated_at_ms=21_000,
+        )
+        self.assertEqual(three.status, "FAIL")
+
+    def test_p1_parser_runtime_error_is_error_not_inconclusive(self) -> None:
+        from total_gateway.outcome_oracles import artifact_content as module
+
+        manifest = self._text_manifest()
+        with mock.patch.object(
+            module, "_inspect_text", side_effect=RuntimeError("internal bug")
+        ):
+            record = self.oracle.evaluate(
+                manifest, self._nonempty(), evaluated_at_ms=21_000
+            )
+        self.assertEqual(record.status, "ERROR")
+        self.assertIn("inspector_failure", record.reason_codes)
+
+    def test_e1_reason_codes_never_carry_user_strings(self) -> None:
+        manifest = self._passed_manifest(
+            xlsx_bytes(["姓名备注"], [["甲"]]),
+            filename="e1.xlsx",
+            format_id="xlsx",
+            declared_mime=XLSX_MIME,
+        )
+        secret_column = "绝密列名XYZ"
+        record = self.oracle.evaluate(
+            manifest,
+            AcceptancePredicate.create(
+                predicate_type="xlsx.required_columns",
+                subject_kind="artifact",
+                params={"columns": [secret_column]},
+            ),
+            evaluated_at_ms=21_000,
+        )
+        self.assertEqual(record.status, "FAIL")
+        self.assertEqual(record.reason_codes, ("xlsx.required_columns_missing",))
+        for code in record.reason_codes:
+            self.assertNotIn(secret_column, code)
+            self.assertNotIn("姓名", code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## M2.2｜对 M2.1 审核裁决八节的逐条落实

**v23 保持 / RECORD ONLY / 状态口径：implementation-present / descriptor-registered / production-unwired。**

### §1 create() 旁路封死
模型验证器重跑 `normalize_predicate_params` 逐字节比对（直接构造 / `model_validate_json` / 未规范化 params 全拒）；`has_valid_identity()` 全语义（sha + 派生 id + 规范化 params + **领域对应** `PREDICATE_SUBJECT_KINDS`）——model_copy+重算哈希的非法谓词在 trust boundary 被拒；规则/领域映射 `MappingProxyType`（测试 A2 五类非法构造全拒）。

### §2 描述符 v3 + 精确绑定
语义版本 2→3；`_validate_artifact_descriptor` 对 pinned 描述符**十二项精确比对**（id/version/config_sha256/supported/supported_kinds/authorities/max_input/impl_ref/producer/deterministic/layer/enforcement）——同 id/version 异 config 或能力 → `OracleSnapshotInvalid`（D1/D2）；v1/v2 快照可解析、不可实例化 v3。

### §3 权威先于任何状态
固定十步顺序：谓词全语义验证 → source 构造 → `verify_artifact_revision`（manifest hash/QC facts/object 绑定）→ applicability → capability → inspectable → **已验证** manifest.size_bytes 上限 → 超限不读 → readback → inspect。NOT_APPLICABLE/INCONCLUSIVE 亦绑定权威已验证 subject。

### §4 确定性语义
marker 双侧 NFKC+casefold（T1：ABC/abc/ＡＢＣ 互配）；XLSX 单趟 `data_only=False`——公式文本计入 visible chars/nonempty cells/data rows（X1/X2）；PPTX `MSO_SHAPE_TYPE` 枚举 + 表格单元格文本，不可分类内容 INCONCLUSIVE 不假 FAIL；解析器分类学（zip/XML 损坏→INCONCLUSIVE，ImportError/RuntimeError→ERROR，P1）；reason_codes 固定机器码、缺失明细只进 observation digest（E1）。

### §5 基线链修复
M1 常量恢复 `502be945…`；新增 M2 阶段常量 `d46cd149…`（JSON Schema 形状未变），REVIEWED 指向当前；推导测试改**两级**（当前−Predicate→M1；M1−三契约→P18），不跨级。

### §6 测试矩阵
A1/A2/D1/D2/O1/O2/N1/T1/X1/X2/P1/E1 十三项新增；M2.1 矩阵同步更新。三个关键发现如实记录于 `M2_2_DESIGN.txt`：①QC 事实核验会读产物 blob——「超限零读取」承诺改为**检查阶段零额外读取**（权威基线对比）；②Gate 对象上限<64MiB——生产限值下权威有效超限不可达，O2 用同源配置补丁等价构造；③单源常量双模块绑定，测试补丁需覆盖两处。

### 验证
M2.2 targeted 13 + P19 全回归 **127 passed**；**全量 3375 passed / 0 failures**（含跨平台发布门）；source-authority / sync / LF 全过。