### PR TITLE
fix(p19): M5 Final Closure Correction — P0 TypeError + 8 audit fixes

### DIFF
--- a/src/total_gateway/completion_gate.py
+++ b/src/total_gateway/completion_gate.py
@@ -170,6 +170,7 @@ class CompletionGate:
         verification_readiness=None,
         active_plan=None,
         verification_disposition=None,
+        verification_failure_evidence=None,
     ) -> CompletionDecision:
         if candidate_text is not None and (
             not candidate_text.strip() or "\x00" in candidate_text or len(candidate_text) > 100_000
@@ -368,12 +369,82 @@ class CompletionGate:
                 raise CompletionGateError(
                     "completion.verification.disposition_lineage_mismatch"
                 )
-            if verification_readiness is not None:
-                # stale check: disposition must reference the CURRENT readiness
-                # (via its FailureEvidence, which we check indirectly through
-                # the disposition's failure_evidence binding)
-                pass  # full staleness check requires Store re-read; enforced
-                      # at the caller level via get_current_verification_disposition
+            # P1-9: the Gate is the FINAL completion authority — it must
+            # not rely on caller self-discipline. With active_plan +
+            # readiness present, the disposition must fully bind to the
+            # CURRENT plan and the CURRENT readiness through its
+            # FailureEvidence.
+            if active_plan is not None:
+                if (
+                    verification_disposition.verification_plan_id
+                    != active_plan.verification_plan_id
+                ):
+                    raise CompletionGateError(
+                        "completion.verification.disposition_plan_mismatch"
+                    )
+                if verification_disposition.plan_entry_id not in {
+                    e.plan_entry_id for e in active_plan.entries
+                }:
+                    raise CompletionGateError(
+                        "completion.verification.disposition_entry_not_in_plan"
+                    )
+            # P1-9: the disposition must carry the authoritative policy
+            # configuration — a decision from an unknown policy cannot
+            # drive completion.
+            from total_gateway.verification_repair_policy import (
+                DEFAULT_POLICY,
+                POLICY_VERSION,
+            )
+
+            if (
+                verification_disposition.policy_version != POLICY_VERSION
+                or verification_disposition.policy_config_sha256
+                != DEFAULT_POLICY.config_sha256()
+            ):
+                raise CompletionGateError(
+                    "completion.verification.disposition_policy_mismatch"
+                )
+            if verification_failure_evidence is not None:
+                if not hasattr(
+                    verification_failure_evidence, "has_valid_identity"
+                ) or not verification_failure_evidence.has_valid_identity():
+                    raise CompletionGateError(
+                        "completion.verification.evidence_identity_invalid"
+                    )
+                if (
+                    verification_failure_evidence.failure_evidence_id
+                    != verification_disposition.failure_evidence_id
+                    or verification_failure_evidence.failure_evidence_sha256
+                    != verification_disposition.failure_evidence_sha256
+                ):
+                    raise CompletionGateError(
+                        "completion.verification.disposition_evidence_mismatch"
+                    )
+                if (
+                    verification_failure_evidence.request_id
+                    != verification_disposition.request_id
+                    or verification_failure_evidence.run_id
+                    != verification_disposition.run_id
+                    or verification_failure_evidence.generation
+                    != verification_disposition.generation
+                    or verification_failure_evidence.plan_entry_id
+                    != verification_disposition.plan_entry_id
+                ):
+                    raise CompletionGateError(
+                        "completion.verification.evidence_lineage_mismatch"
+                    )
+                if (
+                    verification_readiness is not None
+                    and verification_failure_evidence.readiness_sha256
+                    != verification_readiness.readiness_sha256
+                ):
+                    raise CompletionGateError(
+                        "completion.verification.disposition_stale_readiness"
+                    )
+            elif verification_readiness is not None:
+                raise CompletionGateError(
+                    "completion.verification.disposition_without_evidence"
+                )
             _da = verification_disposition.action
             if _da == "RECONCILE":
                 ambiguous = True  # → RECONCILE_REQUIRED

--- a/src/total_gateway/completion_gate.py
+++ b/src/total_gateway/completion_gate.py
@@ -348,10 +348,32 @@ class CompletionGate:
         ambiguous = execution_ambiguous or delivery_ambiguous
         failed = execution_failed or artifacts_failed or delivery_failed
         # M5 Final §17: disposition takes PRIORITY over failure class.
-        # When a current disposition exists, its action decides the
-        # verification outcome — VERIFICATION_FAILED + REPAIR means the
-        # repair is pending, so the request stays IN_PROGRESS (not FAILED).
+        # M5 Final Correction #7: the Gate VALIDATES the disposition's
+        # identity and lineage before consuming it — a caller-forged
+        # disposition with correct-looking action is rejected.
         if verification_disposition is not None:
+            if not hasattr(verification_disposition, "has_valid_identity"):
+                raise CompletionGateError(
+                    "completion.verification.disposition_invalid_type"
+                )
+            if not verification_disposition.has_valid_identity():
+                raise CompletionGateError(
+                    "completion.verification.disposition_identity_invalid"
+                )
+            if (
+                verification_disposition.request_id != requirements.request_id
+                or verification_disposition.run_id != requirements.run_id
+                or verification_disposition.generation != requirements.generation
+            ):
+                raise CompletionGateError(
+                    "completion.verification.disposition_lineage_mismatch"
+                )
+            if verification_readiness is not None:
+                # stale check: disposition must reference the CURRENT readiness
+                # (via its FailureEvidence, which we check indirectly through
+                # the disposition's failure_evidence binding)
+                pass  # full staleness check requires Store re-read; enforced
+                      # at the caller level via get_current_verification_disposition
             _da = verification_disposition.action
             if _da == "RECONCILE":
                 ambiguous = True  # → RECONCILE_REQUIRED

--- a/src/total_gateway/delivery_outbox.py
+++ b/src/total_gateway/delivery_outbox.py
@@ -530,6 +530,7 @@ class GatewayDeliveryOutboxWorker:
                 run_id=plan.run_id,
                 generation=plan.generation,
             )
+            verification_disposition = None
             if active_plan is not None:
                 from total_gateway.verification_plan_executor import (
                     VerificationPlanExecutor,
@@ -546,10 +547,29 @@ class GatewayDeliveryOutboxWorker:
                     fact_ledger=self._facts,
                     plan=active_plan,
                 )
-                executor.execute(
+                readiness = executor.execute(
                     evaluated_at_ms=completed_at_ms,
                     artifact_manifests=tuple(artifacts),
                 )
+                # M5 Final Correction #3: Channel Coordinator wiring
+                if not readiness.verification_ready:
+                    from total_gateway.verification_repair_coordinator import (
+                        VerificationRepairCoordinator,
+                    )
+                    coordinator = VerificationRepairCoordinator(
+                        store=self._store,
+                    )
+                    coordinator.process_readiness(
+                        plan=active_plan,
+                        readiness=readiness,
+                    )
+                    verification_disposition = self._store.get_current_verification_disposition(
+                        request_id=plan.request_id,
+                        run_id=plan.run_id,
+                        generation=plan.generation,
+                        verification_plan_id=active_plan.verification_plan_id,
+                        readiness_sha256=readiness.readiness_sha256,
+                    )
             decision = CompletionGate(self._objects, self._facts, head_state_reader=self._store.get_effect_head_state).evaluate(
                 requirements,
                 candidate_text=text_parts[0] if text_parts else None,
@@ -557,6 +577,7 @@ class GatewayDeliveryOutboxWorker:
                 outbound_plan=plan,
                 delivery_failure="AMBIGUOUS" if ambiguous else "FAILED_FINAL",
                 active_plan=active_plan,
+                verification_disposition=verification_disposition,
                 verification_readiness=self._store.get_latest_verification_readiness(
                     request_id=plan.request_id,
                     run_id=plan.run_id,
@@ -714,6 +735,7 @@ class GatewayDeliveryOutboxWorker:
             run_id=plan.run_id,
             generation=plan.generation,
         )
+        verification_disposition = None
         if active_plan is not None:
             from total_gateway.verification_plan_executor import (
                 VerificationPlanExecutor,
@@ -729,10 +751,29 @@ class GatewayDeliveryOutboxWorker:
                 fact_ledger=self._facts,
                 plan=active_plan,
             )
-            executor.execute(
+            readiness = executor.execute(
                 evaluated_at_ms=completed_at_ms,
                 artifact_manifests=tuple(artifacts),
             )
+            # M5 Final Correction #3: Channel Coordinator wiring (receipt branch)
+            if not readiness.verification_ready:
+                from total_gateway.verification_repair_coordinator import (
+                    VerificationRepairCoordinator,
+                )
+                coordinator = VerificationRepairCoordinator(
+                    store=self._store,
+                )
+                coordinator.process_readiness(
+                    plan=active_plan,
+                    readiness=readiness,
+                )
+                verification_disposition = self._store.get_current_verification_disposition(
+                    request_id=plan.request_id,
+                    run_id=plan.run_id,
+                    generation=plan.generation,
+                    verification_plan_id=active_plan.verification_plan_id,
+                    readiness_sha256=readiness.readiness_sha256,
+                )
         decision = CompletionGate(self._objects, self._facts, head_state_reader=self._store.get_effect_head_state).evaluate(
             requirements,
             candidate_text=text_parts[0] if text_parts else None,
@@ -740,6 +781,7 @@ class GatewayDeliveryOutboxWorker:
             outbound_plan=plan,
             delivery_receipt=receipt,
             active_plan=active_plan,
+            verification_disposition=verification_disposition,
             verification_readiness=self._store.get_latest_verification_readiness(
                 request_id=plan.request_id,
                 run_id=plan.run_id,

--- a/src/total_gateway/delivery_outbox.py
+++ b/src/total_gateway/delivery_outbox.py
@@ -94,6 +94,7 @@ class GatewayDeliveryOutboxWorker:
         gateway_epoch: int,
         worker_id: str,
         advance: Callable[..., object],
+        repair_dispatch: Callable[..., object] | None = None,
     ) -> None:
         self._store = store
         self._objects = objects
@@ -104,6 +105,81 @@ class GatewayDeliveryOutboxWorker:
         self._epoch = gateway_epoch
         self._worker_id = worker_id
         self._advance = advance
+        # P0-3: optional bridge to the EXISTING runtime for artifact-only
+        # channel repairs. When absent NOTHING is auto-repaired here —
+        # the delivery boundary is never blindly replayed.
+        self._repair_dispatch = repair_dispatch
+
+    def _run_channel_repair_loop(self, *, active_plan, readiness, artifacts):
+        """P0-3: channel-side repair with delivery-boundary safety.
+
+        Both finalization paths run AFTER the delivery side effect left
+        the process (receipt = confirmed delivered; ambiguous = unknown).
+        Therefore:
+        - effect / repository subjects are NEVER auto-repaired here —
+          replaying an external side effect is forbidden;
+        - artifact subjects may only be repaired through an injected
+          EXISTING-runtime bridge (artifact content repair does not
+          touch the delivery side effect); without the bridge nothing
+          executes and the REPAIR disposition keeps the request
+          IN_PROGRESS at the Gate;
+        - the delivery itself is never re-sent by this loop.
+        Returns (final_readiness, disposition, failure_evidence).
+        """
+        from total_gateway.verification_plan_executor import (
+            VerificationPlanExecutor,
+        )
+        from total_gateway.verification_repair_coordinator import (
+            RepairDispatchResult,
+            VerificationRepairCoordinator,
+        )
+        from total_gateway.orchestration import _verification_snapshot
+
+        coordinator = VerificationRepairCoordinator(store=self._store)
+
+        def _dispatch(directive):
+            if self._repair_dispatch is None:
+                # Unreachable when kinds=(): kept as a fail-closed guard.
+                return RepairDispatchResult(
+                    execution_outcome="EXECUTION_FAILED",
+                    produced_subject_identity=(
+                        directive.effective_subject_identity
+                    ),
+                    execution_effect_ids=(),
+                )
+            return self._repair_dispatch(directive)
+
+        def _reverify():
+            executor = VerificationPlanExecutor(
+                snapshot=_verification_snapshot(
+                    self._store, active_plan.registry_snapshot_sha256,
+                ),
+                store=self._store,
+                object_store=self._objects,
+                fact_ledger=self._facts,
+                plan=active_plan,
+            )
+            return executor.execute(
+                evaluated_at_ms=time.time_ns() // 1_000_000,
+                artifact_manifests=tuple(artifacts),
+            )
+
+        dispatchable = (
+            ("artifact",) if self._repair_dispatch is not None else ()
+        )
+        readiness, disposition = coordinator.execute_repair_loop(
+            plan=active_plan,
+            readiness=readiness,
+            dispatch=_dispatch,
+            reverify=_reverify,
+            dispatchable_subject_kinds=dispatchable,
+        )
+        evidence = None
+        if disposition is not None:
+            evidence = self._store.get_verification_failure_evidence_by_id(
+                disposition.failure_evidence_id
+            )
+        return readiness, disposition, evidence
 
     def _load_payload(self, record: OutboxRecord) -> DeliveryOutboxPayload:
         intent = record.intent
@@ -531,6 +607,7 @@ class GatewayDeliveryOutboxWorker:
                 generation=plan.generation,
             )
             verification_disposition = None
+            verification_failure_evidence = None
             if active_plan is not None:
                 from total_gateway.verification_plan_executor import (
                     VerificationPlanExecutor,
@@ -551,24 +628,17 @@ class GatewayDeliveryOutboxWorker:
                     evaluated_at_ms=completed_at_ms,
                     artifact_manifests=tuple(artifacts),
                 )
-                # M5 Final Correction #3: Channel Coordinator wiring
+                # P0-3: channel repair runs through the SAME loop with
+                # delivery-boundary safety semantics (no replay).
                 if not readiness.verification_ready:
-                    from total_gateway.verification_repair_coordinator import (
-                        VerificationRepairCoordinator,
-                    )
-                    coordinator = VerificationRepairCoordinator(
-                        store=self._store,
-                    )
-                    coordinator.process_readiness(
-                        plan=active_plan,
+                    (
+                        readiness,
+                        verification_disposition,
+                        verification_failure_evidence,
+                    ) = self._run_channel_repair_loop(
+                        active_plan=active_plan,
                         readiness=readiness,
-                    )
-                    verification_disposition = self._store.get_current_verification_disposition(
-                        request_id=plan.request_id,
-                        run_id=plan.run_id,
-                        generation=plan.generation,
-                        verification_plan_id=active_plan.verification_plan_id,
-                        readiness_sha256=readiness.readiness_sha256,
+                        artifacts=artifacts,
                     )
             decision = CompletionGate(self._objects, self._facts, head_state_reader=self._store.get_effect_head_state).evaluate(
                 requirements,
@@ -578,6 +648,7 @@ class GatewayDeliveryOutboxWorker:
                 delivery_failure="AMBIGUOUS" if ambiguous else "FAILED_FINAL",
                 active_plan=active_plan,
                 verification_disposition=verification_disposition,
+                verification_failure_evidence=verification_failure_evidence,
                 verification_readiness=self._store.get_latest_verification_readiness(
                     request_id=plan.request_id,
                     run_id=plan.run_id,
@@ -736,6 +807,7 @@ class GatewayDeliveryOutboxWorker:
             generation=plan.generation,
         )
         verification_disposition = None
+        verification_failure_evidence = None
         if active_plan is not None:
             from total_gateway.verification_plan_executor import (
                 VerificationPlanExecutor,
@@ -755,24 +827,17 @@ class GatewayDeliveryOutboxWorker:
                 evaluated_at_ms=completed_at_ms,
                 artifact_manifests=tuple(artifacts),
             )
-            # M5 Final Correction #3: Channel Coordinator wiring (receipt branch)
+            # P0-3: receipt branch — delivery side effect already
+            # happened; the same no-replay repair loop applies.
             if not readiness.verification_ready:
-                from total_gateway.verification_repair_coordinator import (
-                    VerificationRepairCoordinator,
-                )
-                coordinator = VerificationRepairCoordinator(
-                    store=self._store,
-                )
-                coordinator.process_readiness(
-                    plan=active_plan,
+                (
+                    readiness,
+                    verification_disposition,
+                    verification_failure_evidence,
+                ) = self._run_channel_repair_loop(
+                    active_plan=active_plan,
                     readiness=readiness,
-                )
-                verification_disposition = self._store.get_current_verification_disposition(
-                    request_id=plan.request_id,
-                    run_id=plan.run_id,
-                    generation=plan.generation,
-                    verification_plan_id=active_plan.verification_plan_id,
-                    readiness_sha256=readiness.readiness_sha256,
+                    artifacts=artifacts,
                 )
         decision = CompletionGate(self._objects, self._facts, head_state_reader=self._store.get_effect_head_state).evaluate(
             requirements,
@@ -782,6 +847,7 @@ class GatewayDeliveryOutboxWorker:
             delivery_receipt=receipt,
             active_plan=active_plan,
             verification_disposition=verification_disposition,
+            verification_failure_evidence=verification_failure_evidence,
             verification_readiness=self._store.get_latest_verification_readiness(
                 request_id=plan.request_id,
                 run_id=plan.run_id,

--- a/src/total_gateway/desktop_completion.py
+++ b/src/total_gateway/desktop_completion.py
@@ -33,6 +33,7 @@ def evaluate_desktop_completion(
     head_state_reader=None,
     verification_readiness=None,
     active_plan=None,
+    verification_disposition=None,
 ) -> CompletionDecision:
     requirements = CompletionRequirements(
         request_id=request_id,
@@ -61,6 +62,7 @@ def evaluate_desktop_completion(
             artifacts=artifacts,
             verification_readiness=verification_readiness,
             active_plan=active_plan,
+            verification_disposition=verification_disposition,
         )
     except CompletionGateError as exc:
         raise DesktopCompletionError(exc.code) from exc

--- a/src/total_gateway/desktop_completion.py
+++ b/src/total_gateway/desktop_completion.py
@@ -34,6 +34,7 @@ def evaluate_desktop_completion(
     verification_readiness=None,
     active_plan=None,
     verification_disposition=None,
+    verification_failure_evidence=None,
 ) -> CompletionDecision:
     requirements = CompletionRequirements(
         request_id=request_id,
@@ -63,6 +64,7 @@ def evaluate_desktop_completion(
             verification_readiness=verification_readiness,
             active_plan=active_plan,
             verification_disposition=verification_disposition,
+            verification_failure_evidence=verification_failure_evidence,
         )
     except CompletionGateError as exc:
         raise DesktopCompletionError(exc.code) from exc

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -155,7 +155,12 @@ from .skill_selection import (
     load_model_capability_manifest,
 )
 from .skill_authority import SkillAuthority
-from .store import ActiveRequestActivation, GatewayStateStore, StoreConflictError
+from .store import (
+    ActiveRequestActivation,
+    GatewayStateStore,
+    StoreConflictError,
+    StoreError,
+)
 from contracts.world_understanding.inquiry import WorldInquiry
 from world_understanding.inquiry.self_will_integration import ExistingSelfWillAdapter
 
@@ -2156,16 +2161,82 @@ class GatewayOrchestrationWorker:
         self._complete_repair_effect(
             repair_effect.effect_id, "SUCCEEDED", None
         )
-        produced_subject = (
-            artifact_manifests[-1].artifact_revision_id
-            if produced_count
-            else directive.effective_subject_identity
-        )
+        # P0-2: the successor is the NEW authoritative reality object
+        # per subject kind — artifact → new revision, effect → the
+        # re-execution effect itself, repository → the mutation effect
+        # with its PRE/POST observation window.
+        produced_subject = directive.effective_subject_identity
+        if directive.subject_kind == "artifact":
+            if produced_count:
+                produced_subject = (
+                    artifact_manifests[-1].artifact_revision_id
+                )
+        elif directive.subject_kind == "effect":
+            produced_subject = repair_effect.effect_id
+        elif directive.subject_kind == "repository":
+            if self._bind_repository_repair_observations(
+                result_payload=result_payload,
+                subject_effect_id=repair_effect.effect_id,
+                directive=directive,
+                observed_at_ms=time.time_ns() // 1_000_000,
+            ):
+                produced_subject = repair_effect.effect_id
         return RepairDispatchResult(
             execution_outcome="DISPATCHED",
             produced_subject_identity=produced_subject,
             execution_effect_ids=(repair_effect.effect_id,),
         )
+
+    def _bind_repository_repair_observations(
+        self,
+        *,
+        result_payload,
+        subject_effect_id: str,
+        directive,
+        observed_at_ms: int,
+    ) -> bool:
+        """P0-2: bind the repair mutation's PRE/POST repository
+        observation window to the NEW subject effect. The observation
+        payloads come from the runtime response and must validate
+        through the authoritative RepositoryObservation contract at the
+        Store boundary. Returns False (no successor) when the window is
+        absent or invalid — the mutation stays unproven."""
+        observations = result_payload.get("repository_observations")
+        if not isinstance(observations, dict):
+            return False
+        try:
+            for role, key in (("PRE", "pre"), ("POST", "post")):
+                payload = observations.get(key)
+                if not isinstance(payload, dict):
+                    return False
+                identity = payload.get("identity") or {}
+                revision = payload.get("revision") or {}
+                observed_at = int(payload.get("observed_at_ms"))
+                self._store.put_repository_observation(
+                    observation_sha256=str(payload["observation_sha256"]),
+                    observation_payload=payload,
+                    request_id=directive.request_id,
+                    run_id=directive.run_id,
+                    generation=directive.generation,
+                    effect_id=subject_effect_id,
+                    repository_id=str(identity.get("repository_id")),
+                    head_commit=str(revision.get("head_commit")),
+                    observed_at_ms=observed_at,
+                    recorded_at_ms=observed_at_ms + 1,
+                )
+                self._store.put_repository_observation_binding(
+                    observation_sha256=str(payload["observation_sha256"]),
+                    request_id=directive.request_id,
+                    run_id=directive.run_id,
+                    generation=directive.generation,
+                    subject_effect_id=subject_effect_id,
+                    observation_role=role,
+                    observed_at_ms=observed_at,
+                    recorded_at_ms=observed_at + 2,
+                )
+            return True
+        except (KeyError, TypeError, ValueError, StoreError):
+            return False
 
     def _complete_repair_effect(
         self, effect_id: str, status: str, error_code: str | None
@@ -2261,7 +2332,19 @@ class GatewayOrchestrationWorker:
                         checked_at_ms=observed_at_ms,
                     )
                 if outcome.passed:
-                    artifact_manifests.append(outcome.registration.record.manifest)
+                    manifest = outcome.registration.record.manifest
+                    artifact_manifests.append(manifest)
+                    # P1-6: QC-passed repair artifacts enter the Store's
+                    # artifact authority projection.
+                    self._store.register_artifact_subject(
+                        artifact_revision_id=manifest.artifact_revision_id,
+                        object_id=manifest.content_object_id,
+                        artifact_sha256=manifest.sha256,
+                        request_id=directive.request_id,
+                        run_id=directive.run_id,
+                        generation=directive.generation,
+                        registered_at_ms=observed_at_ms,
+                    )
                     produced += 1
             except (
                 ArtifactGateError,
@@ -3056,6 +3139,19 @@ class GatewayOrchestrationWorker:
                         evidence_sha256=qc_record.result.qc_result_sha256,
                     )
                     artifacts.append(qc_record.manifest)
+                    # P1-6: register the QC-passed manifest in the Store's
+                    # artifact authority projection (successor boundary).
+                    self._store.register_artifact_subject(
+                        artifact_revision_id=(
+                            qc_record.manifest.artifact_revision_id
+                        ),
+                        object_id=qc_record.manifest.content_object_id,
+                        artifact_sha256=qc_record.manifest.sha256,
+                        request_id=request_id,
+                        run_id=run_id,
+                        generation=generation.generation,
+                        registered_at_ms=observed_at,
+                    )
                 else:
                     self._advance(
                         "artifact",
@@ -3123,6 +3219,7 @@ class GatewayOrchestrationWorker:
                 generation=generation.generation,
             )
             verification_disposition = None
+            verification_failure_evidence = None
             if active_plan is not None:
                 from total_gateway.verification_plan_executor import (
                     VerificationPlanExecutor,
@@ -3203,8 +3300,9 @@ class GatewayOrchestrationWorker:
                         dispatch=_repair_dispatch,
                         reverify=_repair_reverify,
                     )
-                    # M5 Final #7: read CURRENT disposition from Store
-                    # (authoritative source, bound to the final readiness)
+                    # M5 Final #7 + P1-9: read CURRENT disposition and its
+                    # FailureEvidence from Store (authoritative source);
+                    # the Gate validates the full binding.
                     verification_disposition = self._store.get_current_verification_disposition(
                         request_id=request_id,
                         run_id=run_id,
@@ -3212,6 +3310,10 @@ class GatewayOrchestrationWorker:
                         verification_plan_id=active_plan.verification_plan_id,
                         readiness_sha256=readiness.readiness_sha256,
                     )
+                    if verification_disposition is not None:
+                        verification_failure_evidence = self._store.get_verification_failure_evidence_by_id(
+                            verification_disposition.failure_evidence_id
+                        )
             decision = evaluate_desktop_completion(
                 objects=self._objects,
                 facts=self._facts,
@@ -3229,6 +3331,7 @@ class GatewayOrchestrationWorker:
                 ),
                 active_plan=active_plan,
                 verification_disposition=verification_disposition,
+                verification_failure_evidence=verification_failure_evidence,
             )
             desktop_now = time.time_ns() // 1_000_000
             desktop_evidence = canonical_sha256(

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -13,6 +13,7 @@ import os
 import queue
 import threading
 import time
+import uuid
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping
@@ -1865,6 +1866,10 @@ class GatewayOrchestrationWorker:
             effect_id=repair_effect.effect_id,
             effect_intent_sha256=effect_intent,
             reserved_at_ms=issued_at,
+            # invocation-scoped, never the gateway instance id — two
+            # threads in one process still single-flight
+            dispatch_claim_id=uuid.uuid4().hex,
+            claim_expires_at_ms=issued_at + 120_000,
         )
         if reserved["outcome"] != "EXECUTE":
             # Another coordinator owns this attempt — this worker must
@@ -2019,8 +2024,10 @@ class GatewayOrchestrationWorker:
                 grant=None,
                 observed_at_ms=issued_at,
             )
-            # Definite non-execution: terminalize as FAILED_FINAL (the
-            # runtime was never entered).
+            # Definite non-execution: ONE atomic transition puts BOTH
+            # authorities (binding + EffectLedger) into FAILED_FINAL, so
+            # the RepairAttempt(EXECUTION_FAILED) can persist and the
+            # runtime callback count stays zero.
             self._store.complete_repair_execution(
                 repair_directive_id=directive.repair_directive_id,
                 state="FAILED_FINAL",
@@ -2028,6 +2035,7 @@ class GatewayOrchestrationWorker:
                 produced_subject_kind=directive.subject_kind,
                 runtime_result_ref="policy-rejected",
                 completed_at_ms=issued_at,
+                error_code="repair.policy_denied",
             )
             return RepairDispatchResult(
                 execution_outcome="EXECUTION_FAILED",
@@ -2113,14 +2121,13 @@ class GatewayOrchestrationWorker:
             authority_expires_at_ms=issued_at + directive.execution_budget_ms,
         )
         try:
-            self._store.mark_effect_started(
-                repair_effect.effect_id, started_at_ms=issued_at
-            )
-            # Final P0: cross the binding's no-return boundary BEFORE
-            # the runtime — after this point recovery is RECONCILE, not
-            # replay.
-            self._store.mark_repair_execution_started(
+            # Final P0-2: ONE atomic transition crosses BOTH authorities
+            # (EffectLedger CLAIMED→STARTED + binding RESERVED→STARTED)
+            # BEFORE the runtime — no committed state can ever show an
+            # effect past the boundary while its binding is RESERVED.
+            self._store.start_repair_execution(
                 repair_directive_id=directive.repair_directive_id,
+                effect_id=repair_effect.effect_id,
                 started_at_ms=issued_at,
             )
 
@@ -2151,9 +2158,6 @@ class GatewayOrchestrationWorker:
                     timeout=max(1.0, directive.execution_budget_ms / 1000.0)
                 )
             except concurrent.futures.TimeoutError:
-                self._complete_repair_effect(
-                    repair_effect.effect_id, "AMBIGUOUS", "repair.execution_timeout"
-                )
                 self._store.complete_repair_execution(
                     repair_directive_id=directive.repair_directive_id,
                     state="AMBIGUOUS",
@@ -2161,6 +2165,7 @@ class GatewayOrchestrationWorker:
                     produced_subject_kind=directive.subject_kind,
                     runtime_result_ref="timeout",
                     completed_at_ms=time.time_ns() // 1_000_000,
+                    error_code="repair.execution_timeout",
                 )
                 return RepairDispatchResult(
                     execution_outcome="EXECUTION_AMBIGUOUS",
@@ -2168,21 +2173,18 @@ class GatewayOrchestrationWorker:
                     execution_effect_ids=(repair_effect.effect_id,),
                 )
         except BackendClientError as exc:
-            status = "AMBIGUOUS" if exc.ambiguous else "FAILED_FINAL"
-            self._complete_repair_effect(
-                repair_effect.effect_id, status, exc.code
-            )
             self._store.complete_repair_execution(
                 repair_directive_id=directive.repair_directive_id,
-                state=("AMBIGUOUS" if status == "AMBIGUOUS" else "FAILED_FINAL"),
+                state=("AMBIGUOUS" if exc.ambiguous else "FAILED_FINAL"),
                 produced_subject_identity="",
                 produced_subject_kind=directive.subject_kind,
                 runtime_result_ref=exc.code or "",
                 completed_at_ms=time.time_ns() // 1_000_000,
+                error_code=exc.code,
             )
             return RepairDispatchResult(
                 execution_outcome=(
-                    "EXECUTION_AMBIGUOUS" if status == "AMBIGUOUS" else "EXECUTION_FAILED"
+                    "EXECUTION_AMBIGUOUS" if exc.ambiguous else "EXECUTION_FAILED"
                 ),
                 produced_subject_identity=directive.effective_subject_identity,
                 execution_effect_ids=(repair_effect.effect_id,),
@@ -2197,12 +2199,6 @@ class GatewayOrchestrationWorker:
             terminal = (
                 "AMBIGUOUS" if response_status == "AMBIGUOUS" else "FAILED_FINAL"
             )
-            self._complete_repair_effect(
-                repair_effect.effect_id,
-                terminal,
-                getattr(getattr(response, "result", None), "error_code", None)
-                or "repair.execution.failed",
-            )
             self._store.complete_repair_execution(
                 repair_directive_id=directive.repair_directive_id,
                 state=terminal,
@@ -2213,6 +2209,10 @@ class GatewayOrchestrationWorker:
                     or ""
                 ),
                 completed_at_ms=time.time_ns() // 1_000_000,
+                error_code=(
+                    getattr(getattr(response, "result", None), "error_code", None)
+                    or "repair.execution.failed"
+                ),
             )
             return RepairDispatchResult(
                 execution_outcome=(
@@ -2268,10 +2268,8 @@ class GatewayOrchestrationWorker:
                 produced_subject = repair_effect.effect_id
         if not repository_window_ok:
             # The mutation may have happened but its window is unproven
-            # — that is AMBIGUOUS, never a silent failure.
-            self._complete_repair_effect(
-                repair_effect.effect_id, "AMBIGUOUS", "repair.repo_window_invalid"
-            )
+            # — that is AMBIGUOUS, never a silent failure. Both
+            # authorities move atomically.
             self._store.complete_repair_execution(
                 repair_directive_id=directive.repair_directive_id,
                 state="AMBIGUOUS",
@@ -2279,6 +2277,7 @@ class GatewayOrchestrationWorker:
                 produced_subject_kind=directive.subject_kind,
                 runtime_result_ref="repo-window-invalid",
                 completed_at_ms=time.time_ns() // 1_000_000,
+                error_code="repair.repo_window_invalid",
             )
             return RepairDispatchResult(
                 execution_outcome="EXECUTION_AMBIGUOUS",
@@ -2288,6 +2287,8 @@ class GatewayOrchestrationWorker:
         # Persist the produced reality FIRST, then terminalize the
         # binding — recovery reads the binding without re-running the
         # runtime.
+        # ONE atomic transition: binding + EffectLedger both SUCCEEDED,
+        # with the produced subject and runtime result persisted.
         self._store.complete_repair_execution(
             repair_directive_id=directive.repair_directive_id,
             state="SUCCEEDED",
@@ -2300,9 +2301,6 @@ class GatewayOrchestrationWorker:
                 getattr(response, "response_sha256", "") or ""
             ),
             completed_at_ms=time.time_ns() // 1_000_000,
-        )
-        self._complete_repair_effect(
-            repair_effect.effect_id, "SUCCEEDED", None
         )
         return RepairDispatchResult(
             execution_outcome="DISPATCHED",
@@ -2360,24 +2358,6 @@ class GatewayOrchestrationWorker:
             return True
         except (KeyError, TypeError, ValueError, StoreError):
             return False
-
-    def _complete_repair_effect(
-        self, effect_id: str, status: str, error_code: str | None
-    ) -> None:
-        observed_at_ms = time.time_ns() // 1_000_000
-        result = EffectResult(
-            result_id="effect-result-" + effect_id[4:20],
-            effect_id=effect_id,
-            status=status,
-            fact_id="fact-effect-" + effect_id[4:20],
-            evidence_sha256=canonical_sha256(
-                {"code": error_code, "status": status}
-            ),
-            error_code=error_code,
-            observed_at_ms=observed_at_ms,
-            result_sha256="0" * 64,
-        ).with_computed_sha256()
-        self._store.complete_effect(result)
 
     def _register_repair_artifacts(
         self,

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -2120,16 +2120,64 @@ class GatewayOrchestrationWorker:
             registered_at_ms=issued_at,
             authority_expires_at_ms=issued_at + directive.execution_budget_ms,
         )
+        # Final P0-1: repository repairs capture the PRE reality from
+        # the independent read-only sensor BEFORE any mutation (never
+        # from runtime payloads).
+        repo_sensor_pre = None
+        if directive.subject_kind == "repository":
+            repo_sensor_pre = self._capture_repository_sensor_pre(
+                effect_id=repair_effect.effect_id,
+                request_id=request_id,
+                run_id=run_id,
+                generation=generation.generation,
+            )
+            if repo_sensor_pre is None:
+                # Pre-boundary sensor failure: the runtime was never
+                # entered — ONE atomic FAILED_FINAL, no successor.
+                self._store.complete_repair_execution(
+                    repair_directive_id=directive.repair_directive_id,
+                    state="FAILED_FINAL",
+                    produced_subject_identity="",
+                    produced_subject_kind=directive.subject_kind,
+                    runtime_result_ref="repo-pre-sensor-failed",
+                    completed_at_ms=time.time_ns() // 1_000_000,
+                    error_code="repair.repo_sensor_pre_failed",
+                )
+                return RepairDispatchResult(
+                    execution_outcome="EXECUTION_FAILED",
+                    produced_subject_identity=(
+                        directive.effective_subject_identity
+                    ),
+                    execution_effect_ids=(repair_effect.effect_id,),
+                )
         try:
-            # Final P0-2: ONE atomic transition crosses BOTH authorities
-            # (EffectLedger CLAIMED→STARTED + binding RESERVED→STARTED)
-            # BEFORE the runtime — no committed state can ever show an
-            # effect past the boundary while its binding is RESERVED.
-            self._store.start_repair_execution(
+            # Final P0-1/P0-2: ONE atomic, CLAIM-FENCED transition crosses
+            # BOTH authorities (EffectLedger CLAIMED→STARTED + binding
+            # RESERVED→STARTED) BEFORE the runtime. The CAS holds on the
+            # caller's claim id + fencing revision + live lease — a
+            # claim that lost a takeover can never reach the runtime.
+            start_outcome = self._store.start_repair_execution(
                 repair_directive_id=directive.repair_directive_id,
                 effect_id=repair_effect.effect_id,
                 started_at_ms=issued_at,
+                dispatch_claim_id=str(
+                    reserved["binding"]["dispatch_claim_id"]
+                ),
+                expected_claim_revision=int(
+                    reserved["binding"]["claim_revision"]
+                ),
             )
+            if start_outcome["outcome"] != "STARTED":
+                # The boundary was already crossed (by this worker
+                # before a crash, or by a takeover winner): the runtime
+                # must NEVER run again — this is RECONCILE territory.
+                return RepairDispatchResult(
+                    execution_outcome="EXECUTION_AMBIGUOUS",
+                    produced_subject_identity=(
+                        directive.effective_subject_identity
+                    ),
+                    execution_effect_ids=(repair_effect.effect_id,),
+                )
 
             def _execute_repair() -> Any:
                 return BackendClient(
@@ -2258,11 +2306,10 @@ class GatewayOrchestrationWorker:
         elif directive.subject_kind == "effect":
             produced_subject = repair_effect.effect_id
         elif directive.subject_kind == "repository":
-            repository_window_ok = self._bind_repository_repair_observations(
-                result_payload=result_payload,
+            repository_window_ok = self._bind_repository_sensor_post(
+                sensor_pre=repo_sensor_pre,
                 subject_effect_id=repair_effect.effect_id,
                 directive=directive,
-                observed_at_ms=time.time_ns() // 1_000_000,
             )
             if repository_window_ok:
                 produced_subject = repair_effect.effect_id
@@ -2308,55 +2355,76 @@ class GatewayOrchestrationWorker:
             execution_effect_ids=(repair_effect.effect_id,),
         )
 
-    def _bind_repository_repair_observations(
-        self,
-        *,
-        result_payload,
-        subject_effect_id: str,
-        directive,
-        observed_at_ms: int,
-    ) -> bool:
-        """P0-2: bind the repair mutation's PRE/POST repository
-        observation window to the NEW subject effect. The observation
-        payloads come from the runtime response and must validate
-        through the authoritative RepositoryObservation contract at the
-        Store boundary. Returns False (no successor) when the window is
-        absent or invalid — the mutation stays unproven."""
-        observations = result_payload.get("repository_observations")
-        if not isinstance(observations, dict):
-            return False
+    def _capture_repository_sensor_pre(
+        self, *, effect_id: str, request_id: str, run_id: str,
+        generation: int,
+    ):
+        """Final P0-2: the repository PRE reality comes from the
+        INDEPENDENT read-only sensor over the workspace Git authority —
+        never from a runtime payload. Returns (identity, observation)
+        or None when sensing fails (the repair then fails closed)."""
         try:
-            for role, key in (("PRE", "pre"), ("POST", "post")):
-                payload = observations.get(key)
-                if not isinstance(payload, dict):
-                    return False
-                identity = payload.get("identity") or {}
-                revision = payload.get("revision") or {}
-                observed_at = int(payload.get("observed_at_ms"))
-                self._store.put_repository_observation(
-                    observation_sha256=str(payload["observation_sha256"]),
-                    observation_payload=payload,
-                    request_id=directive.request_id,
-                    run_id=directive.run_id,
-                    generation=directive.generation,
-                    effect_id=subject_effect_id,
-                    repository_id=str(identity.get("repository_id")),
-                    head_commit=str(revision.get("head_commit")),
-                    observed_at_ms=observed_at,
-                    recorded_at_ms=observed_at_ms + 1,
-                )
+            from v3.repository_perception import LocalGitRepositoryProvider
+
+            provider = LocalGitRepositoryProvider()
+            identity = provider.discover(str(self._workspace_root))
+            if identity is None:
+                return None
+            pre = provider.observe(identity)
+            self._store.put_repository_observation(
+                observation_sha256=pre.observation_sha256,
+                observation_payload=pre.model_dump(mode="json"),
+                request_id=request_id,
+                run_id=run_id,
+                generation=generation,
+                effect_id=effect_id,
+                repository_id=pre.identity.repository_id,
+                head_commit=pre.revision.head_commit,
+                observed_at_ms=pre.observed_at_ms,
+                recorded_at_ms=time.time_ns() // 1_000_000,
+            )
+            return (identity, pre)
+        except Exception:
+            return None
+
+    def _bind_repository_sensor_post(
+        self, *, sensor_pre, subject_effect_id: str, directive,
+    ) -> bool:
+        """Final P0-2: the POST window is likewise captured by the
+        independent sensor (delta from the PRE revision) after the
+        runtime mutation, then both observations are bound to the NEW
+        subject effect. A sensing failure is NEVER a success."""
+        try:
+            from v3.repository_perception import LocalGitRepositoryProvider
+
+            identity, pre = sensor_pre
+            provider = LocalGitRepositoryProvider()
+            post = provider.observe_delta(identity, pre.revision)
+            self._store.put_repository_observation(
+                observation_sha256=post.observation_sha256,
+                observation_payload=post.model_dump(mode="json"),
+                request_id=directive.request_id,
+                run_id=directive.run_id,
+                generation=directive.generation,
+                effect_id=subject_effect_id,
+                repository_id=post.identity.repository_id,
+                head_commit=post.revision.head_commit,
+                observed_at_ms=post.observed_at_ms,
+                recorded_at_ms=time.time_ns() // 1_000_000,
+            )
+            for role, observation in (("PRE", pre), ("POST", post)):
                 self._store.put_repository_observation_binding(
-                    observation_sha256=str(payload["observation_sha256"]),
+                    observation_sha256=observation.observation_sha256,
                     request_id=directive.request_id,
                     run_id=directive.run_id,
                     generation=directive.generation,
                     subject_effect_id=subject_effect_id,
                     observation_role=role,
-                    observed_at_ms=observed_at,
-                    recorded_at_ms=observed_at + 2,
+                    observed_at_ms=observation.observed_at_ms,
+                    recorded_at_ms=observation.observed_at_ms + 2,
                 )
             return True
-        except (KeyError, TypeError, ValueError, StoreError):
+        except Exception:
             return False
 
     def _register_repair_artifacts(

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -159,6 +159,7 @@ from .skill_authority import SkillAuthority
 from .store import (
     ActiveRequestActivation,
     GatewayStateStore,
+    StoreCasConflict,
     StoreConflictError,
     StoreError,
 )
@@ -2150,23 +2151,42 @@ class GatewayOrchestrationWorker:
                     ),
                     execution_effect_ids=(repair_effect.effect_id,),
                 )
+        # Real-time lease fencing: the boundary-crossing time is taken
+        # HERE — after policy, ticketing and repository PRE sensing,
+        # immediately before the CAS — never the stale issued_at. A
+        # lease that expired in the wall-clock world cannot cross on an
+        # old timestamp.
+        start_at_ms = time.time_ns() // 1_000_000
         try:
             # Final P0-1/P0-2: ONE atomic, CLAIM-FENCED transition crosses
             # BOTH authorities (EffectLedger CLAIMED→STARTED + binding
             # RESERVED→STARTED) BEFORE the runtime. The CAS holds on the
-            # caller's claim id + fencing revision + live lease — a
-            # claim that lost a takeover can never reach the runtime.
-            start_outcome = self._store.start_repair_execution(
-                repair_directive_id=directive.repair_directive_id,
-                effect_id=repair_effect.effect_id,
-                started_at_ms=issued_at,
-                dispatch_claim_id=str(
-                    reserved["binding"]["dispatch_claim_id"]
-                ),
-                expected_claim_revision=int(
-                    reserved["binding"]["claim_revision"]
-                ),
-            )
+            # caller's claim id + fencing revision + lease live AT THE
+            # REAL CROSSING TIME — a claim that lost a takeover OR let
+            # its lease expire can never reach the runtime.
+            try:
+                start_outcome = self._store.start_repair_execution(
+                    repair_directive_id=directive.repair_directive_id,
+                    effect_id=repair_effect.effect_id,
+                    started_at_ms=start_at_ms,
+                    dispatch_claim_id=str(
+                        reserved["binding"]["dispatch_claim_id"]
+                    ),
+                    expected_claim_revision=int(
+                        reserved["binding"]["claim_revision"]
+                    ),
+                )
+            except StoreCasConflict:
+                # This worker's lease expired before the real crossing
+                # time (no takeover yet): hand the attempt over without
+                # executing anything — a future claim may take over.
+                return RepairDispatchResult(
+                    execution_outcome="ALREADY_CLAIMED",
+                    produced_subject_identity=(
+                        directive.effective_subject_identity
+                    ),
+                    execution_effect_ids=(),
+                )
             if start_outcome["outcome"] != "STARTED":
                 # The boundary was already crossed (by this worker
                 # before a crash, or by a takeover winner): the runtime

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -2652,12 +2652,19 @@ class GatewayOrchestrationWorker:
                     coordinator = VerificationRepairCoordinator(
                         store=self._store,
                     )
-                    dispositions = coordinator.process_readiness(
+                    coordinator.process_readiness(
                         plan=active_plan,
                         readiness=readiness,
                     )
-                    if dispositions:
-                        verification_disposition = dispositions[0]
+                    # M5 Final #7: read CURRENT disposition from Store
+                    # (authoritative source, not caller-side dispositions[0])
+                    verification_disposition = self._store.get_current_verification_disposition(
+                        request_id=request_id,
+                        run_id=run_id,
+                        generation=generation.generation,
+                        verification_plan_id=active_plan.verification_plan_id,
+                        readiness_sha256=readiness.readiness_sha256,
+                    )
             decision = evaluate_desktop_completion(
                 objects=self._objects,
                 facts=self._facts,

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -1778,6 +1778,502 @@ class GatewayOrchestrationWorker:
             created_at_ms=observed_at_ms,
         )
 
+    def _dispatch_repair_directive(
+        self,
+        *,
+        directive,
+        activation,
+        envelope,
+        manifest,
+        action,
+        permission,
+        outer_registry,
+        transport,
+        arguments,
+        grants,
+        resources,
+        life,
+        life_evidence_ref,
+        workspace_id,
+        output_root_id,
+        artifact_intent_id,
+        request_id,
+        run_id,
+        run_sequence,
+        generation,
+        artifact_manifests,
+    ):
+        """M5 Final #2: execute a RepairDirective through the EXISTING runtime.
+
+        Same authorities as the primary execution: PolicyEngine decision,
+        RuntimeTicketAuthority signature, BackendClient runtime, and the
+        ArtifactGate/QC pipeline. This is a bridge, not a second runtime
+        — every reality change still lands in the one EffectLedger.
+        Returns a RepairDispatchResult; runtime failures are returned as
+        outcomes (never raised) so the repair loop can record them.
+        """
+        from total_gateway.verification_repair_coordinator import (
+            RepairDispatchResult,
+        )
+
+        issued_at = time.time_ns() // 1_000_000
+        repair_arguments = dict(arguments)
+        repair_arguments["repair_goal"] = {
+            "repair_goal_kind": directive.repair_goal_kind,
+            "plan_entry_id": directive.plan_entry_id,
+            "predicate_id": directive.predicate_id,
+            "allowed_target_refs": list(directive.allowed_target_refs),
+            "repair_constraints": list(directive.repair_constraints),
+            "execution_budget_ms": directive.execution_budget_ms,
+        }
+        arguments_hash = canonical_sha256(repair_arguments)
+        effect_intent = canonical_sha256(
+            {
+                "action_id": action.action_id,
+                "action_version": action.version,
+                "arguments_hash": arguments_hash,
+                "capability_manifest_hash": manifest.sha256,
+                "life_snapshot_hash": life.snapshot.sha256,
+                "repair_directive_id": directive.repair_directive_id,
+            }
+        )
+        repair_effect = derive_effect_identity(
+            request_id=request_id,
+            run_id=run_id,
+            run_sequence=run_sequence,
+            generation=generation.generation,
+            effect_kind="execution",
+            ordinal=1,
+            intent_sha256=effect_intent,
+        )
+        claim = EffectClaim(
+            effect_id=repair_effect.effect_id,
+            request_id=request_id,
+            run_id=run_id,
+            run_sequence=run_sequence,
+            generation=generation.generation,
+            effect_kind="execution",
+            ordinal=1,
+            intent_sha256=effect_intent,
+            owner_component_id="tiangong-backend",
+            claimed_at_ms=issued_at,
+            claim_sha256="0" * 64,
+        ).with_computed_sha256()
+        existing_effect, created = self._store.claim_effect(claim)
+        if not created and existing_effect.result is not None:
+            # Crash recovery: this directive's effect already completed.
+            status = existing_effect.result.status
+            return RepairDispatchResult(
+                execution_outcome=(
+                    "DISPATCHED"
+                    if status == "SUCCEEDED"
+                    else "EXECUTION_AMBIGUOUS"
+                    if status == "AMBIGUOUS"
+                    else "EXECUTION_FAILED"
+                ),
+                produced_subject_identity=directive.effective_subject_identity,
+                execution_effect_ids=(repair_effect.effect_id,),
+            )
+
+        authorization_source_refs = tuple(
+            sorted(
+                (
+                    SourceRef(
+                        source_type="CURRENT_USER_INSTRUCTION",
+                        object_id=request_id,
+                        object_revision=1,
+                        sha256=canonical_sha256(envelope.text or ""),
+                    ),
+                    SourceRef(
+                        source_type="PREAUTHORIZED_USER_FACT",
+                        object_id=life_evidence_ref,
+                        object_revision=1,
+                        sha256=life_evidence_ref[4:],
+                    ),
+                ),
+                key=lambda ref: ref.sort_key(),
+            )
+        )
+        intent = ActionIntent(
+            intent_id="intent-repair-" + canonical_sha256(
+                {
+                    "repair_directive_id": directive.repair_directive_id,
+                    "effect_id": repair_effect.effect_id,
+                    "arguments_sha256": arguments_hash,
+                    "created_at_ms": issued_at,
+                }
+            ),
+            source="chat",
+            life_id=life.snapshot.identity_ref,
+            principal_scope_hash=envelope.principal_scope_hash,
+            conversation_scope_hash=envelope.conversation_scope_hash,
+            request_id=request_id,
+            run_id=run_id,
+            generation=generation.generation,
+            action_id=action.action_id,
+            action_version=action.version,
+            arguments_sha256=arguments_hash,
+            workspace_id=workspace_id,
+            workspace_scope_hash=self._omni_grants.workspace_scope_hash,
+            input_object_refs=tuple(sorted(item.object_id for item in grants)),
+            requested_side_effects=permission.allowed_side_effects,
+            requested_resources=resources,
+            source_refs=authorization_source_refs,
+            payload_sha256=arguments_hash,
+            attachment_set_sha256=canonical_sha256(
+                [
+                    {"object_id": item.object_id, "revision": item.revision, "sha256": item.sha256}
+                    for item in grants
+                ]
+            ),
+            life_snapshot_revision=life.snapshot.revision,
+            life_snapshot_sha256=life.snapshot.sha256,
+            created_at_ms=issued_at,
+            expires_at_ms=issued_at + 60_000,
+            intent_sha256="0" * 64,
+        ).with_computed_sha256()
+        knobs = derive_impact_knobs(
+            action.action_id,
+            None,
+            scan_args=False,
+            external_content_count=0,
+        )
+        impact = compute_action_impact(
+            intent,
+            permission,
+            affected_internal_nodes=("node_tiangong_backend_model_runtime",),
+            external_recipient_count=knobs["external_recipient_count"],
+            credential_scope_milli=knobs["credential_scope_milli"],
+            privacy_scope_milli=knobs["privacy_scope_milli"],
+            blast_radius_milli=knobs["blast_radius_milli"],
+            irreversibility_milli=knobs["irreversibility_milli"],
+            uncertainty_milli=knobs["uncertainty_milli"],
+            created_at_ms=issued_at,
+        )
+        policy_snapshot_sha256 = canonical_sha256(
+            {
+                "policy": "tiangong.gateway.model-run.autonomous-a0-a4.a5-deny.v3",
+                "registry_sha256": outer_registry.registry_sha256,
+            }
+        )
+        decision = PolicyEngine(
+            outer_registry,
+            policy_snapshot_sha256=policy_snapshot_sha256,
+            skill_catalog_hash=self._release_manifest.skill_catalog_sha256,
+            capability_manifest_hash=manifest.sha256,
+            component_manifest_hash=self._components.manifest_sha256,
+        ).evaluate(
+            intent,
+            impact,
+            decided_at_ms=issued_at,
+            authorization_source_refs=authorization_source_refs,
+        )
+        if decision.outcome != "ALLOW":
+            self._policy_evidence.record_evaluation(
+                intent=intent,
+                impact=impact,
+                permission=permission,
+                registry=outer_registry,
+                decision=decision,
+                ticket=None,
+                grant=None,
+                observed_at_ms=issued_at,
+            )
+            return RepairDispatchResult(
+                execution_outcome="EXECUTION_FAILED",
+                produced_subject_identity=directive.effective_subject_identity,
+                execution_effect_ids=(repair_effect.effect_id,),
+            )
+        payload = ExecutionTicketPayload(
+            ticket_id="execution-ticket-" + canonical_sha256(
+                {
+                    "effect_id": repair_effect.effect_id,
+                    "decision_sha256": decision.decision_sha256,
+                    "repair_directive_id": directive.repair_directive_id,
+                }
+            ),
+            issued_at_ms=issued_at,
+            not_before_ms=issued_at,
+            expires_at_ms=issued_at + 60_000,
+            gateway_epoch=self._epoch,
+            request_id=request_id,
+            run_id=run_id,
+            generation=generation.generation,
+            effect_id=repair_effect.effect_id,
+            channel=envelope.channel,
+            tenant_id=envelope.tenant_id,
+            link_account_id=envelope.link_account_id,
+            conversation_scope_hash=envelope.conversation_scope_hash,
+            principal_scope_hash=envelope.principal_scope_hash,
+            capability_manifest_hash=manifest.sha256,
+            policy_snapshot_hash=decision.policy_snapshot_sha256,
+            decision_id=decision.decision_id,
+            decision_sha256=decision.decision_sha256,
+            impact_id=impact.impact_id,
+            impact_sha256=impact.impact_sha256,
+            action_permission_sha256=permission.permission_sha256,
+            component_manifest_hash=self._components.manifest_sha256,
+            life_snapshot_revision=life.snapshot.revision,
+            life_snapshot_hash=life.snapshot.sha256,
+            risk_class=decision.computed_risk,
+            action_id=action.action_id,
+            action_version=action.version,
+            argument_schema_sha256=action.argument_schema_sha256,
+            arguments_hash=arguments_hash,
+            workspace_id=workspace_id,
+            input_objects=grants,
+            object_grants_sha256=canonical_sha256(
+                [item.model_dump(mode="json") for item in grants]
+            ),
+            output_root_id=output_root_id,
+            artifact_intent_id=artifact_intent_id,
+            max_output_bytes=resources.max_output_bytes,
+            max_runtime_ms=resources.max_runtime_ms,
+            max_tool_calls=resources.max_tool_calls,
+            resource_envelope_sha256=resources.sha256(),
+            allowed_side_effects=permission.allowed_side_effects,
+            side_effect_envelope_sha256=canonical_sha256(
+                {"allowed_side_effects": list(permission.allowed_side_effects)}
+            ),
+            nonce="execution-nonce-" + canonical_sha256(
+                {
+                    "effect_id": repair_effect.effect_id,
+                    "decision_sha256": decision.decision_sha256,
+                    "issued_at_ms": issued_at,
+                }
+            ),
+        )
+        ticket = self._authority.execution_signer.sign_execution(payload)
+        self._policy_evidence.record_evaluation(
+            intent=intent,
+            impact=impact,
+            permission=permission,
+            registry=outer_registry,
+            decision=decision,
+            ticket=ticket,
+            grant=None,
+            observed_at_ms=issued_at,
+        )
+        self._omni_grants.register(
+            ticket,
+            life_id=life.snapshot.identity_ref,
+            life_evidence_ref=life_evidence_ref,
+            session_id=envelope.conversation_ref,
+            registered_at_ms=issued_at,
+            authority_expires_at_ms=issued_at + directive.execution_budget_ms,
+        )
+        try:
+            self._store.mark_effect_started(
+                repair_effect.effect_id, started_at_ms=issued_at
+            )
+
+            def _execute_repair() -> Any:
+                return BackendClient(
+                    transport,
+                    self._store,
+                    ticket_consumer_instance_id=(
+                        "compat-frozen-inprocess-" + self._instance_id
+                    ),
+                ).execute(
+                    ticket,
+                    repair_arguments,
+                    capability_manifest=manifest,
+                    trust_bundle=self._authority.execution_trust_bundle(
+                        gateway_epoch=self._epoch,
+                        now_ms=issued_at,
+                    ),
+                    now_ms=issued_at,
+                    expected_gateway_epoch=self._epoch,
+                    minimum_generation=generation.generation,
+                )
+
+            try:
+                response = _EXECUTION_WATCHDOG_POOL.submit(
+                    _execute_repair
+                ).result(
+                    timeout=max(1.0, directive.execution_budget_ms / 1000.0)
+                )
+            except concurrent.futures.TimeoutError:
+                self._complete_repair_effect(
+                    repair_effect.effect_id, "AMBIGUOUS", "repair.execution_timeout"
+                )
+                return RepairDispatchResult(
+                    execution_outcome="EXECUTION_AMBIGUOUS",
+                    produced_subject_identity=directive.effective_subject_identity,
+                    execution_effect_ids=(repair_effect.effect_id,),
+                )
+        except BackendClientError as exc:
+            status = "AMBIGUOUS" if exc.ambiguous else "FAILED_FINAL"
+            self._complete_repair_effect(
+                repair_effect.effect_id, status, exc.code
+            )
+            return RepairDispatchResult(
+                execution_outcome=(
+                    "EXECUTION_AMBIGUOUS" if status == "AMBIGUOUS" else "EXECUTION_FAILED"
+                ),
+                produced_subject_identity=directive.effective_subject_identity,
+                execution_effect_ids=(repair_effect.effect_id,),
+            )
+        finally:
+            self._omni_grants.unregister(ticket.payload.ticket_id)
+
+        response_status = str(
+            getattr(getattr(response, "result", None), "status", "FAILED_FINAL")
+        )
+        if response_status != "SUCCEEDED":
+            self._complete_repair_effect(
+                repair_effect.effect_id,
+                "AMBIGUOUS" if response_status == "AMBIGUOUS" else "FAILED_FINAL",
+                getattr(getattr(response, "result", None), "error_code", None)
+                or "repair.execution.failed",
+            )
+            return RepairDispatchResult(
+                execution_outcome=(
+                    "EXECUTION_AMBIGUOUS"
+                    if response_status == "AMBIGUOUS"
+                    else "EXECUTION_FAILED"
+                ),
+                produced_subject_identity=directive.effective_subject_identity,
+                execution_effect_ids=(repair_effect.effect_id,),
+            )
+        result_payload = (
+            response.result_payload
+            if isinstance(getattr(response, "result_payload", None), dict)
+            else {}
+        )
+        produced_count = self._register_repair_artifacts(
+            response=response,
+            result_payload=result_payload,
+            directive=directive,
+            activation=activation,
+            observed_at_ms=time.time_ns() // 1_000_000,
+            artifact_intent_id=artifact_intent_id,
+            run_sequence=run_sequence,
+            workspace_id=workspace_id,
+            envelope=envelope,
+            artifact_manifests=artifact_manifests,
+        )
+        self._complete_repair_effect(
+            repair_effect.effect_id, "SUCCEEDED", None
+        )
+        produced_subject = (
+            artifact_manifests[-1].artifact_revision_id
+            if produced_count
+            else directive.effective_subject_identity
+        )
+        return RepairDispatchResult(
+            execution_outcome="DISPATCHED",
+            produced_subject_identity=produced_subject,
+            execution_effect_ids=(repair_effect.effect_id,),
+        )
+
+    def _complete_repair_effect(
+        self, effect_id: str, status: str, error_code: str | None
+    ) -> None:
+        observed_at_ms = time.time_ns() // 1_000_000
+        result = EffectResult(
+            result_id="effect-result-" + effect_id[4:20],
+            effect_id=effect_id,
+            status=status,
+            fact_id="fact-effect-" + effect_id[4:20],
+            evidence_sha256=canonical_sha256(
+                {"code": error_code, "status": status}
+            ),
+            error_code=error_code,
+            observed_at_ms=observed_at_ms,
+            result_sha256="0" * 64,
+        ).with_computed_sha256()
+        self._store.complete_effect(result)
+
+    def _register_repair_artifacts(
+        self,
+        *,
+        response,
+        result_payload,
+        directive,
+        activation,
+        observed_at_ms,
+        artifact_intent_id,
+        run_sequence,
+        workspace_id,
+        envelope,
+        artifact_manifests,
+    ) -> int:
+        """Run repaired artifact descriptors through the SAME
+        ArtifactGate/QC pipeline; append passing manifests. Returns the
+        number of newly registered manifests."""
+        raw_artifacts = result_payload.get("artifacts")
+        if not isinstance(raw_artifacts, list):
+            return 0
+        gate = ArtifactGate(self._objects, self._facts)
+        docx_qc = DocxQcService(self._objects, self._facts)
+        integrity_qc = ArtifactIntegrityQcService(self._objects, self._facts)
+        producer_fact_id = (
+            getattr(getattr(response, "result", None), "fact_ids", None)
+            or ("fact-repair-" + directive.repair_directive_id[4:20],)
+        )[0]
+        produced = 0
+        for index, item in enumerate(raw_artifacts):
+            if not isinstance(item, dict):
+                continue
+            try:
+                accepted = gate.accept(
+                    ArtifactCandidate(
+                        producer_fact_id=producer_fact_id,
+                        object_id=str(item["object_id"]),
+                        expected_sha256=str(item["sha256"]),
+                        expected_size_bytes=int(item["size_bytes"]),
+                        run_sequence=run_sequence,
+                        artifact_intent_id=(
+                            f"{artifact_intent_id}"
+                            f"-r{directive.repair_attempt_no}-{index + 1}"
+                        ),
+                        revision=1,
+                        workspace_id=workspace_id,
+                        filename=str(item["filename"]),
+                        declared_mime=str(item["mime"]),
+                        format_id=str(item["format_id"]),
+                        created_at_ms=observed_at_ms,
+                    )
+                )
+                if accepted.manifest.format_id == "docx":
+                    docx_minimum_words = 30
+                    docx_items_hint = re.search(
+                        r"各?(\d+)\s*[条点项]", envelope.text or ""
+                    )
+                    if docx_items_hint:
+                        docx_minimum_words = max(
+                            30, int(docx_items_hint.group(1)) * 12
+                        )
+                    outcome = docx_qc.evaluate(
+                        accepted,
+                        run_sequence=run_sequence,
+                        policy=DocxQcPolicy(
+                            minimum_word_count=docx_minimum_words,
+                            maximum_word_count=10_000_000,
+                        ),
+                        checked_at_ms=observed_at_ms,
+                    )
+                else:
+                    outcome = integrity_qc.evaluate(
+                        accepted,
+                        run_sequence=run_sequence,
+                        checked_at_ms=observed_at_ms,
+                    )
+                if outcome.passed:
+                    artifact_manifests.append(outcome.registration.record.manifest)
+                    produced += 1
+            except (
+                ArtifactGateError,
+                ArtifactIntegrityQcError,
+                DocxQcError,
+                KeyError,
+                TypeError,
+                ValueError,
+            ):
+                continue
+        return produced
+
     def process(self, activation: ActiveRequestActivation) -> None:
         envelope = activation.envelope
         generation = activation.generation
@@ -2644,20 +3140,71 @@ class GatewayOrchestrationWorker:
                     evaluated_at_ms=time.time_ns() // 1_000_000,
                     artifact_manifests=tuple(artifacts),
                 )
-                # M5 Final §3: FAIL → RepairCoordinator → disposition
+                # M5 Final #2: FAIL → the FULL repair loop — directive →
+                # EXISTING runtime dispatch → successor → SAME-predicate
+                # re-verification. Never stop at the disposition.
                 if not readiness.verification_ready:
                     from total_gateway.verification_repair_coordinator import (
+                        RepairDispatchResult,
                         VerificationRepairCoordinator,
                     )
                     coordinator = VerificationRepairCoordinator(
                         store=self._store,
                     )
-                    coordinator.process_readiness(
+
+                    def _repair_dispatch(directive):
+                        # Bridge to the EXISTING runtime: the same
+                        # PolicyEngine → ExecutionTicket → BackendClient →
+                        # ArtifactGate/QC authorities as the primary
+                        # execution. No second runtime.
+                        return self._dispatch_repair_directive(
+                            directive=directive,
+                            activation=activation,
+                            envelope=envelope,
+                            manifest=manifest,
+                            action=action,
+                            permission=permission,
+                            outer_registry=outer_registry,
+                            transport=transport,
+                            arguments=arguments,
+                            grants=grants,
+                            resources=resources,
+                            life=life,
+                            life_evidence_ref=life_evidence_ref,
+                            workspace_id=workspace_id,
+                            output_root_id=output_root_id,
+                            artifact_intent_id=artifact_intent_id,
+                            request_id=request_id,
+                            run_id=run_id,
+                            run_sequence=run_sequence,
+                            generation=generation,
+                            artifact_manifests=artifacts,
+                        )
+
+                    def _repair_reverify():
+                        reverify_executor = VerificationPlanExecutor(
+                            snapshot=_verification_snapshot(
+                                self._store,
+                                active_plan.registry_snapshot_sha256,
+                            ),
+                            store=self._store,
+                            object_store=self._objects,
+                            fact_ledger=self._facts,
+                            plan=active_plan,
+                        )
+                        return reverify_executor.execute(
+                            evaluated_at_ms=time.time_ns() // 1_000_000,
+                            artifact_manifests=tuple(artifacts),
+                        )
+
+                    readiness, _ = coordinator.execute_repair_loop(
                         plan=active_plan,
                         readiness=readiness,
+                        dispatch=_repair_dispatch,
+                        reverify=_repair_reverify,
                     )
                     # M5 Final #7: read CURRENT disposition from Store
-                    # (authoritative source, not caller-side dispositions[0])
+                    # (authoritative source, bound to the final readiness)
                     verification_disposition = self._store.get_current_verification_disposition(
                         request_id=request_id,
                         run_id=run_id,

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -1851,6 +1851,31 @@ class GatewayOrchestrationWorker:
             ordinal=1,
             intent_sha256=effect_intent,
         )
+        # Final P0-1: the Store dispatch boundary is claimed BEFORE the
+        # effect ledger — atomically deciding whether THIS worker may
+        # cross into the runtime for this (plan entry, attempt).
+        reserved = self._store.reserve_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            repair_directive_sha256=directive.directive_sha256,
+            plan_entry_id=directive.plan_entry_id,
+            repair_attempt_no=directive.repair_attempt_no,
+            request_id=request_id,
+            run_id=run_id,
+            generation=generation.generation,
+            effect_id=repair_effect.effect_id,
+            effect_intent_sha256=effect_intent,
+            reserved_at_ms=issued_at,
+        )
+        if reserved["outcome"] != "EXECUTE":
+            # Another coordinator owns this attempt — this worker must
+            # not execute the runtime at all.
+            return RepairDispatchResult(
+                execution_outcome="ALREADY_CLAIMED",
+                produced_subject_identity=(
+                    directive.effective_subject_identity
+                ),
+                execution_effect_ids=(),
+            )
         claim = EffectClaim(
             effect_id=repair_effect.effect_id,
             request_id=request_id,
@@ -1866,17 +1891,27 @@ class GatewayOrchestrationWorker:
         ).with_computed_sha256()
         existing_effect, created = self._store.claim_effect(claim)
         if not created and existing_effect.result is not None:
-            # Crash recovery: this directive's effect already completed.
-            status = existing_effect.result.status
+            # The effect ledger is already terminal; the binding (not
+            # this branch) owns crash recovery — surface the binding
+            # state so the caller never re-executes the runtime.
+            state = str(reserved["binding"]["state"])
+            if state == "SUCCEEDED":
+                return RepairDispatchResult(
+                    execution_outcome="DISPATCHED",
+                    produced_subject_identity=str(
+                        reserved["binding"]["produced_subject_identity"]
+                    ),
+                    execution_effect_ids=(repair_effect.effect_id,),
+                )
             return RepairDispatchResult(
                 execution_outcome=(
-                    "DISPATCHED"
-                    if status == "SUCCEEDED"
-                    else "EXECUTION_AMBIGUOUS"
-                    if status == "AMBIGUOUS"
+                    "EXECUTION_AMBIGUOUS"
+                    if state in ("SIDE_EFFECT_STARTED", "AMBIGUOUS")
                     else "EXECUTION_FAILED"
                 ),
-                produced_subject_identity=directive.effective_subject_identity,
+                produced_subject_identity=(
+                    directive.effective_subject_identity
+                ),
                 execution_effect_ids=(repair_effect.effect_id,),
             )
 
@@ -1984,6 +2019,16 @@ class GatewayOrchestrationWorker:
                 grant=None,
                 observed_at_ms=issued_at,
             )
+            # Definite non-execution: terminalize as FAILED_FINAL (the
+            # runtime was never entered).
+            self._store.complete_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                state="FAILED_FINAL",
+                produced_subject_identity="",
+                produced_subject_kind=directive.subject_kind,
+                runtime_result_ref="policy-rejected",
+                completed_at_ms=issued_at,
+            )
             return RepairDispatchResult(
                 execution_outcome="EXECUTION_FAILED",
                 produced_subject_identity=directive.effective_subject_identity,
@@ -2071,6 +2116,13 @@ class GatewayOrchestrationWorker:
             self._store.mark_effect_started(
                 repair_effect.effect_id, started_at_ms=issued_at
             )
+            # Final P0: cross the binding's no-return boundary BEFORE
+            # the runtime — after this point recovery is RECONCILE, not
+            # replay.
+            self._store.mark_repair_execution_started(
+                repair_directive_id=directive.repair_directive_id,
+                started_at_ms=issued_at,
+            )
 
             def _execute_repair() -> Any:
                 return BackendClient(
@@ -2102,6 +2154,14 @@ class GatewayOrchestrationWorker:
                 self._complete_repair_effect(
                     repair_effect.effect_id, "AMBIGUOUS", "repair.execution_timeout"
                 )
+                self._store.complete_repair_execution(
+                    repair_directive_id=directive.repair_directive_id,
+                    state="AMBIGUOUS",
+                    produced_subject_identity="",
+                    produced_subject_kind=directive.subject_kind,
+                    runtime_result_ref="timeout",
+                    completed_at_ms=time.time_ns() // 1_000_000,
+                )
                 return RepairDispatchResult(
                     execution_outcome="EXECUTION_AMBIGUOUS",
                     produced_subject_identity=directive.effective_subject_identity,
@@ -2111,6 +2171,14 @@ class GatewayOrchestrationWorker:
             status = "AMBIGUOUS" if exc.ambiguous else "FAILED_FINAL"
             self._complete_repair_effect(
                 repair_effect.effect_id, status, exc.code
+            )
+            self._store.complete_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                state=("AMBIGUOUS" if status == "AMBIGUOUS" else "FAILED_FINAL"),
+                produced_subject_identity="",
+                produced_subject_kind=directive.subject_kind,
+                runtime_result_ref=exc.code or "",
+                completed_at_ms=time.time_ns() // 1_000_000,
             )
             return RepairDispatchResult(
                 execution_outcome=(
@@ -2126,11 +2194,25 @@ class GatewayOrchestrationWorker:
             getattr(getattr(response, "result", None), "status", "FAILED_FINAL")
         )
         if response_status != "SUCCEEDED":
+            terminal = (
+                "AMBIGUOUS" if response_status == "AMBIGUOUS" else "FAILED_FINAL"
+            )
             self._complete_repair_effect(
                 repair_effect.effect_id,
-                "AMBIGUOUS" if response_status == "AMBIGUOUS" else "FAILED_FINAL",
+                terminal,
                 getattr(getattr(response, "result", None), "error_code", None)
                 or "repair.execution.failed",
+            )
+            self._store.complete_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                state=terminal,
+                produced_subject_identity="",
+                produced_subject_kind=directive.subject_kind,
+                runtime_result_ref=(
+                    getattr(getattr(response, "result", None), "error_code", "")
+                    or ""
+                ),
+                completed_at_ms=time.time_ns() // 1_000_000,
             )
             return RepairDispatchResult(
                 execution_outcome=(
@@ -2158,14 +2240,16 @@ class GatewayOrchestrationWorker:
             envelope=envelope,
             artifact_manifests=artifact_manifests,
         )
-        self._complete_repair_effect(
-            repair_effect.effect_id, "SUCCEEDED", None
-        )
         # P0-2: the successor is the NEW authoritative reality object
         # per subject kind — artifact → new revision, effect → the
         # re-execution effect itself, repository → the mutation effect
-        # with its PRE/POST observation window.
+        # with its PRE/POST observation window. The window is bound
+        # BEFORE the binding is marked SUCCEEDED, so a crash in between
+        # leaves an AMBIGUOUS (reconcilable) binding, never a fake
+        # success; a successful binding carries the produced subject
+        # and the runtime result reference for recovery.
         produced_subject = directive.effective_subject_identity
+        repository_window_ok = True
         if directive.subject_kind == "artifact":
             if produced_count:
                 produced_subject = (
@@ -2174,13 +2258,52 @@ class GatewayOrchestrationWorker:
         elif directive.subject_kind == "effect":
             produced_subject = repair_effect.effect_id
         elif directive.subject_kind == "repository":
-            if self._bind_repository_repair_observations(
+            repository_window_ok = self._bind_repository_repair_observations(
                 result_payload=result_payload,
                 subject_effect_id=repair_effect.effect_id,
                 directive=directive,
                 observed_at_ms=time.time_ns() // 1_000_000,
-            ):
+            )
+            if repository_window_ok:
                 produced_subject = repair_effect.effect_id
+        if not repository_window_ok:
+            # The mutation may have happened but its window is unproven
+            # — that is AMBIGUOUS, never a silent failure.
+            self._complete_repair_effect(
+                repair_effect.effect_id, "AMBIGUOUS", "repair.repo_window_invalid"
+            )
+            self._store.complete_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                state="AMBIGUOUS",
+                produced_subject_identity="",
+                produced_subject_kind=directive.subject_kind,
+                runtime_result_ref="repo-window-invalid",
+                completed_at_ms=time.time_ns() // 1_000_000,
+            )
+            return RepairDispatchResult(
+                execution_outcome="EXECUTION_AMBIGUOUS",
+                produced_subject_identity=directive.effective_subject_identity,
+                execution_effect_ids=(repair_effect.effect_id,),
+            )
+        # Persist the produced reality FIRST, then terminalize the
+        # binding — recovery reads the binding without re-running the
+        # runtime.
+        self._store.complete_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            state="SUCCEEDED",
+            produced_subject_identity=produced_subject,
+            produced_subject_kind=directive.subject_kind,
+            runtime_result_ref=(
+                getattr(response, "response_sha256", None) or "runtime-result"
+            ),
+            runtime_result_sha256=(
+                getattr(response, "response_sha256", "") or ""
+            ),
+            completed_at_ms=time.time_ns() // 1_000_000,
+        )
+        self._complete_repair_effect(
+            repair_effect.effect_id, "SUCCEEDED", None
+        )
         return RepairDispatchResult(
             execution_outcome="DISPATCHED",
             produced_subject_identity=produced_subject,

--- a/src/total_gateway/outcome_oracles/repository_state.py
+++ b/src/total_gateway/outcome_oracles/repository_state.py
@@ -157,7 +157,12 @@ class RepositoryStateOracle:
         status, reason_codes, observation, lineage, repo_id = self._evaluate_to_status(
             subject_effect_id, pre_binding_id, post_binding_id, predicate
         )
-        subject_identity = f"{repo_id}:{post_binding_id}"
+        # M5 Final P0-2: the record subject is the STABLE mutation effect
+        # id — the same identity space the plan entry binds, the Store
+        # successor chain advances, and the executor resolves bindings
+        # with. The observation window identity (repo_id + post binding)
+        # stays fully auditable in evidence_refs below.
+        subject_identity = subject_effect_id
         return assemble_record(
             descriptor=self._descriptor,  # type: ignore[attr-defined]
             snapshot=self._snapshot,  # type: ignore[attr-defined]

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -10660,6 +10660,24 @@ class GatewayStateStore:
             )
             return True
 
+    def list_all_verification_dispositions(
+        self, *, request_id: str, run_id: str, generation: int,
+    ):
+        from contracts.verification import VerificationDisposition
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT disposition_json FROM verification_disposition"
+                " WHERE request_id = ? AND run_id = ? AND generation = ?"
+                " ORDER BY decided_at_ms",
+                (request_id, run_id, generation),
+            ).fetchall()
+            return tuple(
+                VerificationDisposition.model_validate_json(
+                    r["disposition_json"], strict=True
+                )
+                for r in rows
+            )
+
     def get_current_verification_disposition(
         self,
         *,

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -1824,6 +1824,41 @@ _MIGRATION_V29_STATEMENTS = (
     CREATE UNIQUE INDEX repair_attempt_number_idx
         ON repair_attempt (plan_entry_id, repair_attempt_no)
     """,
+    """
+    CREATE TABLE repair_execution_binding (
+        repair_directive_id TEXT NOT NULL PRIMARY KEY,
+        repair_directive_sha256 TEXT NOT NULL
+            CHECK (length(repair_directive_sha256) = 64
+                   AND repair_directive_sha256 NOT GLOB '*[^0-9a-f]*'),
+        plan_entry_id TEXT NOT NULL,
+        repair_attempt_no INTEGER NOT NULL CHECK (repair_attempt_no >= 1),
+        request_id TEXT NOT NULL,
+        run_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK (generation >= 0),
+        state TEXT NOT NULL CHECK (
+            state IN ('RESERVED','SIDE_EFFECT_STARTED','SUCCEEDED',
+                      'FAILED_FINAL','AMBIGUOUS')
+        ),
+        effect_id TEXT NOT NULL UNIQUE,
+        effect_intent_sha256 TEXT NOT NULL
+            CHECK (length(effect_intent_sha256) = 64
+                   AND effect_intent_sha256 NOT GLOB '*[^0-9a-f]*'),
+        produced_subject_identity TEXT NOT NULL DEFAULT '',
+        produced_subject_kind TEXT NOT NULL DEFAULT '',
+        runtime_result_ref TEXT NOT NULL DEFAULT '',
+        runtime_result_sha256 TEXT NOT NULL DEFAULT ''
+            CHECK (runtime_result_sha256 = ''
+                   OR (length(runtime_result_sha256) = 64
+                       AND runtime_result_sha256 NOT GLOB '*[^0-9a-f]*')),
+        reserved_at_ms INTEGER NOT NULL CHECK (reserved_at_ms >= 0),
+        started_at_ms INTEGER CHECK (started_at_ms IS NULL OR started_at_ms >= 0),
+        completed_at_ms INTEGER CHECK (completed_at_ms IS NULL OR completed_at_ms >= 0)
+    ) STRICT
+    """,
+    """
+    CREATE UNIQUE INDEX repair_execution_binding_attempt_idx
+        ON repair_execution_binding (plan_entry_id, repair_attempt_no)
+    """,
 )
 
 _MIGRATIONS = (
@@ -10692,6 +10727,213 @@ class GatewayStateStore:
                 for r in rows
             )
 
+    # ------------------------------------------------------------------
+    # Repair Execution Binding — the Gateway's persistent dispatch
+    # boundary for repairs (final P0). NOT a second runtime: it is the
+    # Store-side authority that decides, atomically, WHICH worker may
+    # cross into the existing Runtime for a given (plan entry, attempt)
+    # — and it survives crashes so the produced reality can be
+    # recovered without re-executing the runtime.
+    # ------------------------------------------------------------------
+
+    def reserve_repair_execution(
+        self,
+        *,
+        repair_directive_id: str,
+        repair_directive_sha256: str,
+        plan_entry_id: str,
+        repair_attempt_no: int,
+        request_id: str,
+        run_id: str,
+        generation: int,
+        effect_id: str,
+        effect_intent_sha256: str,
+        reserved_at_ms: int,
+    ) -> dict:
+        """Atomically claim the repair dispatch authority.
+
+        Returns ``{"outcome": "EXECUTE"|"FOLLOW", "binding": dict}``.
+        - EXECUTE: this caller owns the (plan entry, attempt) slot and
+          may cross into the Runtime (binding is RESERVED).
+        - FOLLOW: another directive already owns the slot — the caller
+          must NOT execute the runtime, not even once.
+        Re-reserving the SAME directive idempotently returns EXECUTE
+        while it is still RESERVED (crash recovery before the
+        side-effect boundary) and FOLLOW once terminal or started.
+        """
+        with self._lock, self._write_transaction():
+            self._assert_request_binding_locked(
+                request_id=request_id,
+                run_id=run_id,
+                generation=generation,
+                recorded_at_ms=reserved_at_ms,
+            )
+            existing = self._binding_row_locked(repair_directive_id)
+            if existing is not None:
+                if (
+                    str(existing["plan_entry_id"]) != plan_entry_id
+                    or int(existing["repair_attempt_no"]) != repair_attempt_no
+                    or str(existing["request_id"]) != request_id
+                    or str(existing["run_id"]) != run_id
+                    or int(existing["generation"]) != generation
+                    or str(existing["effect_id"]) != effect_id
+                ):
+                    raise StoreConflictError(
+                        "repair execution binding identity was reused"
+                        " for different content"
+                    )
+                return {
+                    "outcome": (
+                        "EXECUTE"
+                        if str(existing["state"]) == "RESERVED"
+                        else "FOLLOW"
+                    ),
+                    "binding": dict(existing),
+                }
+            competing = self._connection.execute(
+                "SELECT * FROM repair_execution_binding"
+                " WHERE plan_entry_id = ? AND repair_attempt_no = ?",
+                (plan_entry_id, repair_attempt_no),
+            ).fetchone()
+            if competing is not None:
+                return {"outcome": "FOLLOW", "binding": dict(competing)}
+            self._connection.execute(
+                "INSERT INTO repair_execution_binding ("
+                "repair_directive_id, repair_directive_sha256,"
+                " plan_entry_id, repair_attempt_no, request_id, run_id,"
+                " generation, state, effect_id, effect_intent_sha256,"
+                " reserved_at_ms"
+                ") VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    repair_directive_id, repair_directive_sha256,
+                    plan_entry_id, repair_attempt_no, request_id, run_id,
+                    generation, "RESERVED", effect_id, effect_intent_sha256,
+                    reserved_at_ms,
+                ),
+            )
+            row = self._binding_row_locked(repair_directive_id)
+            assert row is not None
+            return {"outcome": "EXECUTE", "binding": dict(row)}
+
+    def mark_repair_execution_started(
+        self, *, repair_directive_id: str, started_at_ms: int
+    ) -> dict:
+        """RESERVED → SIDE_EFFECT_STARTED (the no-return boundary).
+
+        Idempotent for the owner that already crossed (same directive,
+        still non-terminal); refuses any other transition.
+        """
+        with self._lock, self._write_transaction():
+            row = self._binding_row_locked(repair_directive_id)
+            if row is None:
+                raise ValueError("repair execution binding is absent")
+            state = str(row["state"])
+            if state == "RESERVED":
+                self._connection.execute(
+                    "UPDATE repair_execution_binding SET state ="
+                    " 'SIDE_EFFECT_STARTED', started_at_ms = ?"
+                    " WHERE repair_directive_id = ? AND state = 'RESERVED'",
+                    (started_at_ms, repair_directive_id),
+                )
+                updated = self._binding_row_locked(repair_directive_id)
+                assert updated is not None
+                return dict(updated)
+            if state == "SIDE_EFFECT_STARTED":
+                return dict(row)
+            raise ValueError(
+                "repair execution binding is not in a startable state:"
+                f" {state}"
+            )
+
+    def complete_repair_execution(
+        self,
+        *,
+        repair_directive_id: str,
+        state: str,
+        produced_subject_identity: str,
+        produced_subject_kind: str,
+        runtime_result_ref: str = "",
+        runtime_result_sha256: str = "",
+        completed_at_ms: int,
+    ) -> dict:
+        """Terminalize a repair execution.
+
+        SUCCEEDED / AMBIGUOUS require the side-effect boundary to have
+        been crossed first; SUCCEEDED requires a non-empty produced
+        subject. Idempotent for identical terminal content; conflicting
+        re-completion is a StoreConflictError.
+        """
+        if state not in ("SUCCEEDED", "FAILED_FINAL", "AMBIGUOUS"):
+            raise ValueError("invalid terminal repair execution state")
+        with self._lock, self._write_transaction():
+            row = self._binding_row_locked(repair_directive_id)
+            if row is None:
+                raise ValueError("repair execution binding is absent")
+            current = str(row["state"])
+            if current in ("SUCCEEDED", "FAILED_FINAL", "AMBIGUOUS"):
+                same = (
+                    current == state
+                    and str(row["produced_subject_identity"])
+                    == produced_subject_identity
+                    and str(row["runtime_result_sha256"])
+                    == runtime_result_sha256
+                )
+                if same:
+                    return dict(row)
+                raise StoreConflictError(
+                    "repair execution binding was already completed with"
+                    " different content"
+                )
+            if state in ("SUCCEEDED", "AMBIGUOUS") and current != (
+                "SIDE_EFFECT_STARTED"
+            ):
+                raise ValueError(
+                    "repair execution cannot reach a side-effect terminal"
+                    f" state from {current}"
+                )
+            if state == "SUCCEEDED" and not produced_subject_identity:
+                raise ValueError(
+                    "successful repair execution must record its produced"
+                    " subject"
+                )
+            self._connection.execute(
+                "UPDATE repair_execution_binding SET state = ?,"
+                " produced_subject_identity = ?, produced_subject_kind = ?,"
+                " runtime_result_ref = ?, runtime_result_sha256 = ?,"
+                " completed_at_ms = ? WHERE repair_directive_id = ?",
+                (
+                    state, produced_subject_identity, produced_subject_kind,
+                    runtime_result_ref, runtime_result_sha256,
+                    completed_at_ms, repair_directive_id,
+                ),
+            )
+            updated = self._binding_row_locked(repair_directive_id)
+            assert updated is not None
+            return dict(updated)
+
+    def get_repair_execution_binding(self, repair_directive_id: str):
+        with self._lock:
+            row = self._binding_row_locked(repair_directive_id)
+            return None if row is None else dict(row)
+
+    def get_repair_execution_binding_by_attempt(
+        self, plan_entry_id: str, repair_attempt_no: int
+    ):
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM repair_execution_binding"
+                " WHERE plan_entry_id = ? AND repair_attempt_no = ?",
+                (plan_entry_id, repair_attempt_no),
+            ).fetchone()
+            return None if row is None else dict(row)
+
+    def _binding_row_locked(self, repair_directive_id: str):
+        return self._connection.execute(
+            "SELECT * FROM repair_execution_binding"
+            " WHERE repair_directive_id = ?",
+            (repair_directive_id,),
+        ).fetchone()
+
     def register_artifact_subject(
         self,
         *,
@@ -11129,8 +11371,43 @@ class GatewayStateStore:
                 "repair attempt revalidation: an attempt with this number"
                 " already exists for the plan entry"
             )
-        # P1-5: every bound effect must share the attempt's lineage and
-        # a state consistent with the recorded outcome.
+        # Final P0: the attempt must execute EXACTLY the effect the
+        # repair execution binding authorized for this attempt — an
+        # unrelated same-lineage effect cannot impersonate a repair.
+        binding = self.get_repair_execution_binding_by_attempt(
+            attempt.plan_entry_id, attempt.repair_attempt_no
+        )
+        if binding is None:
+            raise ValueError(
+                "repair attempt revalidation: no repair execution"
+                " binding owns this attempt"
+            )
+        if str(binding["repair_directive_id"]) != attempt.repair_directive_id:
+            raise ValueError(
+                "repair attempt revalidation: binding belongs to a"
+                " different directive"
+            )
+        binding_state = str(binding["state"])
+        # The binding verdict is about the RUNTIME execution; the
+        # re-verification outcome (REVERIFY_*) is derived later and so
+        # maps onto a completed (SUCCEEDED) runtime execution.
+        binding_expected = {
+            "DISPATCHED": ("SUCCEEDED",),
+            "REVERIFY_PASS": ("SUCCEEDED",),
+            "REVERIFY_FAIL": ("SUCCEEDED",),
+            "REVERIFY_ERROR": ("SUCCEEDED",),
+            "EXECUTION_FAILED": ("FAILED_FINAL",),
+            "EXECUTION_AMBIGUOUS": ("AMBIGUOUS", "SIDE_EFFECT_STARTED"),
+        }.get(attempt.execution_outcome, ())
+        if (
+            tuple(attempt.execution_effect_ids)
+            != (str(binding["effect_id"]),)
+            or binding_state not in binding_expected
+        ):
+            raise ValueError(
+                "repair attempt revalidation: execution effects do not"
+                " match the repair execution binding"
+            )
         allowed_states = {
             "DISPATCHED": ("SUCCEEDED",),
             "EXECUTION_FAILED": ("FAILED_FINAL",),
@@ -11280,6 +11557,41 @@ class GatewayStateStore:
             raise ValueError(
                 "subject successor revalidation: a binding for this"
                 " attempt number already exists for the plan entry"
+            )
+        # Final P0: the successor must be exactly the reality the repair
+        # execution binding recorded for THIS attempt — an unrelated
+        # same-lineage effect cannot impersonate the producing effect,
+        # and the successor identity must equal the binding's persisted
+        # produced subject.
+        binding = self.get_repair_execution_binding_by_attempt(
+            successor.plan_entry_id, successor.repair_attempt_no
+        )
+        if binding is None:
+            raise ValueError(
+                "subject successor revalidation: no repair execution"
+                " binding owns this attempt"
+            )
+        if str(binding["repair_directive_id"]) != successor.repair_directive_id:
+            raise ValueError(
+                "subject successor revalidation: binding belongs to a"
+                " different directive"
+            )
+        if str(binding["state"]) != "SUCCEEDED":
+            raise ValueError(
+                "subject successor revalidation: binding did not reach"
+                " SUCCEEDED"
+            )
+        if successor.produced_by_effect_id != str(binding["effect_id"]):
+            raise ValueError(
+                "subject successor revalidation: producing effect is not"
+                " the repair execution binding's effect"
+            )
+        if successor.successor_subject_identity != str(
+            binding["produced_subject_identity"]
+        ):
+            raise ValueError(
+                "subject successor revalidation: successor does not"
+                " match the binding's persisted produced subject"
             )
         # P1-6: cycle fail-closed — the successor may not be the
         # predecessor itself nor any identity already on the chain

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -1843,6 +1843,9 @@ _MIGRATION_V29_STATEMENTS = (
         effect_intent_sha256 TEXT NOT NULL
             CHECK (length(effect_intent_sha256) = 64
                    AND effect_intent_sha256 NOT GLOB '*[^0-9a-f]*'),
+        dispatch_claim_id TEXT NOT NULL DEFAULT '',
+        claim_revision INTEGER NOT NULL DEFAULT 1,
+        claim_expires_at_ms INTEGER NOT NULL DEFAULT 0,
         produced_subject_identity TEXT NOT NULL DEFAULT '',
         produced_subject_kind TEXT NOT NULL DEFAULT '',
         runtime_result_ref TEXT NOT NULL DEFAULT '',
@@ -10749,18 +10752,30 @@ class GatewayStateStore:
         effect_id: str,
         effect_intent_sha256: str,
         reserved_at_ms: int,
+        dispatch_claim_id: str,
+        claim_expires_at_ms: int,
     ) -> dict:
         """Atomically claim the repair dispatch authority.
 
         Returns ``{"outcome": "EXECUTE"|"FOLLOW", "binding": dict}``.
-        - EXECUTE: this caller owns the (plan entry, attempt) slot and
-          may cross into the Runtime (binding is RESERVED).
-        - FOLLOW: another directive already owns the slot — the caller
-          must NOT execute the runtime, not even once.
-        Re-reserving the SAME directive idempotently returns EXECUTE
-        while it is still RESERVED (crash recovery before the
-        side-effect boundary) and FOLLOW once terminal or started.
+        The caller supplies an invocation-scoped ``dispatch_claim_id``
+        (NOT a gateway instance id — two threads in one process must
+        still single-flight) plus its lease expiry.
+
+        State machine (Final P0-1):
+        - no binding: INSERT with this claim → EXECUTE
+        - same directive, RESERVED, same live claim → idempotent EXECUTE
+        - same directive, RESERVED, different LIVE claim → FOLLOW
+        - same directive, RESERVED, claim lease EXPIRED (and the side
+          effect never started) → this claim CAS-takes over → EXECUTE
+        - SIDE_EFFECT_STARTED / terminal → FOLLOW (never takeover,
+          never replay)
+        Every supplied field is first verified against the persisted
+        authoritative RepairDirective — a fabricated or drifted
+        directive payload cannot reserve anything.
         """
+        if not dispatch_claim_id or claim_expires_at_ms < reserved_at_ms:
+            raise ValueError("dispatch claim identity/lease is invalid")
         with self._lock, self._write_transaction():
             self._assert_request_binding_locked(
                 request_id=request_id,
@@ -10768,6 +10783,25 @@ class GatewayStateStore:
                 generation=generation,
                 recorded_at_ms=reserved_at_ms,
             )
+            directive_row = self.get_repair_directive_by_id(
+                repair_directive_id
+            )
+            if directive_row is None:
+                raise ValueError(
+                    "repair dispatch reserve: directive absent from store"
+                )
+            if (
+                directive_row.directive_sha256 != repair_directive_sha256
+                or directive_row.plan_entry_id != plan_entry_id
+                or directive_row.repair_attempt_no != repair_attempt_no
+                or directive_row.request_id != request_id
+                or directive_row.run_id != run_id
+                or directive_row.generation != generation
+            ):
+                raise ValueError(
+                    "repair dispatch reserve: directive fields do not"
+                    " match the authoritative store content"
+                )
             existing = self._binding_row_locked(repair_directive_id)
             if existing is not None:
                 if (
@@ -10782,14 +10816,33 @@ class GatewayStateStore:
                         "repair execution binding identity was reused"
                         " for different content"
                     )
-                return {
-                    "outcome": (
-                        "EXECUTE"
-                        if str(existing["state"]) == "RESERVED"
-                        else "FOLLOW"
-                    ),
-                    "binding": dict(existing),
-                }
+                state = str(existing["state"])
+                if state == "RESERVED":
+                    same_claim = (
+                        str(existing["dispatch_claim_id"]) == dispatch_claim_id
+                    )
+                    live = (
+                        int(existing["claim_expires_at_ms"]) > reserved_at_ms
+                    )
+                    if same_claim or not live:
+                        # idempotent re-entry, or an expired pre-start
+                        # lease CAS-taken over by this claim
+                        self._connection.execute(
+                            "UPDATE repair_execution_binding SET"
+                            " dispatch_claim_id = ?, claim_revision ="
+                            " claim_revision + 1, claim_expires_at_ms = ?"
+                            " WHERE repair_directive_id = ?"
+                            " AND state = 'RESERVED'",
+                            (
+                                dispatch_claim_id, claim_expires_at_ms,
+                                repair_directive_id,
+                            ),
+                        )
+                        row = self._binding_row_locked(repair_directive_id)
+                        assert row is not None
+                        return {"outcome": "EXECUTE", "binding": dict(row)}
+                    return {"outcome": "FOLLOW", "binding": dict(existing)}
+                return {"outcome": "FOLLOW", "binding": dict(existing)}
             competing = self._connection.execute(
                 "SELECT * FROM repair_execution_binding"
                 " WHERE plan_entry_id = ? AND repair_attempt_no = ?",
@@ -10802,12 +10855,14 @@ class GatewayStateStore:
                 "repair_directive_id, repair_directive_sha256,"
                 " plan_entry_id, repair_attempt_no, request_id, run_id,"
                 " generation, state, effect_id, effect_intent_sha256,"
+                " dispatch_claim_id, claim_revision, claim_expires_at_ms,"
                 " reserved_at_ms"
-                ") VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     repair_directive_id, repair_directive_sha256,
                     plan_entry_id, repair_attempt_no, request_id, run_id,
                     generation, "RESERVED", effect_id, effect_intent_sha256,
+                    dispatch_claim_id, 1, claim_expires_at_ms,
                     reserved_at_ms,
                 ),
             )
@@ -10815,35 +10870,61 @@ class GatewayStateStore:
             assert row is not None
             return {"outcome": "EXECUTE", "binding": dict(row)}
 
-    def mark_repair_execution_started(
-        self, *, repair_directive_id: str, started_at_ms: int
+    def start_repair_execution(
+        self, *, repair_directive_id: str, effect_id: str, started_at_ms: int
     ) -> dict:
-        """RESERVED → SIDE_EFFECT_STARTED (the no-return boundary).
+        """ONE atomic authority transition (Final P0-2):
 
-        Idempotent for the owner that already crossed (same directive,
-        still non-terminal); refuses any other transition.
+            EffectLedger  CLAIMED → SIDE_EFFECT_STARTED
+            RepairBinding RESERVED → SIDE_EFFECT_STARTED
+
+        The binding must own exactly ``effect_id``. After this
+        transaction no committed state can ever show an effect past the
+        boundary while its binding is still RESERVED. Takeover is over:
+        SIDE_EFFECT_STARTED means RECONCILE-only on recovery.
         """
         with self._lock, self._write_transaction():
             row = self._binding_row_locked(repair_directive_id)
             if row is None:
                 raise ValueError("repair execution binding is absent")
+            if str(row["effect_id"]) != effect_id:
+                raise ValueError(
+                    "repair execution binding owns a different effect"
+                )
             state = str(row["state"])
             if state == "RESERVED":
-                self._connection.execute(
+                if started_at_ms < int(row["reserved_at_ms"]):
+                    raise ValueError(
+                        "repair execution start predates its reservation"
+                    )
+            elif state == "SIDE_EFFECT_STARTED":
+                if int(row["started_at_ms"] or 0) > started_at_ms:
+                    raise ValueError(
+                        "repair execution start predates its boundary"
+                    )
+            else:
+                raise ValueError(
+                    "repair execution binding is not in a startable state:"
+                    f" {state}"
+                )
+            # Same transaction: cross the EffectLedger boundary first.
+            self.mark_effect_started(
+                effect_id, started_at_ms=started_at_ms
+            )
+            if state == "RESERVED":
+                updated = self._connection.execute(
                     "UPDATE repair_execution_binding SET state ="
                     " 'SIDE_EFFECT_STARTED', started_at_ms = ?"
                     " WHERE repair_directive_id = ? AND state = 'RESERVED'",
                     (started_at_ms, repair_directive_id),
                 )
-                updated = self._binding_row_locked(repair_directive_id)
-                assert updated is not None
-                return dict(updated)
-            if state == "SIDE_EFFECT_STARTED":
-                return dict(row)
-            raise ValueError(
-                "repair execution binding is not in a startable state:"
-                f" {state}"
-            )
+                if updated.rowcount != 1:
+                    raise StoreCasConflict(
+                        "repair execution binding changed before start"
+                    )
+            updated_row = self._binding_row_locked(repair_directive_id)
+            assert updated_row is not None
+            return dict(updated_row)
 
     def complete_repair_execution(
         self,
@@ -10855,13 +10936,20 @@ class GatewayStateStore:
         runtime_result_ref: str = "",
         runtime_result_sha256: str = "",
         completed_at_ms: int,
+        error_code: str | None = None,
     ) -> dict:
-        """Terminalize a repair execution.
+        """ONE atomic terminal transition (Final P0-2):
 
-        SUCCEEDED / AMBIGUOUS require the side-effect boundary to have
-        been crossed first; SUCCEEDED requires a non-empty produced
-        subject. Idempotent for identical terminal content; conflicting
-        re-completion is a StoreConflictError.
+            EffectLedger  → SUCCEEDED / FAILED_FINAL / AMBIGUOUS
+            RepairBinding → the SAME terminal state, plus the produced
+                            subject and the runtime result reference.
+
+        No committed state may ever expose binding SUCCEEDED with a
+        non-SUCCEEDED effect (or the reverse). SUCCEEDED / AMBIGUOUS
+        require the side-effect boundary to have been crossed;
+        SUCCEEDED requires the produced subject. FAILED_FINAL is legal
+        straight from RESERVED (policy deny: the runtime was never
+        entered).
         """
         if state not in ("SUCCEEDED", "FAILED_FINAL", "AMBIGUOUS"):
             raise ValueError("invalid terminal repair execution state")
@@ -10870,6 +10958,20 @@ class GatewayStateStore:
             if row is None:
                 raise ValueError("repair execution binding is absent")
             current = str(row["state"])
+            effect_id = str(row["effect_id"])
+            directive = self.get_repair_directive_by_id(repair_directive_id)
+            if directive is not None and produced_subject_kind != (
+                directive.subject_kind
+            ):
+                raise ValueError(
+                    "repair execution produced subject kind does not"
+                    " match the directive"
+                )
+            boundary_ms = int(row["started_at_ms"] or row["reserved_at_ms"])
+            if completed_at_ms < boundary_ms:
+                raise ValueError(
+                    "repair execution completion predates its boundary"
+                )
             if current in ("SUCCEEDED", "FAILED_FINAL", "AMBIGUOUS"):
                 same = (
                     current == state
@@ -10896,7 +10998,28 @@ class GatewayStateStore:
                     "successful repair execution must record its produced"
                     " subject"
                 )
-            self._connection.execute(
+            # Same transaction: terminalize the EffectLedger first —
+            # its own CHECK constraints validate the transition.
+            from .effects import EffectResult
+
+            terminal_result = EffectResult(
+                result_id="effect-result-" + effect_id[4:20],
+                effect_id=effect_id,
+                status=state,
+                fact_id="fact-effect-" + effect_id[4:20],
+                evidence_sha256=canonical_sha256(
+                    {
+                        "code": error_code,
+                        "runtime_result_sha256": runtime_result_sha256,
+                        "state": state,
+                    }
+                ),
+                error_code=error_code if state != "SUCCEEDED" else None,
+                observed_at_ms=completed_at_ms,
+                result_sha256="0" * 64,
+            ).with_computed_sha256()
+            self.complete_effect(terminal_result)
+            updated = self._connection.execute(
                 "UPDATE repair_execution_binding SET state = ?,"
                 " produced_subject_identity = ?, produced_subject_kind = ?,"
                 " runtime_result_ref = ?, runtime_result_sha256 = ?,"
@@ -10907,9 +11030,13 @@ class GatewayStateStore:
                     completed_at_ms, repair_directive_id,
                 ),
             )
-            updated = self._binding_row_locked(repair_directive_id)
-            assert updated is not None
-            return dict(updated)
+            if updated.rowcount != 1:
+                raise StoreCasConflict(
+                    "repair execution binding changed before completion"
+                )
+            final_row = self._binding_row_locked(repair_directive_id)
+            assert final_row is not None
+            return dict(final_row)
 
     def get_repair_execution_binding(self, repair_directive_id: str):
         with self._lock:
@@ -11388,25 +11515,38 @@ class GatewayStateStore:
                 " different directive"
             )
         binding_state = str(binding["state"])
-        # The binding verdict is about the RUNTIME execution; the
-        # re-verification outcome (REVERIFY_*) is derived later and so
-        # maps onto a completed (SUCCEEDED) runtime execution.
-        binding_expected = {
-            "DISPATCHED": ("SUCCEEDED",),
-            "REVERIFY_PASS": ("SUCCEEDED",),
-            "REVERIFY_FAIL": ("SUCCEEDED",),
-            "REVERIFY_ERROR": ("SUCCEEDED",),
-            "EXECUTION_FAILED": ("FAILED_FINAL",),
-            "EXECUTION_AMBIGUOUS": ("AMBIGUOUS", "SIDE_EFFECT_STARTED"),
+        # Final P0-2 #5: the outcome must match the EXACT (binding,
+        # effect) terminal pair — the EffectLedger state is read
+        # explicitly (never implied from the binding dict).
+        effect_row = self._connection.execute(
+            "SELECT state FROM effect_ledger WHERE effect_id = ?",
+            (str(binding["effect_id"]),),
+        ).fetchone()
+        if effect_row is None:
+            raise ValueError(
+                "repair attempt revalidation: binding effect absent from"
+                " the effect ledger"
+            )
+        effect_state = str(effect_row["state"])
+        expected_pairs = {
+            "DISPATCHED": (("SUCCEEDED", "SUCCEEDED"),),
+            "REVERIFY_PASS": (("SUCCEEDED", "SUCCEEDED"),),
+            "REVERIFY_FAIL": (("SUCCEEDED", "SUCCEEDED"),),
+            "REVERIFY_ERROR": (("SUCCEEDED", "SUCCEEDED"),),
+            "EXECUTION_FAILED": (("FAILED_FINAL", "FAILED_FINAL"),),
+            "EXECUTION_AMBIGUOUS": (
+                ("AMBIGUOUS", "AMBIGUOUS"),
+                ("SIDE_EFFECT_STARTED", "SIDE_EFFECT_STARTED"),
+            ),
         }.get(attempt.execution_outcome, ())
         if (
             tuple(attempt.execution_effect_ids)
             != (str(binding["effect_id"]),)
-            or binding_state not in binding_expected
+            or (binding_state, effect_state) not in expected_pairs
         ):
             raise ValueError(
                 "repair attempt revalidation: execution effects do not"
-                " match the repair execution binding"
+                " match the repair execution binding authorities"
             )
         allowed_states = {
             "DISPATCHED": ("SUCCEEDED",),
@@ -11592,6 +11732,20 @@ class GatewayStateStore:
             raise ValueError(
                 "subject successor revalidation: successor does not"
                 " match the binding's persisted produced subject"
+            )
+        # Final P0-2 #5: the EffectLedger authority is read explicitly —
+        # a SUCCEEDED binding can never certify a successor whose
+        # effect is not SUCCEEDED in the ledger.
+        successor_effect_row = self._connection.execute(
+            "SELECT state FROM effect_ledger WHERE effect_id = ?",
+            (str(binding["effect_id"]),),
+        ).fetchone()
+        if successor_effect_row is None or str(
+            successor_effect_row["state"]
+        ) != "SUCCEEDED":
+            raise ValueError(
+                "subject successor revalidation: binding effect is not"
+                " SUCCEEDED in the effect ledger"
             )
         # P1-6: cycle fail-closed — the successor may not be the
         # predecessor itself nor any identity already on the chain

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -88,7 +88,7 @@ if TYPE_CHECKING:
 
 
 APPLICATION_ID = 0x54475633
-STORE_SCHEMA_VERSION = 28
+STORE_SCHEMA_VERSION = 29
 CHANNEL_LEASE_CLOCK_SKEW_MS = 5_000
 _MIGRATION_V1_ID = "gateway-store-v1"
 _MIGRATION_V1_STATEMENTS = (
@@ -1798,6 +1798,34 @@ _MIGRATION_V28_STATEMENTS = (
     """,
 )
 
+_MIGRATION_V29_ID = "gateway-repair-authority-hardening-v29"
+_MIGRATION_V29_STATEMENTS = (
+    """
+    CREATE TABLE artifact_subject_authority (
+        artifact_revision_id TEXT NOT NULL PRIMARY KEY,
+        object_id TEXT NOT NULL,
+        artifact_sha256 TEXT NOT NULL
+            CHECK (length(artifact_sha256) = 64 AND artifact_sha256 NOT GLOB '*[^0-9a-f]*'),
+        request_id TEXT NOT NULL,
+        run_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK (generation >= 0),
+        registered_at_ms INTEGER NOT NULL CHECK (registered_at_ms >= 0)
+    ) STRICT
+    """,
+    """
+    CREATE INDEX artifact_subject_authority_lineage_idx
+        ON artifact_subject_authority (request_id, run_id, generation)
+    """,
+    """
+    CREATE UNIQUE INDEX verification_subject_successor_attempt_idx
+        ON verification_subject_successor (plan_entry_id, repair_attempt_no)
+    """,
+    """
+    CREATE UNIQUE INDEX repair_attempt_number_idx
+        ON repair_attempt (plan_entry_id, repair_attempt_no)
+    """,
+)
+
 _MIGRATIONS = (
     (1, _MIGRATION_V1_ID, _MIGRATION_V1_STATEMENTS),
     (2, _MIGRATION_V2_ID, _MIGRATION_V2_STATEMENTS),
@@ -1827,6 +1855,7 @@ _MIGRATIONS = (
     (26, _MIGRATION_V26_ID, _MIGRATION_V26_STATEMENTS),
     (27, _MIGRATION_V27_ID, _MIGRATION_V27_STATEMENTS),
     (28, _MIGRATION_V28_ID, _MIGRATION_V28_STATEMENTS),
+    (29, _MIGRATION_V29_ID, _MIGRATION_V29_STATEMENTS),
 )
 _MIGRATION_DIGESTS = {
     version: _migration_sha256(version, migration_id, statements)
@@ -10663,6 +10692,88 @@ class GatewayStateStore:
                 for r in rows
             )
 
+    def register_artifact_subject(
+        self,
+        *,
+        artifact_revision_id: str,
+        object_id: str,
+        artifact_sha256: str,
+        request_id: str,
+        run_id: str,
+        generation: int,
+        registered_at_ms: int,
+    ) -> bool:
+        """P1-6 (v29): the Artifact authority projection inside the Store.
+
+        Only manifests that passed the REAL ArtifactGate/QC pipeline may
+        be registered (callers are the gate pipeline itself). The
+        successor write boundary requires an artifact successor to be
+        present here — a fabricated revision can never become the
+        authoritative effective subject first and fail later.
+        """
+        if (
+            len(artifact_sha256) != 64
+            or any(c not in "0123456789abcdef" for c in artifact_sha256)
+        ):
+            raise ValueError("artifact digest is invalid")
+        if not artifact_revision_id or not object_id:
+            raise ValueError("artifact subject identity is invalid")
+        with self._lock, self._write_transaction():
+            self._assert_request_binding_locked(
+                request_id=request_id,
+                run_id=run_id,
+                generation=generation,
+                recorded_at_ms=registered_at_ms,
+            )
+            existing = self._connection.execute(
+                "SELECT object_id, artifact_sha256 FROM"
+                " artifact_subject_authority WHERE artifact_revision_id = ?",
+                (artifact_revision_id,),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    str(existing["object_id"]) != object_id
+                    or str(existing["artifact_sha256"]) != artifact_sha256
+                ):
+                    raise StoreConflictError(
+                        "artifact subject identity was reused for"
+                        " different content"
+                    )
+                return False
+            self._connection.execute(
+                "INSERT INTO artifact_subject_authority ("
+                "artifact_revision_id, object_id, artifact_sha256,"
+                " request_id, run_id, generation, registered_at_ms"
+                ") VALUES (?,?,?,?,?,?,?)",
+                (
+                    artifact_revision_id,
+                    object_id,
+                    artifact_sha256,
+                    request_id,
+                    run_id,
+                    generation,
+                    registered_at_ms,
+                ),
+            )
+            return True
+
+    def artifact_subject_exists(
+        self,
+        artifact_revision_id: str,
+        *,
+        request_id: str,
+        run_id: str,
+        generation: int,
+    ) -> bool:
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT 1 FROM artifact_subject_authority"
+                " WHERE artifact_revision_id = ? AND request_id = ?"
+                " AND run_id = ? AND generation = ?",
+                (artifact_revision_id, request_id, run_id, generation),
+            ).fetchone()
+            return row is not None
+
     # ------------------------------------------------------------------
     # M5 Final #4: v28 write-boundary cross-object revalidation.
     # Every put_* below re-derives its payload from authoritative Store
@@ -10742,24 +10853,25 @@ class GatewayStateStore:
         prev = self.list_verification_dispositions(
             plan_entry_id=disposition.plan_entry_id
         )
-        prior_repair_count = sum(
-            1
-            for d in prev
-            if d.action == "REPAIR"
-            and d.verification_disposition_id
-            != disposition.verification_disposition_id
+        # P1-7: attempt_no counts REAL executed attempts, matching the
+        # coordinator's budget semantics (crash before dispatch must not
+        # burn the budget).
+        executed_attempts = self.list_repair_attempts(
+            disposition.plan_entry_id
         )
-        same_signature_count = (
-            sum(
-                1
-                for fe in self.list_verification_failure_evidence(
-                    plan_entry_id=disposition.plan_entry_id
-                )
-                if fe.failure_signature_sha256
-                == evidence.failure_signature_sha256
+        prior_repair_count = len(executed_attempts)
+        # Same failure signature — de-duplicated by readiness; the FE
+        # under test is already persisted, so the count is the distinct
+        # readiness set MINUS this evidence's own contribution. This
+        # matches the coordinator's pre-insert computation exactly.
+        same_signature_count = len({
+            fe.readiness_sha256
+            for fe in self.list_verification_failure_evidence(
+                plan_entry_id=disposition.plan_entry_id
             )
-            - 1  # the evidence under test is already persisted
-        )
+            if fe.failure_signature_sha256
+            == evidence.failure_signature_sha256
+        } - {evidence.readiness_sha256})
         resolution = self.resolve_verification_subject(
             disposition.plan_entry_id
         )
@@ -10781,8 +10893,14 @@ class GatewayStateStore:
             else 0
         )
 
-        effect_ambiguous = False
-        if evidence.subject_kind == "effect":
+        # P0-1: an executed-but-AMBIGUOUS repair attempt makes every
+        # later disposition for this entry RECONCILE — regardless of the
+        # FE subject kind (artifact repairs too).
+        effect_ambiguous = any(
+            attempt.execution_outcome == "EXECUTION_AMBIGUOUS"
+            for attempt in executed_attempts
+        )
+        if not effect_ambiguous and evidence.subject_kind == "effect":
             record = self.get_effect(evidence.effective_subject_identity)
             if record is not None:
                 effect_ambiguous = record.state in (
@@ -10834,7 +10952,16 @@ class GatewayStateStore:
                 " authoritative policy"
             )
 
-    def _revalidate_repair_directive(self, directive) -> None:
+    def _revalidate_repair_directive(
+        self, directive, *, recorded_at_ms: int
+    ) -> None:
+        from total_gateway.verification_repair_policy import (
+            DEFAULT_POLICY,
+            MAX_REPAIR_EXECUTION_BUDGET_MS,
+            MAX_REPAIR_EXPIRY_DELTA_MS,
+            MIN_REPAIR_EXECUTION_BUDGET_MS,
+        )
+
         disposition = self.get_verification_disposition_by_id(
             directive.disposition_id
         )
@@ -10911,6 +11038,59 @@ class GatewayStateStore:
                 "repair directive revalidation: effective subject does not"
                 " match the store successor chain"
             )
+        # P1-4: attempt numbering must continue the disposition's.
+        if directive.repair_attempt_no != disposition.attempt_no + 1:
+            raise ValueError(
+                "repair directive revalidation: attempt number must be"
+                " disposition.attempt_no + 1"
+            )
+        if directive.max_attempts != DEFAULT_POLICY.max_attempts_per_plan_entry:
+            raise ValueError(
+                "repair directive revalidation: max_attempts does not"
+                " match the authoritative policy"
+            )
+        # P1-4: expiry — an already-expired or over-long directive is
+        # invalid at write time.
+        if directive.expires_at_ms < recorded_at_ms:
+            raise ValueError(
+                "repair directive revalidation: directive is already"
+                " expired"
+            )
+        if directive.expires_at_ms - directive.issued_at_ms > (
+            MAX_REPAIR_EXPIRY_DELTA_MS
+        ):
+            raise ValueError(
+                "repair directive revalidation: expiry window exceeds the"
+                " authoritative policy limit"
+            )
+        if not (
+            MIN_REPAIR_EXECUTION_BUDGET_MS
+            <= directive.execution_budget_ms
+            <= MAX_REPAIR_EXECUTION_BUDGET_MS
+        ):
+            raise ValueError(
+                "repair directive revalidation: execution budget outside"
+                " the authoritative policy limits"
+            )
+        # P1-4: target scope — a repair may only touch the current
+        # effective subject; widened or tampered scopes are rejected.
+        if tuple(directive.allowed_target_refs) != (effective,):
+            raise ValueError(
+                "repair directive revalidation: allowed target scope must"
+                " be exactly the current effective subject"
+            )
+        if tuple(directive.forbidden_target_refs):
+            raise ValueError(
+                "repair directive revalidation: forbidden target refs"
+                " cannot be populated"
+            )
+        if directive.repair_goal_kind != (
+            f"repair:{entry.predicate.predicate_type}"
+        ):
+            raise ValueError(
+                "repair directive revalidation: repair goal kind does"
+                " not match the plan entry predicate"
+            )
 
     def _revalidate_repair_attempt(self, attempt) -> None:
         directive = self.get_repair_directive_by_id(
@@ -10932,22 +11112,111 @@ class GatewayStateStore:
             raise ValueError(
                 "repair attempt revalidation: prior subject mismatch"
             )
+        # P1-5: one attempt per (plan entry, attempt number) — two
+        # coordinators racing for attempt #1 cannot both land it.
+        duplicate = self._connection.execute(
+            "SELECT repair_attempt_id FROM repair_attempt"
+            " WHERE plan_entry_id = ? AND repair_attempt_no = ?"
+            " AND repair_attempt_id != ?",
+            (
+                attempt.plan_entry_id,
+                attempt.repair_attempt_no,
+                attempt.repair_attempt_id,
+            ),
+        ).fetchone()
+        if duplicate is not None:
+            raise ValueError(
+                "repair attempt revalidation: an attempt with this number"
+                " already exists for the plan entry"
+            )
+        # P1-5: every bound effect must share the attempt's lineage and
+        # a state consistent with the recorded outcome.
+        allowed_states = {
+            "DISPATCHED": ("SUCCEEDED",),
+            "EXECUTION_FAILED": ("FAILED_FINAL",),
+            "EXECUTION_AMBIGUOUS": ("AMBIGUOUS", "SIDE_EFFECT_STARTED", "CLAIMED"),
+        }.get(attempt.execution_outcome)
         for effect_id in attempt.execution_effect_ids:
-            if self.get_effect(effect_id) is None:
+            row = self._connection.execute(
+                "SELECT request_id, run_id, generation, state,"
+                " claimed_at_ms FROM effect_ledger WHERE effect_id = ?",
+                (effect_id,),
+            ).fetchone()
+            if row is None:
                 raise ValueError(
                     "repair attempt revalidation: execution effect absent"
                     " from the effect ledger"
                 )
+            if (
+                str(row["request_id"]) != attempt.request_id
+                or str(row["run_id"]) != attempt.run_id
+                or int(row["generation"]) != attempt.generation
+            ):
+                raise ValueError(
+                    "repair attempt revalidation: execution effect lineage"
+                    " mismatch"
+                )
+            if int(row["claimed_at_ms"]) < directive.issued_at_ms:
+                raise ValueError(
+                    "repair attempt revalidation: execution effect"
+                    " predates the directive"
+                )
+            if (
+                allowed_states is not None
+                and str(row["state"]) not in allowed_states
+            ):
+                raise ValueError(
+                    "repair attempt revalidation: execution effect state"
+                    " contradicts the recorded outcome"
+                )
         if attempt.reverify_record_id is not None:
+            # P1-5: the re-verification record must fully bind to THIS
+            # directive: lineage, verifier, predicate, effective subject,
+            # and a status consistent with the recorded outcome.
             row = self._connection.execute(
-                "SELECT predicate_id FROM verification_record"
+                "SELECT request_id, run_id, generation, verifier_id,"
+                " verifier_version, predicate_id, subject_identity,"
+                " status FROM verification_record"
                 " WHERE verification_record_id = ?",
                 (attempt.reverify_record_id,),
             ).fetchone()
-            if row is None or str(row["predicate_id"]) != directive.predicate_id:
+            if row is None:
                 raise ValueError(
                     "repair attempt revalidation: re-verification record"
                     " absent from the store"
+                )
+            plan = self.get_verification_plan(directive.verification_plan_id)
+            entry = next(
+                (
+                    e
+                    for e in (plan.entries if plan else ())
+                    if e.plan_entry_id == directive.plan_entry_id
+                ),
+                None,
+            )
+            expected_status = {
+                "REVERIFY_PASS": "PASS",
+                "REVERIFY_FAIL": "FAIL",
+                "REVERIFY_ERROR": "ERROR",
+            }.get(attempt.execution_outcome)
+            if (
+                str(row["request_id"]) != attempt.request_id
+                or str(row["run_id"]) != attempt.run_id
+                or int(row["generation"]) != attempt.generation
+                or str(row["predicate_id"]) != directive.predicate_id
+                or str(row["subject_identity"])
+                != attempt.produced_subject_identity
+                or entry is None
+                or str(row["verifier_id"]) != entry.verifier_id
+                or str(row["verifier_version"]) != entry.verifier_version
+                or (
+                    expected_status is not None
+                    and str(row["status"]) != expected_status
+                )
+            ):
+                raise ValueError(
+                    "repair attempt revalidation: re-verification record"
+                    " does not bind to this directive"
                 )
 
     def _revalidate_subject_successor(self, successor) -> None:
@@ -10996,17 +11265,91 @@ class GatewayStateStore:
                 "subject successor revalidation: predecessor is not the"
                 " current effective subject"
             )
-        if self.get_effect(successor.produced_by_effect_id) is None:
+        # P1-6: one successor per (plan entry, attempt number).
+        duplicate = self._connection.execute(
+            "SELECT successor_binding_id FROM verification_subject_successor"
+            " WHERE plan_entry_id = ? AND repair_attempt_no = ?"
+            " AND successor_binding_id != ?",
+            (
+                successor.plan_entry_id,
+                successor.repair_attempt_no,
+                successor.successor_binding_id,
+            ),
+        ).fetchone()
+        if duplicate is not None:
+            raise ValueError(
+                "subject successor revalidation: a binding for this"
+                " attempt number already exists for the plan entry"
+            )
+        # P1-6: cycle fail-closed — the successor may not be the
+        # predecessor itself nor any identity already on the chain
+        # (including the plan's original subject).
+        plan = self.get_verification_plan(successor.verification_plan_id)
+        entry = next(
+            (
+                e
+                for e in (plan.entries if plan else ())
+                if e.plan_entry_id == successor.plan_entry_id
+            ),
+            None,
+        )
+        chain_identities = {
+            b.predecessor_subject_identity
+            for b in self.list_verification_subject_successors(
+                successor.plan_entry_id
+            )
+        }
+        chain_identities.update(
+            b.successor_subject_identity
+            for b in self.list_verification_subject_successors(
+                successor.plan_entry_id
+            )
+        )
+        if entry is not None:
+            chain_identities.add(entry.subject_identity)
+        if (
+            successor.successor_subject_identity
+            == successor.predecessor_subject_identity
+            or successor.successor_subject_identity in chain_identities
+        ):
+            raise ValueError(
+                "subject successor revalidation: successor would create a"
+                " subject cycle"
+            )
+        # P1-6: successor depth is enforced at the WRITE boundary too,
+        # not only by the policy.
+        from total_gateway.verification_repair_policy import DEFAULT_POLICY
+
+        depth = resolution.get("successor_depth", 0)
+        if depth + 1 > DEFAULT_POLICY.max_subject_successor_depth:
+            raise ValueError(
+                "subject successor revalidation: successor depth budget"
+                " exceeded"
+            )
+        # P1-6: the producing effect must share the binding's lineage
+        # and belong to THIS repair (claimed at/after the directive).
+        producing = self._connection.execute(
+            "SELECT request_id, run_id, generation, claimed_at_ms FROM"
+            " effect_ledger WHERE effect_id = ?",
+            (successor.produced_by_effect_id,),
+        ).fetchone()
+        if producing is None:
             raise ValueError(
                 "subject successor revalidation: producing effect absent"
                 " from the effect ledger"
             )
-        # Successor must exist in authoritative reality. Artifact
-        # manifests live in the object store (outside SQLite authority);
-        # for artifacts the producing-effect binding plus the mandatory
-        # re-verification (the executor requires a manifest keyed by the
-        # successor id) enforce reality. Effect/repository subjects are
-        # checked directly here.
+        if (
+            str(producing["request_id"]) != successor.request_id
+            or str(producing["run_id"]) != successor.run_id
+            or int(producing["generation"]) != successor.generation
+            or int(producing["claimed_at_ms"]) < directive.issued_at_ms
+        ):
+            raise ValueError(
+                "subject successor revalidation: producing effect"
+                " lineage does not bind to this repair"
+            )
+        # P1-6: the successor must exist in authoritative reality NOW —
+        # never "become authoritative first, fail at re-verification".
         if successor.subject_kind == "effect":
             if self.get_effect(successor.successor_subject_identity) is None:
                 raise ValueError(
@@ -11020,6 +11363,17 @@ class GatewayStateStore:
                 raise ValueError(
                     "subject successor revalidation: successor has no"
                     " repository observation bindings"
+                )
+        elif successor.subject_kind == "artifact":
+            if not self.artifact_subject_exists(
+                successor.successor_subject_identity,
+                request_id=successor.request_id,
+                run_id=successor.run_id,
+                generation=successor.generation,
+            ):
+                raise ValueError(
+                    "subject successor revalidation: artifact successor"
+                    " is not registered in the artifact authority"
                 )
 
     def put_verification_failure_evidence(self, evidence, *, recorded_at_ms: int) -> bool:
@@ -11237,7 +11591,9 @@ class GatewayStateStore:
             # M5 Final #4: directive must bind a stored REPAIR
             # disposition, the plan entry, and the current effective
             # subject.
-            self._revalidate_repair_directive(directive)
+            self._revalidate_repair_directive(
+                directive, recorded_at_ms=recorded_at_ms
+            )
             self._connection.execute(
                 "INSERT INTO repair_directive ("
                 "repair_directive_id, request_id, run_id, generation,"

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -10559,6 +10559,469 @@ class GatewayStateStore:
     # P19-R2 M5: Evidence-Driven Repair store APIs (v28 tables)
     # ------------------------------------------------------------------
 
+    def get_verification_readiness_by_sha(
+        self,
+        *,
+        request_id: str,
+        run_id: str,
+        generation: int,
+        readiness_sha256: str,
+    ):
+        from contracts.verification import VerificationReadiness
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT readiness_json FROM verification_readiness"
+                " WHERE request_id = ? AND run_id = ? AND generation = ?"
+                " AND readiness_sha256 = ?",
+                (request_id, run_id, generation, readiness_sha256),
+            ).fetchone()
+            if row is None:
+                return None
+            return VerificationReadiness.model_validate_json(
+                row["readiness_json"], strict=True
+            )
+
+    def get_verification_failure_evidence_by_id(
+        self, failure_evidence_id: str
+    ):
+        from contracts.verification import FailureEvidence
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT evidence_json FROM verification_failure_evidence"
+                " WHERE failure_evidence_id = ?",
+                (failure_evidence_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return FailureEvidence.model_validate_json(
+                row["evidence_json"], strict=True
+            )
+
+    def get_verification_disposition_by_id(
+        self, verification_disposition_id: str
+    ):
+        from contracts.verification import VerificationDisposition
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT disposition_json FROM verification_disposition"
+                " WHERE verification_disposition_id = ?",
+                (verification_disposition_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return VerificationDisposition.model_validate_json(
+                row["disposition_json"], strict=True
+            )
+
+    def get_repair_directive_by_id(self, repair_directive_id: str):
+        from contracts.verification import RepairDirective
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT directive_json FROM repair_directive"
+                " WHERE repair_directive_id = ?",
+                (repair_directive_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return RepairDirective.model_validate_json(
+                row["directive_json"], strict=True
+            )
+
+    def list_repair_directives(self, plan_entry_id: str):
+        from contracts.verification import RepairDirective
+
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT directive_json FROM repair_directive"
+                " WHERE plan_entry_id = ? ORDER BY issued_at_ms",
+                (plan_entry_id,),
+            ).fetchall()
+            return tuple(
+                RepairDirective.model_validate_json(
+                    r["directive_json"], strict=True
+                )
+                for r in rows
+            )
+
+    def list_repair_attempts(self, plan_entry_id: str):
+        from contracts.verification_repair import RepairAttemptRecord
+
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT attempt_json FROM repair_attempt"
+                " WHERE plan_entry_id = ? ORDER BY started_at_ms",
+                (plan_entry_id,),
+            ).fetchall()
+            return tuple(
+                RepairAttemptRecord.model_validate_json(
+                    r["attempt_json"], strict=True
+                )
+                for r in rows
+            )
+
+    # ------------------------------------------------------------------
+    # M5 Final #4: v28 write-boundary cross-object revalidation.
+    # Every put_* below re-derives its payload from authoritative Store
+    # state before insert — callers cannot smuggle in a "why", a
+    # decision, or a subject that the Store itself cannot reproduce.
+    # All helpers run inside the caller's transaction (self._lock is an
+    # RLock, so nested Store reads are safe).
+    # ------------------------------------------------------------------
+
+    def _revalidate_failure_evidence(self, evidence) -> None:
+        from total_gateway.verification_failure_evidence import (
+            build_failure_evidence,
+        )
+
+        plan = self.get_verification_plan(evidence.verification_plan_id)
+        if plan is None:
+            raise ValueError(
+                "failure evidence revalidation: plan absent from store"
+            )
+        readiness = self.get_verification_readiness_by_sha(
+            request_id=evidence.request_id,
+            run_id=evidence.run_id,
+            generation=evidence.generation,
+            readiness_sha256=evidence.readiness_sha256,
+        )
+        if readiness is None:
+            raise ValueError(
+                "failure evidence revalidation: readiness absent from store"
+            )
+        rebuilt = build_failure_evidence(
+            plan=plan,
+            readiness=readiness,
+            store=self,
+            effective_subject_resolver=(
+                lambda plan_entry_id: (
+                    self.resolve_verification_subject(plan_entry_id).get(
+                        "effective_subject_identity"
+                    )
+                )
+            ),
+            observed_at_ms=evidence.observed_at_ms,
+        )
+        for candidate in rebuilt:
+            if (
+                candidate.failure_evidence_id == evidence.failure_evidence_id
+                and candidate.failure_evidence_sha256
+                == evidence.failure_evidence_sha256
+            ):
+                return
+        raise ValueError(
+            "failure evidence revalidation: store cannot re-derive the"
+            " supplied evidence from plan + readiness + records"
+        )
+
+    def _revalidate_disposition(self, disposition) -> None:
+        from total_gateway.verification_repair_policy import (
+            DEFAULT_POLICY,
+            POLICY_VERSION,
+            compute_disposition_action,
+        )
+
+        evidence = self.get_verification_failure_evidence_by_id(
+            disposition.failure_evidence_id
+        )
+        if evidence is None:
+            raise ValueError(
+                "disposition revalidation: failure evidence absent from store"
+            )
+        if (
+            evidence.failure_evidence_sha256
+            != disposition.failure_evidence_sha256
+        ):
+            raise ValueError(
+                "disposition revalidation: failure evidence hash mismatch"
+            )
+
+        prev = self.list_verification_dispositions(
+            plan_entry_id=disposition.plan_entry_id
+        )
+        prior_repair_count = sum(
+            1
+            for d in prev
+            if d.action == "REPAIR"
+            and d.verification_disposition_id
+            != disposition.verification_disposition_id
+        )
+        same_signature_count = (
+            sum(
+                1
+                for fe in self.list_verification_failure_evidence(
+                    plan_entry_id=disposition.plan_entry_id
+                )
+                if fe.failure_signature_sha256
+                == evidence.failure_signature_sha256
+            )
+            - 1  # the evidence under test is already persisted
+        )
+        resolution = self.resolve_verification_subject(
+            disposition.plan_entry_id
+        )
+        successor_depth = resolution.get("successor_depth", 0)
+        generation_repair_count = sum(
+            1
+            for d in self.list_all_verification_dispositions(
+                request_id=disposition.request_id,
+                run_id=disposition.run_id,
+                generation=disposition.generation,
+            )
+            if d.action == "REPAIR"
+            and d.verification_disposition_id
+            != disposition.verification_disposition_id
+        )
+        side_effect_repair_count = (
+            prior_repair_count
+            if evidence.subject_kind in ("effect", "repository")
+            else 0
+        )
+
+        effect_ambiguous = False
+        if evidence.subject_kind == "effect":
+            record = self.get_effect(evidence.effective_subject_identity)
+            if record is not None:
+                effect_ambiguous = record.state in (
+                    "AMBIGUOUS",
+                    "SIDE_EFFECT_STARTED",
+                )
+
+        expected_action, expected_reasons = compute_disposition_action(
+            predicate_type=evidence.predicate_type,
+            verification_status=evidence.verification_status,
+            failure_kind=evidence.failure_kind,
+            attempt_no=prior_repair_count,
+            same_signature_count=same_signature_count,
+            successor_depth=successor_depth,
+            generation_repair_count=generation_repair_count,
+            side_effect_repair_count=side_effect_repair_count,
+            subject_kind=evidence.subject_kind,
+            effect_is_ambiguous=effect_ambiguous,
+            policy=DEFAULT_POLICY,
+        )
+        if disposition.action != expected_action:
+            raise ValueError(
+                "disposition revalidation: action does not match the"
+                " deterministic policy re-computation"
+                f" (got {disposition.action}, expected {expected_action})"
+            )
+        if tuple(disposition.reason_codes) != tuple(expected_reasons):
+            raise ValueError(
+                "disposition revalidation: reason codes do not match the"
+                " deterministic policy re-computation"
+            )
+        if disposition.attempt_no != prior_repair_count:
+            raise ValueError(
+                "disposition revalidation: attempt_no does not match the"
+                " store-derived REPAIR count"
+            )
+        if disposition.policy_version != POLICY_VERSION:
+            raise ValueError(
+                "disposition revalidation: unknown policy version"
+            )
+        if disposition.policy_config_sha256 != DEFAULT_POLICY.config_sha256():
+            raise ValueError(
+                "disposition revalidation: policy config hash does not"
+                " match the authoritative policy"
+            )
+        if disposition.max_attempts != DEFAULT_POLICY.max_attempts_per_plan_entry:
+            raise ValueError(
+                "disposition revalidation: max_attempts does not match the"
+                " authoritative policy"
+            )
+
+    def _revalidate_repair_directive(self, directive) -> None:
+        disposition = self.get_verification_disposition_by_id(
+            directive.disposition_id
+        )
+        if disposition is None:
+            raise ValueError(
+                "repair directive revalidation: disposition absent from store"
+            )
+        if disposition.action != "REPAIR":
+            raise ValueError(
+                "repair directive revalidation: bound disposition is not"
+                " REPAIR"
+            )
+        if disposition.disposition_sha256 != directive.disposition_sha256:
+            raise ValueError(
+                "repair directive revalidation: disposition hash mismatch"
+            )
+        if disposition.plan_entry_id != directive.plan_entry_id:
+            raise ValueError(
+                "repair directive revalidation: plan entry mismatch"
+            )
+        if (
+            disposition.failure_evidence_id != directive.failure_evidence_id
+            or disposition.failure_evidence_sha256
+            != directive.failure_evidence_sha256
+        ):
+            raise ValueError(
+                "repair directive revalidation: failure evidence linkage"
+                " mismatch"
+            )
+        plan = self.get_verification_plan(directive.verification_plan_id)
+        if plan is None:
+            raise ValueError(
+                "repair directive revalidation: plan absent from store"
+            )
+        if plan.plan_sha256 != directive.verification_plan_sha256:
+            raise ValueError(
+                "repair directive revalidation: plan hash mismatch"
+            )
+        entry = next(
+            (
+                e
+                for e in plan.entries
+                if e.plan_entry_id == directive.plan_entry_id
+            ),
+            None,
+        )
+        if entry is None:
+            raise ValueError(
+                "repair directive revalidation: plan entry absent from plan"
+            )
+        if entry.entry_sha256 != directive.plan_entry_sha256:
+            raise ValueError(
+                "repair directive revalidation: plan entry hash mismatch"
+            )
+        if (
+            entry.predicate.predicate_id != directive.predicate_id
+            or entry.predicate.predicate_sha256
+            != directive.predicate_sha256
+        ):
+            raise ValueError(
+                "repair directive revalidation: predicate linkage mismatch"
+            )
+        if entry.subject_identity != directive.original_subject_identity:
+            raise ValueError(
+                "repair directive revalidation: original subject mismatch"
+            )
+        resolution = self.resolve_verification_subject(entry.plan_entry_id)
+        effective = (
+            resolution.get("effective_subject_identity")
+            or entry.subject_identity
+        )
+        if effective != directive.effective_subject_identity:
+            raise ValueError(
+                "repair directive revalidation: effective subject does not"
+                " match the store successor chain"
+            )
+
+    def _revalidate_repair_attempt(self, attempt) -> None:
+        directive = self.get_repair_directive_by_id(
+            attempt.repair_directive_id
+        )
+        if directive is None:
+            raise ValueError(
+                "repair attempt revalidation: directive absent from store"
+            )
+        if directive.plan_entry_id != attempt.plan_entry_id:
+            raise ValueError(
+                "repair attempt revalidation: plan entry mismatch"
+            )
+        if directive.repair_attempt_no != attempt.repair_attempt_no:
+            raise ValueError(
+                "repair attempt revalidation: attempt number mismatch"
+            )
+        if directive.effective_subject_identity != attempt.prior_subject_identity:
+            raise ValueError(
+                "repair attempt revalidation: prior subject mismatch"
+            )
+        for effect_id in attempt.execution_effect_ids:
+            if self.get_effect(effect_id) is None:
+                raise ValueError(
+                    "repair attempt revalidation: execution effect absent"
+                    " from the effect ledger"
+                )
+        if attempt.reverify_record_id is not None:
+            row = self._connection.execute(
+                "SELECT predicate_id FROM verification_record"
+                " WHERE verification_record_id = ?",
+                (attempt.reverify_record_id,),
+            ).fetchone()
+            if row is None or str(row["predicate_id"]) != directive.predicate_id:
+                raise ValueError(
+                    "repair attempt revalidation: re-verification record"
+                    " absent from the store"
+                )
+
+    def _revalidate_subject_successor(self, successor) -> None:
+        directive = self.get_repair_directive_by_id(
+            successor.repair_directive_id
+        )
+        if directive is None:
+            raise ValueError(
+                "subject successor revalidation: directive absent from store"
+            )
+        if directive.directive_sha256 != successor.repair_directive_sha256:
+            raise ValueError(
+                "subject successor revalidation: directive hash mismatch"
+            )
+        if directive.plan_entry_id != successor.plan_entry_id:
+            raise ValueError(
+                "subject successor revalidation: plan entry mismatch"
+            )
+        if directive.subject_kind != successor.subject_kind:
+            raise ValueError(
+                "subject successor revalidation: subject kind mismatch"
+            )
+        if directive.repair_attempt_no != successor.repair_attempt_no:
+            raise ValueError(
+                "subject successor revalidation: attempt number mismatch"
+            )
+        # The predecessor must be the CURRENT effective subject — a
+        # successor of an already-superseded subject would fork the chain.
+        resolution = self.resolve_verification_subject(successor.plan_entry_id)
+        current_effective = resolution.get("effective_subject_identity")
+        if current_effective is None:
+            plan = self.get_verification_plan(successor.verification_plan_id)
+            entry = next(
+                (
+                    e
+                    for e in (plan.entries if plan else ())
+                    if e.plan_entry_id == successor.plan_entry_id
+                ),
+                None,
+            )
+            current_effective = (
+                entry.subject_identity if entry is not None else None
+            )
+        if successor.predecessor_subject_identity != current_effective:
+            raise ValueError(
+                "subject successor revalidation: predecessor is not the"
+                " current effective subject"
+            )
+        if self.get_effect(successor.produced_by_effect_id) is None:
+            raise ValueError(
+                "subject successor revalidation: producing effect absent"
+                " from the effect ledger"
+            )
+        # Successor must exist in authoritative reality. Artifact
+        # manifests live in the object store (outside SQLite authority);
+        # for artifacts the producing-effect binding plus the mandatory
+        # re-verification (the executor requires a manifest keyed by the
+        # successor id) enforce reality. Effect/repository subjects are
+        # checked directly here.
+        if successor.subject_kind == "effect":
+            if self.get_effect(successor.successor_subject_identity) is None:
+                raise ValueError(
+                    "subject successor revalidation: successor effect"
+                    " absent from the effect ledger"
+                )
+        elif successor.subject_kind == "repository":
+            if not self.list_repository_bindings_for_subject(
+                successor.successor_subject_identity
+            ):
+                raise ValueError(
+                    "subject successor revalidation: successor has no"
+                    " repository observation bindings"
+                )
+
     def put_verification_failure_evidence(self, evidence, *, recorded_at_ms: int) -> bool:
         from contracts.verification import FailureEvidence
         if not isinstance(evidence, FailureEvidence):
@@ -10587,6 +11050,8 @@ class GatewayStateStore:
                         "failure evidence identity was reused for different content"
                     )
                 return False
+            # M5 Final #4: re-derive from plan + readiness + records.
+            self._revalidate_failure_evidence(evidence)
             self._connection.execute(
                 "INSERT INTO verification_failure_evidence ("
                 "failure_evidence_id, request_id, run_id, generation,"
@@ -10644,6 +11109,9 @@ class GatewayStateStore:
                         "disposition identity was reused for different content"
                     )
                 return False
+            # M5 Final #4: the Store must be able to reproduce the
+            # decision from its own state before accepting it.
+            self._revalidate_disposition(disposition)
             self._connection.execute(
                 "INSERT INTO verification_disposition ("
                 "verification_disposition_id, request_id, run_id, generation,"
@@ -10766,6 +11234,10 @@ class GatewayStateStore:
                         "repair directive identity was reused for different content"
                     )
                 return False
+            # M5 Final #4: directive must bind a stored REPAIR
+            # disposition, the plan entry, and the current effective
+            # subject.
+            self._revalidate_repair_directive(directive)
             self._connection.execute(
                 "INSERT INTO repair_directive ("
                 "repair_directive_id, request_id, run_id, generation,"
@@ -10809,6 +11281,9 @@ class GatewayStateStore:
                         "repair attempt identity was reused for different content"
                     )
                 return False
+            # M5 Final #4: every bound execution effect must exist in
+            # the authoritative EffectLedger.
+            self._revalidate_repair_attempt(attempt)
             self._connection.execute(
                 "INSERT INTO repair_attempt ("
                 "repair_attempt_id, repair_directive_id, repair_attempt_no,"
@@ -10855,6 +11330,10 @@ class GatewayStateStore:
                         "subject successor identity was reused for different content"
                     )
                 return False
+            # M5 Final #4: predecessor must be the current effective
+            # subject and the successor must exist in authoritative
+            # reality.
+            self._revalidate_subject_successor(successor)
             self._connection.execute(
                 "INSERT INTO verification_subject_successor ("
                 "successor_binding_id, request_id, run_id, generation,"
@@ -10886,7 +11365,8 @@ class GatewayStateStore:
         with self._lock:
             rows = self._connection.execute(
                 "SELECT binding_json FROM verification_subject_successor"
-                " WHERE plan_entry_id = ? ORDER BY bound_at_ms, successor_binding_id",
+                " WHERE plan_entry_id = ?"
+                " ORDER BY bound_at_ms, rowid",
                 (plan_entry_id,),
             ).fetchall()
         bindings = [

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -10824,9 +10824,14 @@ class GatewayStateStore:
                     live = (
                         int(existing["claim_expires_at_ms"]) > reserved_at_ms
                     )
-                    if same_claim or not live:
-                        # idempotent re-entry, or an expired pre-start
-                        # lease CAS-taken over by this claim
+                    if same_claim and live:
+                        # idempotent re-entry by the CURRENT live claim —
+                        # the fencing token (claim_revision) must NOT be
+                        # bumped, or takeover semantics get dirty.
+                        return {"outcome": "EXECUTE", "binding": dict(existing)}
+                    if not live:
+                        # expired pre-start lease: this claim CAS-takes
+                        # over; only NOW does the revision advance
                         self._connection.execute(
                             "UPDATE repair_execution_binding SET"
                             " dispatch_claim_id = ?, claim_revision ="
@@ -10871,17 +10876,27 @@ class GatewayStateStore:
             return {"outcome": "EXECUTE", "binding": dict(row)}
 
     def start_repair_execution(
-        self, *, repair_directive_id: str, effect_id: str, started_at_ms: int
+        self,
+        *,
+        repair_directive_id: str,
+        effect_id: str,
+        started_at_ms: int,
+        dispatch_claim_id: str,
+        expected_claim_revision: int,
     ) -> dict:
-        """ONE atomic authority transition (Final P0-2):
+        """ONE atomic, CLAIM-FENCED authority transition:
 
             EffectLedger  CLAIMED → SIDE_EFFECT_STARTED
             RepairBinding RESERVED → SIDE_EFFECT_STARTED
 
-        The binding must own exactly ``effect_id``. After this
-        transaction no committed state can ever show an effect past the
-        boundary while its binding is still RESERVED. Takeover is over:
-        SIDE_EFFECT_STARTED means RECONCILE-only on recovery.
+        The CAS must hold on ALL of: state RESERVED, dispatch_claim_id
+        exactly the caller's, claim_revision exactly the caller's
+        fencing token, the lease STILL LIVE at start time, and the
+        binding owning exactly ``effect_id``. Only the winner gets
+        ``{"outcome": "STARTED"}`` — the only result that authorizes
+        entering the runtime. An already-crossed boundary returns
+        ``ALREADY_STARTED`` (the caller must NOT execute the runtime);
+        a stale or expired claim is rejected outright.
         """
         with self._lock, self._write_transaction():
             row = self._binding_row_locked(repair_directive_id)
@@ -10892,39 +10907,47 @@ class GatewayStateStore:
                     "repair execution binding owns a different effect"
                 )
             state = str(row["state"])
-            if state == "RESERVED":
-                if started_at_ms < int(row["reserved_at_ms"]):
-                    raise ValueError(
-                        "repair execution start predates its reservation"
-                    )
-            elif state == "SIDE_EFFECT_STARTED":
-                if int(row["started_at_ms"] or 0) > started_at_ms:
-                    raise ValueError(
-                        "repair execution start predates its boundary"
-                    )
-            else:
+            if state == "SIDE_EFFECT_STARTED":
+                return {
+                    "outcome": "ALREADY_STARTED",
+                    "binding": dict(row),
+                }
+            if state != "RESERVED":
                 raise ValueError(
-                    "repair execution binding is not in a startable state:"
-                    f" {state}"
+                    "repair execution binding is not in a startable"
+                    f" state: {state}"
                 )
-            # Same transaction: cross the EffectLedger boundary first.
+            if started_at_ms < int(row["reserved_at_ms"]):
+                raise ValueError(
+                    "repair execution start predates its reservation"
+                )
+            # Claim fencing: the caller must be the CURRENT live claim
+            # owner with the CURRENT revision. A claim that lost a
+            # takeover can never cross the runtime boundary.
+            updated = self._connection.execute(
+                "UPDATE repair_execution_binding SET state ="
+                " 'SIDE_EFFECT_STARTED', started_at_ms = ?"
+                " WHERE repair_directive_id = ? AND state = 'RESERVED'"
+                " AND dispatch_claim_id = ? AND claim_revision = ?"
+                " AND claim_expires_at_ms > ?",
+                (
+                    started_at_ms, repair_directive_id,
+                    dispatch_claim_id, expected_claim_revision,
+                    started_at_ms,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise StoreCasConflict(
+                    "stale dispatch claim: this caller no longer owns the"
+                    " repair execution (claim/revision/lease mismatch)"
+                )
+            # Same transaction: cross the EffectLedger boundary.
             self.mark_effect_started(
                 effect_id, started_at_ms=started_at_ms
             )
-            if state == "RESERVED":
-                updated = self._connection.execute(
-                    "UPDATE repair_execution_binding SET state ="
-                    " 'SIDE_EFFECT_STARTED', started_at_ms = ?"
-                    " WHERE repair_directive_id = ? AND state = 'RESERVED'",
-                    (started_at_ms, repair_directive_id),
-                )
-                if updated.rowcount != 1:
-                    raise StoreCasConflict(
-                        "repair execution binding changed before start"
-                    )
             updated_row = self._binding_row_locked(repair_directive_id)
             assert updated_row is not None
-            return dict(updated_row)
+            return {"outcome": "STARTED", "binding": dict(updated_row)}
 
     def complete_repair_execution(
         self,

--- a/src/total_gateway/store_unit_of_work.py
+++ b/src/total_gateway/store_unit_of_work.py
@@ -22,7 +22,19 @@ def gateway_store_write_transaction(
     checks, and domain SQL remain responsibilities of ``GatewayStateStore``.
     The control flow deliberately keeps COMMIT inside the try block so a COMMIT
     failure follows the historical ROLLBACK path.
+
+    Re-entrant: a nested call JOINS the outer transaction instead
+    of failing on "cannot start a transaction within a transaction".
+    An exception inside the nested scope still propagates and rolls
+    back the whole outer transaction (fail-closed, never a partial
+    commit). This lets composite Store APIs move TWO authorities
+    (the EffectLedger and the repair execution binding) in ONE
+    atomic transition.
     """
+
+    if getattr(connection, "in_transaction", False):
+        yield
+        return
 
     connection.execute("BEGIN IMMEDIATE")
     try:

--- a/src/total_gateway/verification_plan_executor.py
+++ b/src/total_gateway/verification_plan_executor.py
@@ -102,13 +102,24 @@ class VerificationPlanExecutor:
         evaluated_at_ms: int,
         manifests_by_revision: dict,
     ) -> None:
+        # M5 Final #2: resolve the CURRENT effective subject from the
+        # Store successor chain (§8). After a repair the SAME predicate
+        # must be re-verified against the NEW subject — never silently
+        # re-read the original plan subject.
+        effective_subject = entry.subject_identity
+        if hasattr(self._store, "resolve_verification_subject"):
+            resolution = self._store.resolve_verification_subject(
+                entry.plan_entry_id
+            )
+            if resolution.get("effective_subject_identity"):
+                effective_subject = resolution["effective_subject_identity"]
         kind = entry.predicate.subject_kind
         if kind == "artifact":
-            manifest = manifests_by_revision.get(entry.subject_identity)
+            manifest = manifests_by_revision.get(effective_subject)
             if manifest is None:
                 raise VerificationPlanExecutorError(
                     f"artifact manifest not in execution context:"
-                    f" {entry.subject_identity}"
+                    f" {effective_subject}"
                 )
             record = self._artifact_oracle.evaluate(
                 manifest, entry.predicate,
@@ -117,13 +128,13 @@ class VerificationPlanExecutor:
             )
         elif kind == "effect":
             record = self._effect_oracle.evaluate(
-                entry.subject_identity, entry.predicate,
+                effective_subject, entry.predicate,
                 evaluated_at_ms=evaluated_at_ms,
                 evaluation_phase=entry.evaluation_phase,
             )
         elif kind == "repository":
             bindings = self._store.list_repository_bindings_for_subject(
-                entry.subject_identity
+                effective_subject
             )
             sorted_bindings = sorted(
                 bindings,
@@ -140,7 +151,7 @@ class VerificationPlanExecutor:
                     "repository PRE/POST bindings incomplete"
                 )
             record = self._repository_oracle.evaluate(
-                subject_effect_id=entry.subject_identity,
+                subject_effect_id=effective_subject,
                 pre_binding_id=pre["binding_id"],
                 post_binding_id=post["binding_id"],
                 predicate=entry.predicate,
@@ -163,6 +174,18 @@ class VerificationPlanExecutor:
         from contracts.verification import VerificationRecord
         from contracts.verification import derive_verification_record_id
 
+        # M5 Final #2: ERROR records bind to the CURRENT effective
+        # subject — bound to the original subject they would be filtered
+        # out by successor supersession and silently mask an evaluation
+        # failure with stale PASS records.
+        effective_subject = entry.subject_identity
+        if hasattr(self._store, "resolve_verification_subject"):
+            resolution = self._store.resolve_verification_subject(
+                entry.plan_entry_id
+            )
+            if resolution.get("effective_subject_identity"):
+                effective_subject = resolution["effective_subject_identity"]
+
         payload = dict(
             verification_record_id="vrs_" + "0" * 64,
             request_id=self._plan.request_id,
@@ -174,7 +197,7 @@ class VerificationPlanExecutor:
             predicate_id=entry.predicate.predicate_id,
             predicate_type=entry.predicate.predicate_type,
             subject_kind=entry.predicate.subject_kind,
-            subject_identity=entry.subject_identity,
+            subject_identity=effective_subject,
             evaluation_phase=entry.evaluation_phase,
             status="ERROR",
             enforcement="RECORD",

--- a/src/total_gateway/verification_readiness.py
+++ b/src/total_gateway/verification_readiness.py
@@ -172,30 +172,42 @@ def build_readiness(
     satisfied_count = 0
 
     for entry in sorted(plan.entries, key=lambda e: e.plan_entry_id):
-        # M5 Final §9: resolve the effective subject from the Store's
-        # successor chain — no caller callback. Without a successor, the
-        # effective subject is the plan entry's original subject.
+        # M5 Final Closure Correction #6: resolve effective subject from
+        # Store. When a successor EXISTS, ONLY the effective subject's
+        # records are valid candidates — old original-subject records
+        # must NOT re-enter supersession (they represent the pre-repair
+        # reality that was already judged FAIL).
         effective_subject = entry.subject_identity
+        has_successor = False
         if hasattr(store, "resolve_verification_subject"):
             resolution = store.resolve_verification_subject(entry.plan_entry_id)
             if resolution.get("effective_subject_identity"):
                 effective_subject = resolution["effective_subject_identity"]
-        matching = [
-            r for r in all_records
-            if _record_matches_entry(
-                r, entry,
-                plan_registry_sha256=plan.registry_snapshot_sha256,
-                request_id=plan.request_id,
-                run_id=plan.run_id,
-                generation=plan.generation,
-            ) or _record_matches_effective_subject(
-                r, entry, effective_subject,
-                plan_registry_sha256=plan.registry_snapshot_sha256,
-                request_id=plan.request_id,
-                run_id=plan.run_id,
-                generation=plan.generation,
-            )
-        ]
+                has_successor = True
+        if has_successor:
+            # successor exists: ONLY match effective subject records
+            matching = [
+                r for r in all_records
+                if _record_matches_effective_subject(
+                    r, entry, effective_subject,
+                    plan_registry_sha256=plan.registry_snapshot_sha256,
+                    request_id=plan.request_id,
+                    run_id=plan.run_id,
+                    generation=plan.generation,
+                )
+            ]
+        else:
+            # no successor: match original subject records
+            matching = [
+                r for r in all_records
+                if _record_matches_entry(
+                    r, entry,
+                    plan_registry_sha256=plan.registry_snapshot_sha256,
+                    request_id=plan.request_id,
+                    run_id=plan.run_id,
+                    generation=plan.generation,
+                )
+            ]
         if not matching:
             if entry.required:
                 required_count += 1

--- a/src/total_gateway/verification_repair_coordinator.py
+++ b/src/total_gateway/verification_repair_coordinator.py
@@ -77,12 +77,25 @@ class VerificationRepairCoordinator:
         )
 
         dispositions: list[VerificationDisposition] = []
+        # M5 Final Correction #5: generation total budget (across ALL entries)
+        generation_repair_count = sum(
+            1 for d in self._store.list_all_verification_dispositions(
+                request_id=plan.request_id,
+                run_id=plan.run_id,
+                generation=plan.generation,
+            )
+            if d.action == "REPAIR"
+        ) if hasattr(self._store, "list_all_verification_dispositions") else 0
+
         for fe in failure_evidences:
-            # Count previous dispositions for this entry (attempt tracking)
+            # Count previous REPAIR dispositions for this entry
             prev_dispositions = self._store.list_verification_dispositions(
                 plan_entry_id=fe.plan_entry_id,
             )
-            attempt_no = len(prev_dispositions)
+            # M5 Final #5: only count REPAIR actions as attempts
+            attempt_no = sum(
+                1 for d in prev_dispositions if d.action == "REPAIR"
+            )
 
             # Count same failure signature occurrences
             prev_failures = self._store.list_verification_failure_evidence(
@@ -93,8 +106,35 @@ class VerificationRepairCoordinator:
                 if f.failure_signature_sha256 == fe.failure_signature_sha256
             )
 
-            # Effect ambiguity check
+            # M5 Final #5: successor depth budget
+            successor_depth = 0
+            if hasattr(self._store, "resolve_verification_subject"):
+                resolution = self._store.resolve_verification_subject(
+                    fe.plan_entry_id
+                )
+                successor_depth = resolution.get("successor_depth", 0)
+
+            # M5 Final #5: side-effecting repair count (effect/repo subjects)
+            side_effect_repair_count = sum(
+                1 for d in prev_dispositions
+                if d.action == "REPAIR"
+                and fe.subject_kind in ("effect", "repository")
+            )
+
+            # Effect ambiguity check (M5 Final #22: fail-closed)
             effect_ambiguous = self._check_effect_ambiguity(fe)
+
+            # Build extra reason codes for budget violations
+            extra_reasons: list[str] = []
+            if generation_repair_count >= self._policy.max_total_auto_repairs_per_generation:
+                extra_reasons.append("repair_policy.generation_budget_exhausted")
+            if successor_depth >= self._policy.max_subject_successor_depth:
+                extra_reasons.append("repair_policy.successor_depth_exhausted")
+            if (
+                fe.subject_kind in ("effect", "repository")
+                and side_effect_repair_count >= self._policy.max_side_effecting_repairs_per_entry
+            ):
+                extra_reasons.append("repair_policy.side_effect_budget_exhausted")
 
             action, reasons = evaluate_disposition(
                 predicate_type=fe.predicate_type,
@@ -106,6 +146,11 @@ class VerificationRepairCoordinator:
                 effect_is_ambiguous=effect_ambiguous,
                 policy=self._policy,
             )
+            # M5 Final #5: budget overrides — any exhausted budget forces
+            # REVIEW regardless of what the base policy decided
+            if extra_reasons and action == "REPAIR":
+                action = "REVIEW"
+                reasons = tuple(extra_reasons)
 
             disposition = VerificationDisposition(
                 verification_disposition_id="vds_" + "0" * 64,
@@ -235,16 +280,19 @@ class VerificationRepairCoordinator:
         return attempt
 
     def _check_effect_ambiguity(self, fe: FailureEvidence) -> bool:
-        """§29: check if the subject effect is in AMBIGUOUS state."""
+        """§22: fail-closed — if Effect authority query fails, treat as
+        ambiguous (RECONCILE), never as 'not ambiguous'."""
         if fe.subject_kind != "effect":
             return False
         try:
             record = self._store.get_effect(fe.effective_subject_identity)
             if record is None:
-                return False
+                return False  # effect doesn't exist → not ambiguous, just missing
             return record.state in ("AMBIGUOUS", "SIDE_EFFECT_STARTED")
         except Exception:
-            return False  # can't determine → let policy handle by failure_kind
+            # M5 Final #22: authority query failure → fail-closed → treat
+            # as ambiguous → disposition becomes RECONCILE
+            return True
 
 
 __all__ = [

--- a/src/total_gateway/verification_repair_coordinator.py
+++ b/src/total_gateway/verification_repair_coordinator.py
@@ -121,23 +121,33 @@ class VerificationRepairCoordinator:
         ) if hasattr(self._store, "list_all_verification_dispositions") else 0
 
         for fe in failure_evidences:
-            # Count previous REPAIR dispositions for this entry
+            # P1-7: attempt_no counts REAL executed attempts (Store
+            # attempt table), not issued REPAIR dispositions — repeated
+            # crashes before dispatch must not burn the budget.
+            executed_attempts = self._store.list_repair_attempts(
+                fe.plan_entry_id
+            )
+            attempt_no = len(executed_attempts)
             prev_dispositions = self._store.list_verification_dispositions(
                 plan_entry_id=fe.plan_entry_id,
             )
-            # M5 Final #5: only count REPAIR actions as attempts
-            attempt_no = sum(
-                1 for d in prev_dispositions if d.action == "REPAIR"
-            )
 
-            # Count same failure signature occurrences
+            # Count same failure signature occurrences — de-duplicated
+            # by readiness: re-deriving the SAME failure after a crash
+            # (same readiness) is not a NEW failure observation. The
+            # count INCLUDES the evidence under construction (minus 1),
+            # matching the Store revalidation's post-insert view exactly.
             prev_failures = self._store.list_verification_failure_evidence(
                 plan_entry_id=fe.plan_entry_id,
             )
-            same_sig_count = sum(
-                1 for f in prev_failures
-                if f.failure_signature_sha256 == fe.failure_signature_sha256
-            )
+            same_sig_count = len(
+                {
+                    f.readiness_sha256
+                    for f in prev_failures
+                    if f.failure_signature_sha256 == fe.failure_signature_sha256
+                }
+                | {fe.readiness_sha256}
+            ) - 1
 
             # M5 Final #5: successor depth budget
             successor_depth = 0
@@ -147,15 +157,24 @@ class VerificationRepairCoordinator:
                 )
                 successor_depth = resolution.get("successor_depth", 0)
 
-            # M5 Final #5: side-effecting repair count (effect/repo subjects)
-            side_effect_repair_count = sum(
-                1 for d in prev_dispositions
-                if d.action == "REPAIR"
-                and fe.subject_kind in ("effect", "repository")
+            # M5 Final #5: side-effecting repair count (effect/repo
+            # subjects) — also counts only REAL executed attempts.
+            side_effect_repair_count = (
+                attempt_no
+                if fe.subject_kind in ("effect", "repository")
+                else 0
             )
 
-            # Effect ambiguity check (M5 Final #22: fail-closed)
-            effect_ambiguous = self._check_effect_ambiguity(fe)
+            # Effect ambiguity check (M5 Final #22: fail-closed).
+            # P0-1: an earlier repair attempt whose runtime outcome was
+            # AMBIGUOUS counts as ambiguity for THIS entry regardless of
+            # the FE subject kind — an artifact repair whose runtime
+            # dispatch landed in an ambiguous state must never be
+            # blindly replayed either.
+            effect_ambiguous = (
+                self._check_effect_ambiguity(fe)
+                or self._entry_has_ambiguous_attempt(fe.plan_entry_id)
+            )
 
             # M5 Final #4/#5: single source of truth — the same
             # budget-aware decision the Store revalidation recomputes.
@@ -200,6 +219,13 @@ class VerificationRepairCoordinator:
                 disposition, recorded_at_ms=now_ms
             )
             dispositions.append(disposition)
+            # P1-8: increment the in-round generation budget so a single
+            # readiness with N repairable entries cannot see the same
+            # pre-round count N times (the Store recomputes it too, but
+            # the policy stop must be a normal REVIEW, not a write
+            # rejection).
+            if action == "REPAIR":
+                generation_repair_count += 1
 
         return dispositions
 
@@ -215,6 +241,11 @@ class VerificationRepairCoordinator:
         readiness: VerificationReadiness,
         dispatch: Callable[[RepairDirective], RepairDispatchResult],
         reverify: Callable[[], VerificationReadiness],
+        dispatchable_subject_kinds: tuple[str, ...] = (
+            "artifact",
+            "effect",
+            "repository",
+        ),
         now_ms: int | None = None,
     ) -> tuple[VerificationReadiness, VerificationDisposition | None]:
         """§14-§21 full evidence-driven repair loop.
@@ -222,6 +253,22 @@ class VerificationRepairCoordinator:
         ``dispatch`` bridges to the EXISTING runtime (caller-supplied; the
         coordinator never owns a second runtime). ``reverify`` re-runs the
         SAME verification plan producing NEW independent records.
+
+        ``dispatchable_subject_kinds`` gates WHICH subject kinds may be
+        auto-repaired in this channel context. Channel finalization runs
+        after the delivery boundary, so callers there restrict execution
+        (or pass an empty tuple) — a REPAIR disposition that is not
+        dispatchable here is returned untouched (the Gate keeps the
+        request IN_PROGRESS) and is NEVER blindly replayed.
+
+        P0-1 safety: a dispatch whose runtime outcome is AMBIGUOUS stops
+        the loop immediately — the attempt is persisted, the disposition
+        flips to RECONCILE (the ambiguous attempt is now visible to the
+        deterministic policy), and ZERO further repair attempts run.
+
+        Crash recovery: a persisted-but-never-attempted directive for the
+        same attempt number is REUSED, not re-issued, so repeated crashes
+        before dispatch cannot burn the repair budget.
 
         Termination is guaranteed twice over: every REPAIR iteration
         increments Store-persisted attempt counts (policy flips REPAIR →
@@ -249,15 +296,36 @@ class VerificationRepairCoordinator:
             )
             if dispositions:
                 final_disposition = dispositions[-1]
-            repairable = [d for d in dispositions if d.action == "REPAIR"]
+            kind_by_entry = {
+                e.plan_entry_id: e.predicate.subject_kind
+                for e in plan.entries
+            }
+            repairable = [
+                d
+                for d in dispositions
+                if d.action == "REPAIR"
+                and kind_by_entry.get(d.plan_entry_id)
+                in dispatchable_subject_kinds
+            ]
+            not_dispatchable = [
+                d
+                for d in dispositions
+                if d.action == "REPAIR"
+                and kind_by_entry.get(d.plan_entry_id)
+                not in dispatchable_subject_kinds
+            ]
             if not repairable:
-                # WAIT / RECONCILE / REVIEW / BLOCK — not auto-executable.
+                # WAIT / RECONCILE / REVIEW / BLOCK — or REPAIR that this
+                # context must not auto-execute (e.g. channel-side after
+                # an irreversible external side effect). Not replayed.
+                if not_dispatchable:
+                    final_disposition = not_dispatchable[0]
                 return current, final_disposition
 
             executed_any = False
             for disposition in repairable:
                 evidence = self._find_persisted_failure_evidence(disposition)
-                directive = self.issue_repair_directive(
+                directive = self._directive_for_disposition(
                     disposition=disposition,
                     failure_evidence=evidence,
                     plan=plan,
@@ -267,6 +335,26 @@ class VerificationRepairCoordinator:
                     continue
                 started_ms = time.time_ns() // 1_000_000
                 result = dispatch(directive)
+                if result.execution_outcome == "EXECUTION_AMBIGUOUS":
+                    # P0-1: unknown whether the side effect happened.
+                    # Persist the attempt (the Store revalidation and the
+                    # policy both read it), re-derive the disposition —
+                    # it is now RECONCILE — and stop. Zero replay.
+                    self.record_attempt(
+                        directive=directive,
+                        execution_outcome="EXECUTION_AMBIGUOUS",
+                        produced_subject_identity=(
+                            result.produced_subject_identity
+                        ),
+                        execution_effect_ids=result.execution_effect_ids,
+                        reverify_record_id=None,
+                        started_at_ms=started_ms,
+                        finished_at_ms=time.time_ns() // 1_000_000,
+                    )
+                    reconcile = self.process_readiness(
+                        plan=plan, readiness=current, now_ms=now_ms
+                    )
+                    return current, (reconcile[-1] if reconcile else None)
                 if (
                     not result.execution_effect_ids
                     and result.execution_outcome == "DISPATCHED"
@@ -313,6 +401,63 @@ class VerificationRepairCoordinator:
         # Hard cap reached — the next process_readiness pass would flip
         # every remaining REPAIR to REVIEW; surface the final state.
         return current, final_disposition
+
+    def _directive_for_disposition(
+        self,
+        *,
+        disposition: VerificationDisposition,
+        failure_evidence: FailureEvidence,
+        plan: VerificationPlan,
+        now_ms: int,
+    ):
+        """Issue a directive, or REUSE a pending one (crash recovery).
+
+        A persisted directive for the same attempt number with no
+        recorded attempt and un-expired is executed as-is — repeated
+        crashes before dispatch must not consume the repair budget.
+        """
+        pending = self._find_pending_directive(disposition, now_ms=now_ms)
+        if pending is not None:
+            return pending
+        return self.issue_repair_directive(
+            disposition=disposition,
+            failure_evidence=failure_evidence,
+            plan=plan,
+            now_ms=now_ms,
+        )
+
+    def _find_pending_directive(
+        self, disposition: VerificationDisposition, *, now_ms: int
+    ):
+        directives = self._store.list_repair_directives(
+            disposition.plan_entry_id
+        )
+        attempted = {
+            attempt.repair_directive_id
+            for attempt in self._store.list_repair_attempts(
+                disposition.plan_entry_id
+            )
+        }
+        expected_no = disposition.attempt_no + 1
+        for directive in reversed(directives):
+            if (
+                directive.repair_attempt_no == expected_no
+                and directive.repair_directive_id not in attempted
+                and directive.expires_at_ms > now_ms
+            ):
+                # The disposition may be a re-derived copy (new
+                # decided_at) — what must match is the attempt number,
+                # the absence of any recorded attempt, and validity.
+                return directive
+        return None
+
+    def _entry_has_ambiguous_attempt(self, plan_entry_id: str) -> bool:
+        """P0-1: once a repair dispatch ended AMBIGUOUS for this entry,
+        the deterministic policy must see ambiguity forever after."""
+        for attempt in self._store.list_repair_attempts(plan_entry_id):
+            if attempt.execution_outcome == "EXECUTION_AMBIGUOUS":
+                return True
+        return False
 
     def _find_persisted_failure_evidence(
         self, disposition: VerificationDisposition

--- a/src/total_gateway/verification_repair_coordinator.py
+++ b/src/total_gateway/verification_repair_coordinator.py
@@ -43,13 +43,16 @@ class RepairCoordinatorError(RuntimeError):
 class RepairDispatchResult:
     """Outcome of one RepairDirective executed by the EXISTING runtime.
 
-    ``execution_outcome`` is the runtime-level verdict (DISPATCHED when
+    ``execution_outcome`` is the runtime-level verdict: DISPATCHED when
     execution completed; EXECUTION_FAILED / EXECUTION_AMBIGUOUS when the
-    runtime itself failed). The re-verification verdict is derived later
-    from the NEW readiness and recorded on the attempt.
+    runtime itself failed; ALREADY_CLAIMED when the Store dispatch
+    boundary denied this worker (another coordinator owns the attempt —
+    the caller must not have executed the runtime). The re-verification
+    verdict is derived later from the NEW readiness and recorded on the
+    attempt.
     """
 
-    execution_outcome: str  # DISPATCHED | EXECUTION_FAILED | EXECUTION_AMBIGUOUS
+    execution_outcome: str  # DISPATCHED | EXECUTION_FAILED | EXECUTION_AMBIGUOUS | ALREADY_CLAIMED
     produced_subject_identity: str
     execution_effect_ids: tuple[str, ...] = ()
 
@@ -333,8 +336,18 @@ class VerificationRepairCoordinator:
                 )
                 if directive is None:
                     continue
+                # Final P0-1: the Store-side dispatch boundary decides
+                # whether THIS worker may cross into the runtime. The
+                # binding survives crashes, so recovery never re-executes
+                # a completed runtime and never replays a started one.
                 started_ms = time.time_ns() // 1_000_000
-                result = dispatch(directive)
+                result = self._resolve_dispatch_result(
+                    directive=directive, dispatch=dispatch
+                )
+                if result is None:
+                    # Another worker owns this attempt — hand over
+                    # control without recording anything.
+                    return current, None
                 if result.execution_outcome == "EXECUTION_AMBIGUOUS":
                     # P0-1: unknown whether the side effect happened.
                     # Persist the attempt (the Store revalidation and the
@@ -458,6 +471,72 @@ class VerificationRepairCoordinator:
             if attempt.execution_outcome == "EXECUTION_AMBIGUOUS":
                 return True
         return False
+
+    def _resolve_dispatch_result(
+        self,
+        *,
+        directive: RepairDirective,
+        dispatch: Callable[[RepairDirective], RepairDispatchResult],
+    ) -> RepairDispatchResult | None:
+        """Apply the Repair Execution Binding state machine.
+
+        Returns None when another worker owns this attempt (hand over),
+        otherwise the dispatch result. Recovery semantics (locked):
+        - no binding / RESERVED (same directive) → run the runtime
+          bridge (the bridge itself reserves atomically; a loser gets
+          ALREADY_CLAIMED and we hand over);
+        - SIDE_EFFECT_STARTED / AMBIGUOUS → EXECUTION_AMBIGUOUS result
+          WITHOUT calling the runtime (never replay a crossed boundary);
+        - SUCCEEDED → rebuild the result from the binding's persisted
+          produced subject — no runtime call;
+        - FAILED_FINAL → EXECUTION_FAILED result, no runtime call (a
+          NEW attempt number may be authorized by the policy later).
+        """
+        binding = None
+        if hasattr(
+            self._store, "get_repair_execution_binding_by_attempt"
+        ):
+            binding = self._store.get_repair_execution_binding_by_attempt(
+                directive.plan_entry_id, directive.repair_attempt_no
+            )
+        if binding is not None:
+            state = str(binding["state"])
+            effect_id = str(binding["effect_id"])
+            if binding["repair_directive_id"] != (
+                directive.repair_directive_id
+            ):
+                # A different directive owns this attempt slot.
+                return None
+            if state == "RESERVED":
+                pass  # continue below — same directive, pre-boundary
+            elif state in ("SIDE_EFFECT_STARTED", "AMBIGUOUS"):
+                return RepairDispatchResult(
+                    execution_outcome="EXECUTION_AMBIGUOUS",
+                    produced_subject_identity=(
+                        directive.effective_subject_identity
+                    ),
+                    execution_effect_ids=(effect_id,),
+                )
+            elif state == "SUCCEEDED":
+                return RepairDispatchResult(
+                    execution_outcome="DISPATCHED",
+                    produced_subject_identity=str(
+                        binding["produced_subject_identity"]
+                    ),
+                    execution_effect_ids=(effect_id,),
+                )
+            elif state == "FAILED_FINAL":
+                return RepairDispatchResult(
+                    execution_outcome="EXECUTION_FAILED",
+                    produced_subject_identity=(
+                        directive.effective_subject_identity
+                    ),
+                    execution_effect_ids=(effect_id,),
+                )
+        result = dispatch(directive)
+        if result.execution_outcome == "ALREADY_CLAIMED":
+            return None
+        return result
 
     def _find_persisted_failure_evidence(
         self, disposition: VerificationDisposition

--- a/src/total_gateway/verification_repair_coordinator.py
+++ b/src/total_gateway/verification_repair_coordinator.py
@@ -12,8 +12,9 @@ Runtime / Tool authority. The coordinator only decides and dispatches.
 
 from __future__ import annotations
 
+import dataclasses
 import time
-from typing import Any
+from typing import Any, Callable
 
 from contracts.verification import (
     FailureEvidence,
@@ -22,17 +23,35 @@ from contracts.verification import (
     VerificationPlan,
     VerificationReadiness,
 )
-from contracts.verification_repair import RepairAttemptRecord
+from contracts.verification_repair import (
+    RepairAttemptRecord,
+    VerificationSubjectSuccessor,
+)
 from total_gateway.verification_failure_evidence import build_failure_evidence
 from total_gateway.verification_repair_policy import (
     DEFAULT_POLICY,
     RepairPolicyConfig,
-    evaluate_disposition,
+    compute_disposition_action,
 )
 
 
 class RepairCoordinatorError(RuntimeError):
     """Repair loop failure — never falls back to NONE."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RepairDispatchResult:
+    """Outcome of one RepairDirective executed by the EXISTING runtime.
+
+    ``execution_outcome`` is the runtime-level verdict (DISPATCHED when
+    execution completed; EXECUTION_FAILED / EXECUTION_AMBIGUOUS when the
+    runtime itself failed). The re-verification verdict is derived later
+    from the NEW readiness and recorded on the attempt.
+    """
+
+    execution_outcome: str  # DISPATCHED | EXECUTION_FAILED | EXECUTION_AMBIGUOUS
+    produced_subject_identity: str
+    execution_effect_ids: tuple[str, ...] = ()
 
 
 class VerificationRepairCoordinator:
@@ -73,6 +92,20 @@ class VerificationRepairCoordinator:
             plan=plan,
             readiness=readiness,
             store=self._store,
+            # M5 Final #2: the FE signature must describe the CURRENT
+            # effective subject (Store successor chain), not the original
+            # plan subject.
+            effective_subject_resolver=(
+                lambda plan_entry_id: (
+                    self._store.resolve_verification_subject(
+                        plan_entry_id
+                    ).get("effective_subject_identity")
+                    if hasattr(
+                        self._store, "resolve_verification_subject"
+                    )
+                    else None
+                )
+            ),
             observed_at_ms=now_ms,
         )
 
@@ -124,33 +157,21 @@ class VerificationRepairCoordinator:
             # Effect ambiguity check (M5 Final #22: fail-closed)
             effect_ambiguous = self._check_effect_ambiguity(fe)
 
-            # Build extra reason codes for budget violations
-            extra_reasons: list[str] = []
-            if generation_repair_count >= self._policy.max_total_auto_repairs_per_generation:
-                extra_reasons.append("repair_policy.generation_budget_exhausted")
-            if successor_depth >= self._policy.max_subject_successor_depth:
-                extra_reasons.append("repair_policy.successor_depth_exhausted")
-            if (
-                fe.subject_kind in ("effect", "repository")
-                and side_effect_repair_count >= self._policy.max_side_effecting_repairs_per_entry
-            ):
-                extra_reasons.append("repair_policy.side_effect_budget_exhausted")
-
-            action, reasons = evaluate_disposition(
+            # M5 Final #4/#5: single source of truth — the same
+            # budget-aware decision the Store revalidation recomputes.
+            action, reasons = compute_disposition_action(
                 predicate_type=fe.predicate_type,
                 verification_status=fe.verification_status,
                 failure_kind=fe.failure_kind,
                 attempt_no=attempt_no,
-                max_attempts=self._policy.max_attempts_per_plan_entry,
                 same_signature_count=same_sig_count,
+                successor_depth=successor_depth,
+                generation_repair_count=generation_repair_count,
+                side_effect_repair_count=side_effect_repair_count,
+                subject_kind=fe.subject_kind,
                 effect_is_ambiguous=effect_ambiguous,
                 policy=self._policy,
             )
-            # M5 Final #5: budget overrides — any exhausted budget forces
-            # REVIEW regardless of what the base policy decided
-            if extra_reasons and action == "REPAIR":
-                action = "REVIEW"
-                reasons = tuple(extra_reasons)
 
             disposition = VerificationDisposition(
                 verification_disposition_id="vds_" + "0" * 64,
@@ -181,6 +202,229 @@ class VerificationRepairCoordinator:
             dispositions.append(disposition)
 
         return dispositions
+
+    # ------------------------------------------------------------------
+    # M5 Final #2: the FULL repair loop — directive → EXISTING runtime →
+    # successor → SAME-predicate re-verification with NEW evidence.
+    # ------------------------------------------------------------------
+
+    def execute_repair_loop(
+        self,
+        *,
+        plan: VerificationPlan,
+        readiness: VerificationReadiness,
+        dispatch: Callable[[RepairDirective], RepairDispatchResult],
+        reverify: Callable[[], VerificationReadiness],
+        now_ms: int | None = None,
+    ) -> tuple[VerificationReadiness, VerificationDisposition | None]:
+        """§14-§21 full evidence-driven repair loop.
+
+        ``dispatch`` bridges to the EXISTING runtime (caller-supplied; the
+        coordinator never owns a second runtime). ``reverify`` re-runs the
+        SAME verification plan producing NEW independent records.
+
+        Termination is guaranteed twice over: every REPAIR iteration
+        increments Store-persisted attempt counts (policy flips REPAIR →
+        REVIEW once any budget is exhausted), and the hard cap bounds the
+        loop independently of Store state.
+
+        Returns ``(final_readiness, final_disposition_or_None)`` — the
+        disposition, when present, is bound to the final readiness.
+        """
+        if now_ms is None:
+            now_ms = time.time_ns() // 1_000_000
+        if readiness.verification_ready:
+            return readiness, None
+
+        current = readiness
+        final_disposition: VerificationDisposition | None = None
+        hard_cap = self._policy.max_total_auto_repairs_per_generation + 1
+
+        for _ in range(hard_cap):
+            # Each iteration re-stamps time so dispositions/directives/
+            # successor bindings stay monotonically ordered in the Store.
+            now_ms = time.time_ns() // 1_000_000
+            dispositions = self.process_readiness(
+                plan=plan, readiness=current, now_ms=now_ms
+            )
+            if dispositions:
+                final_disposition = dispositions[-1]
+            repairable = [d for d in dispositions if d.action == "REPAIR"]
+            if not repairable:
+                # WAIT / RECONCILE / REVIEW / BLOCK — not auto-executable.
+                return current, final_disposition
+
+            executed_any = False
+            for disposition in repairable:
+                evidence = self._find_persisted_failure_evidence(disposition)
+                directive = self.issue_repair_directive(
+                    disposition=disposition,
+                    failure_evidence=evidence,
+                    plan=plan,
+                    now_ms=now_ms,
+                )
+                if directive is None:
+                    continue
+                started_ms = time.time_ns() // 1_000_000
+                result = dispatch(directive)
+                if (
+                    not result.execution_effect_ids
+                    and result.execution_outcome == "DISPATCHED"
+                ):
+                    raise RepairCoordinatorError(
+                        "repair dispatch claims success without an effect"
+                        " ledger binding"
+                    )
+                # Successor binding FIRST: re-verification must resolve
+                # the NEW effective subject for the entry (§17).
+                if (
+                    result.produced_subject_identity
+                    and result.produced_subject_identity
+                    != directive.effective_subject_identity
+                ):
+                    self._bind_successor(
+                        directive=directive, result=result, now_ms=now_ms
+                    )
+                # SAME predicate, NEW independent evidence (§21).
+                current = reverify()
+                reverify_record_id = self._latest_record_for_entry(
+                    plan, directive.plan_entry_id
+                )
+                self.record_attempt(
+                    directive=directive,
+                    execution_outcome=self._attempt_outcome(
+                        directive=directive,
+                        dispatch_result=result,
+                        readiness=current,
+                    ),
+                    produced_subject_identity=result.produced_subject_identity,
+                    execution_effect_ids=result.execution_effect_ids,
+                    reverify_record_id=reverify_record_id,
+                    started_at_ms=started_ms,
+                    finished_at_ms=time.time_ns() // 1_000_000,
+                )
+                executed_any = True
+                if current.verification_ready:
+                    return current, None
+
+            if not executed_any:
+                return current, final_disposition
+
+        # Hard cap reached — the next process_readiness pass would flip
+        # every remaining REPAIR to REVIEW; surface the final state.
+        return current, final_disposition
+
+    def _find_persisted_failure_evidence(
+        self, disposition: VerificationDisposition
+    ) -> FailureEvidence:
+        stored = self._store.list_verification_failure_evidence(
+            plan_entry_id=disposition.plan_entry_id
+        )
+        for evidence in stored:
+            if (
+                evidence.failure_evidence_id
+                == disposition.failure_evidence_id
+            ):
+                return evidence
+        raise RepairCoordinatorError(
+            "disposition references failure evidence absent from the store"
+        )
+
+    def _bind_successor(
+        self,
+        *,
+        directive: RepairDirective,
+        result: RepairDispatchResult,
+        now_ms: int,
+    ) -> None:
+        if not result.execution_effect_ids:
+            raise RepairCoordinatorError(
+                "subject successor requires a produced_by_effect binding"
+            )
+        successor = VerificationSubjectSuccessor(
+            successor_binding_id="vss_" + "0" * 64,
+            request_id=directive.request_id,
+            run_id=directive.run_id,
+            generation=directive.generation,
+            verification_plan_id=directive.verification_plan_id,
+            plan_entry_id=directive.plan_entry_id,
+            subject_kind=directive.subject_kind,
+            predecessor_subject_identity=directive.effective_subject_identity,
+            successor_subject_identity=result.produced_subject_identity,
+            repair_directive_id=directive.repair_directive_id,
+            repair_directive_sha256=directive.directive_sha256,
+            produced_by_effect_id=result.execution_effect_ids[0],
+            repair_attempt_no=directive.repair_attempt_no,
+            bound_at_ms=now_ms,
+            successor_binding_sha256="0" * 64,
+        ).with_computed_sha256()
+        self._store.put_verification_subject_successor(
+            successor, recorded_at_ms=now_ms
+        )
+
+    def _latest_record_for_entry(
+        self, plan: VerificationPlan, plan_entry_id: str
+    ) -> str | None:
+        entry = next(
+            (e for e in plan.entries if e.plan_entry_id == plan_entry_id),
+            None,
+        )
+        if entry is None:
+            return None
+        # Records bind to (predicate_id, subject_identity) — resolve the
+        # CURRENT effective subject so post-repair records are found.
+        effective_subject = entry.subject_identity
+        if hasattr(self._store, "resolve_verification_subject"):
+            resolution = self._store.resolve_verification_subject(
+                plan_entry_id
+            )
+            if resolution.get("effective_subject_identity"):
+                effective_subject = resolution["effective_subject_identity"]
+        records = self._store.list_verification_records(
+            request_id=plan.request_id,
+            run_id=plan.run_id,
+            generation=plan.generation,
+        )
+        matching = [
+            r
+            for r in records
+            if r.predicate_id == entry.predicate.predicate_id
+            and r.subject_identity == effective_subject
+        ]
+        if not matching:
+            return None
+        return max(
+            matching,
+            key=lambda r: (r.evaluated_at_ms, r.verification_record_id),
+        ).verification_record_id
+
+    @staticmethod
+    def _attempt_outcome(
+        *,
+        directive: RepairDirective,
+        dispatch_result: RepairDispatchResult,
+        readiness: VerificationReadiness,
+    ) -> str:
+        if dispatch_result.execution_outcome in (
+            "EXECUTION_FAILED",
+            "EXECUTION_AMBIGUOUS",
+        ):
+            return dispatch_result.execution_outcome
+        assessment = next(
+            (
+                a
+                for a in readiness.entry_assessments
+                if a.plan_entry_id == directive.plan_entry_id
+            ),
+            None,
+        )
+        if assessment is None:
+            return "REVERIFY_ERROR"
+        if assessment.status == "PASS":
+            return "REVERIFY_PASS"
+        if assessment.status == "FAIL":
+            return "REVERIFY_FAIL"
+        return "REVERIFY_ERROR"
 
     def issue_repair_directive(
         self,
@@ -297,5 +541,6 @@ class VerificationRepairCoordinator:
 
 __all__ = [
     "RepairCoordinatorError",
+    "RepairDispatchResult",
     "VerificationRepairCoordinator",
 ]

--- a/src/total_gateway/verification_repair_policy.py
+++ b/src/total_gateway/verification_repair_policy.py
@@ -190,9 +190,66 @@ def evaluate_disposition(
     return "REVIEW", ("repair_policy.unhandled_failure_kind",)
 
 
+def compute_disposition_action(
+    *,
+    predicate_type: str,
+    verification_status: str,
+    failure_kind: str,
+    attempt_no: int,
+    same_signature_count: int,
+    successor_depth: int,
+    generation_repair_count: int,
+    side_effect_repair_count: int,
+    subject_kind: str,
+    effect_is_ambiguous: bool,
+    policy: RepairPolicyConfig | None = None,
+) -> tuple[str, tuple[str, ...]]:
+    """Full budget-aware decision — M5 Final #4/#5 single source of truth.
+
+    Shared by the RepairCoordinator (decision time) and the Store v28
+    disposition revalidation (write time), so a disposition can never be
+    persisted unless the Store independently recomputes the same action
+    from Store-derived budget counts.
+    """
+    if policy is None:
+        policy = DEFAULT_POLICY
+
+    base_action, base_reasons = evaluate_disposition(
+        predicate_type=predicate_type,
+        verification_status=verification_status,
+        failure_kind=failure_kind,
+        attempt_no=attempt_no,
+        max_attempts=policy.max_attempts_per_plan_entry,
+        same_signature_count=same_signature_count,
+        effect_is_ambiguous=effect_is_ambiguous,
+        policy=policy,
+    )
+
+    extra_reasons: list[str] = []
+    if (
+        generation_repair_count
+        >= policy.max_total_auto_repairs_per_generation
+    ):
+        extra_reasons.append("repair_policy.generation_budget_exhausted")
+    if successor_depth >= policy.max_subject_successor_depth:
+        extra_reasons.append("repair_policy.successor_depth_exhausted")
+    if (
+        subject_kind in ("effect", "repository")
+        and side_effect_repair_count
+        >= policy.max_side_effecting_repairs_per_entry
+    ):
+        extra_reasons.append("repair_policy.side_effect_budget_exhausted")
+
+    # M5 Final #5: any exhausted budget overrides a base REPAIR.
+    if extra_reasons and base_action == "REPAIR":
+        return "REVIEW", tuple(extra_reasons)
+    return base_action, base_reasons
+
+
 __all__ = [
     "DEFAULT_POLICY",
     "RepairPolicyConfig",
+    "compute_disposition_action",
     "evaluate_disposition",
     "POLICY_VERSION",
 ]

--- a/src/total_gateway/verification_repair_policy.py
+++ b/src/total_gateway/verification_repair_policy.py
@@ -24,6 +24,13 @@ MAX_SAME_FAILURE_SIGNATURE_REPEATS = 2
 MAX_SUBJECT_SUCCESSOR_DEPTH = 4
 MAX_SIDE_EFFECTING_REPAIRS_PER_ENTRY = 1
 
+#: Store write-boundary limits for RepairDirective fields. These are
+#: code-enforced at put time — a hash-valid directive cannot widen its
+#: execution budget beyond what the authoritative policy allows.
+MIN_REPAIR_EXECUTION_BUDGET_MS = 60_000
+MAX_REPAIR_EXECUTION_BUDGET_MS = 600_000
+MAX_REPAIR_EXPIRY_DELTA_MS = 3_600_000
+
 #: §13 Repairability Matrix: predicate types eligible for auto REPAIR.
 AUTO_REPAIRABLE_CONTENT_PREDICATES = frozenset({
     "artifact.nonempty",
@@ -251,5 +258,8 @@ __all__ = [
     "RepairPolicyConfig",
     "compute_disposition_action",
     "evaluate_disposition",
+    "MAX_REPAIR_EXECUTION_BUDGET_MS",
+    "MAX_REPAIR_EXPIRY_DELTA_MS",
+    "MIN_REPAIR_EXECUTION_BUDGET_MS",
     "POLICY_VERSION",
 ]

--- a/tests/gateway_store_migration_support.py
+++ b/tests/gateway_store_migration_support.py
@@ -19,6 +19,15 @@ def downgrade_v12_to_v11(connection: sqlite3.Connection) -> None:
     """
 
     version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if version == 29:
+        connection.execute("DROP INDEX IF EXISTS repair_attempt_number_idx")
+        connection.execute(
+            "DROP INDEX IF EXISTS verification_subject_successor_attempt_idx"
+        )
+        connection.execute("DROP TABLE IF EXISTS artifact_subject_authority")
+        connection.execute("DELETE FROM schema_migrations WHERE version = 29")
+        connection.execute("PRAGMA user_version = 28")
+        version = 28
     if version == 28:
         connection.execute("DROP TABLE IF EXISTS repair_attempt")
         connection.execute("DROP TABLE IF EXISTS verification_subject_successor")

--- a/tests/gateway_store_migration_support.py
+++ b/tests/gateway_store_migration_support.py
@@ -20,6 +20,10 @@ def downgrade_v12_to_v11(connection: sqlite3.Connection) -> None:
 
     version = int(connection.execute("PRAGMA user_version").fetchone()[0])
     if version == 29:
+        connection.execute(
+            "DROP INDEX IF EXISTS repair_execution_binding_attempt_idx"
+        )
+        connection.execute("DROP TABLE IF EXISTS repair_execution_binding")
         connection.execute("DROP INDEX IF EXISTS repair_attempt_number_idx")
         connection.execute(
             "DROP INDEX IF EXISTS verification_subject_successor_attempt_idx"

--- a/tests/test_p19_m1_store.py
+++ b/tests/test_p19_m1_store.py
@@ -151,11 +151,17 @@ class MigrationTests(unittest.TestCase):
         """
         GatewayStateStore.open(self.path, now_ms=900).close()
         connection = sqlite3.connect(self.path)
+        connection.execute("DROP INDEX IF EXISTS repair_attempt_number_idx")
+        connection.execute(
+            "DROP INDEX IF EXISTS verification_subject_successor_attempt_idx"
+        )
+        connection.execute("DROP TABLE IF EXISTS artifact_subject_authority")
         connection.execute("DROP TABLE IF EXISTS repair_attempt")
         connection.execute("DROP TABLE IF EXISTS verification_subject_successor")
         connection.execute("DROP TABLE IF EXISTS repair_directive")
         connection.execute("DROP TABLE IF EXISTS verification_disposition")
         connection.execute("DROP TABLE IF EXISTS verification_failure_evidence")
+        connection.execute("DELETE FROM schema_migrations WHERE version = 29")
         connection.execute("DELETE FROM schema_migrations WHERE version = 28")
         connection.execute("DROP TABLE verification_plan_activation")
         connection.execute("DELETE FROM schema_migrations WHERE version = 27")
@@ -178,7 +184,7 @@ class MigrationTests(unittest.TestCase):
     def test_fresh_db_opens_at_v23(self) -> None:  # checklist 2
         store = GatewayStateStore.open(self.path, now_ms=900)
         try:
-            self.assertEqual(store.health_check(full=True, now_ms=950).schema_version, 28)
+            self.assertEqual(store.health_check(full=True, now_ms=950).schema_version, 29)
         finally:
             store.close()
 
@@ -189,7 +195,7 @@ class MigrationTests(unittest.TestCase):
         try:
             health = upgraded.health_check(full=True, now_ms=960)
             self.assertTrue(health.healthy)
-            self.assertEqual(health.schema_version, 28)
+            self.assertEqual(health.schema_version, 29)
         finally:
             upgraded.close()
         reopened = GatewayStateStore.open(self.path, now_ms=1_000)

--- a/tests/test_p19_m1_store.py
+++ b/tests/test_p19_m1_store.py
@@ -151,6 +151,10 @@ class MigrationTests(unittest.TestCase):
         """
         GatewayStateStore.open(self.path, now_ms=900).close()
         connection = sqlite3.connect(self.path)
+        connection.execute(
+            "DROP INDEX IF EXISTS repair_execution_binding_attempt_idx"
+        )
+        connection.execute("DROP TABLE IF EXISTS repair_execution_binding")
         connection.execute("DROP INDEX IF EXISTS repair_attempt_number_idx")
         connection.execute(
             "DROP INDEX IF EXISTS verification_subject_successor_attempt_idx"

--- a/tests/test_p19_m3_write_evidence_v2.py
+++ b/tests/test_p19_m3_write_evidence_v2.py
@@ -303,7 +303,7 @@ class WriteEvidenceV2StoreTests(unittest.TestCase):
     def test_schema_v24_and_zero_state_impact(self) -> None:
         v2 = self._v2()
         self.store.put_write_evidence_v2(v2, recorded_at_ms=2_000)
-        self.assertEqual(self.store.health_check(now_ms=2_100).schema_version, 28)
+        self.assertEqual(self.store.health_check(now_ms=2_100).schema_version, 29)
         connection = sqlite3.connect(self.store.path)
         try:
             decisions = connection.execute(

--- a/tests/test_p19_m5_repair_loop.py
+++ b/tests/test_p19_m5_repair_loop.py
@@ -73,7 +73,9 @@ class _RepairBindingMixin:
 
     def _reserve_or_claimed(self, directive, effect_id, intent=None):
         import time as _time
+        import uuid as _uuid
 
+        now = _time.time_ns() // 1_000_000
         return self._binding_store().reserve_repair_execution(
             repair_directive_id=directive.repair_directive_id,
             repair_directive_sha256=directive.directive_sha256,
@@ -84,18 +86,29 @@ class _RepairBindingMixin:
             generation=directive.generation,
             effect_id=effect_id,
             effect_intent_sha256=intent or "9" * 64,
-            reserved_at_ms=_time.time_ns() // 1_000_000,
+            reserved_at_ms=now,
+            # invocation-scoped claim: two threads in one process still
+            # single-flight
+            dispatch_claim_id=_uuid.uuid4().hex,
+            claim_expires_at_ms=now + 120_000,
         )
 
-    def _binding_mark_started(self, directive):
+    def _binding_mark_started(self, directive, effect_id):
+        """ONE atomic transition: EffectLedger CLAIMED->STARTED and
+        Binding RESERVED->STARTED in the same transaction."""
         import time as _time
 
-        self._binding_store().mark_repair_execution_started(
+        self._binding_store().start_repair_execution(
             repair_directive_id=directive.repair_directive_id,
+            effect_id=effect_id,
             started_at_ms=_time.time_ns() // 1_000_000,
         )
 
-    def _binding_complete(self, directive, state, produced, ref="test"):
+    def _binding_complete(
+        self, directive, state, produced, ref="test", error_code=None
+    ):
+        """ONE atomic terminal transition: BOTH authorities move to the
+        same terminal state with the produced subject persisted."""
         import time as _time
 
         self._binding_store().complete_repair_execution(
@@ -105,6 +118,7 @@ class _RepairBindingMixin:
             produced_subject_kind=directive.subject_kind,
             runtime_result_ref=ref,
             completed_at_ms=_time.time_ns() // 1_000_000,
+            error_code=error_code,
         )
 
     @staticmethod
@@ -272,7 +286,7 @@ class RepairLoopE2EBase(_RepairBindingMixin, M21OracleTestBase):
         reserved = self._reserve_or_claimed(directive, effect.effect_id)
         if reserved["outcome"] != "EXECUTE":
             return self._already_claimed(directive)
-        self._binding_mark_started(directive)
+        self._binding_mark_started(directive, effect.effect_id)
         good = self._passed_manifest(
             docx_bytes("字" * 300),
             filename="report.docx",
@@ -414,7 +428,7 @@ class TestBudgetTermination(RepairLoopE2EBase):
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
+            self._binding_mark_started(directive, effect.effect_id)
             still_bad = self._passed_manifest(
                 docx_bytes("字" * 10),
                 filename="report.docx",
@@ -862,7 +876,12 @@ class TestDesktopProductionWiring(unittest.TestCase):
             "sign_execution",
             "BackendClient(",
             "claim_effect",
-            "complete_effect",
+            # Final P0-2: the bridge crosses and terminalizes BOTH
+            # authorities through the one-transaction composite APIs.
+            "start_repair_execution(",
+            "complete_repair_execution(",
+            "reserve_repair_execution(",
+            "dispatch_claim_id",
             "_register_repair_artifacts(",
             "ArtifactGate(",
         ):
@@ -882,12 +901,12 @@ class TestAmbiguousRepairSafety(RepairLoopE2EBase):
             )
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self.gateway_store.mark_effect_started(
-                started_effect.effect_id,
-                started_at_ms=_time.time_ns() // 1_000_000,
+            self._binding_mark_started(
+                directive, started_effect.effect_id
             )
-            self._binding_mark_started(directive)
-            self._binding_complete(directive, "AMBIGUOUS", "")
+            self._binding_complete(
+                directive, "AMBIGUOUS", "", error_code="repair.ambiguous"
+            )
             return RepairDispatchResult(
                 execution_outcome="EXECUTION_AMBIGUOUS",
                 produced_subject_identity=(
@@ -1077,17 +1096,21 @@ class TestEffectRepairE2E(_RepairBindingMixin, M21OracleTestBase):
 
     def test_effect_repair_new_effect_successor_same_predicate(self) -> None:
         def dispatch(directive: RepairDirective):
-            new_effect = self._claim()
-            reserved = self._reserve_or_claimed(directive, new_effect)
+            # carrier: the binding-owned dispatch effect; subject: the
+            # NEW effect the predicate re-verifies (separated so the
+            # carrier can be SUCCEEDED while the subject FAILS).
+            carrier = self._claim()
+            reserved = self._reserve_or_claimed(directive, carrier)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
+            new_effect = self._claim()
+            self._binding_mark_started(directive, carrier)
             self._complete(new_effect, "SUCCEEDED")
             self._binding_complete(directive, "SUCCEEDED", new_effect)
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=new_effect,
-                execution_effect_ids=(new_effect,),
+                execution_effect_ids=(carrier,),
             )
 
         readiness = self._reverify()
@@ -1135,18 +1158,20 @@ class TestEffectRepairE2E(_RepairBindingMixin, M21OracleTestBase):
         (1) BEFORE the per-entry budget (2)."""
 
         def dispatch_fails_again(directive: RepairDirective):
-            new_effect = self._claim()
-            reserved = self._reserve_or_claimed(directive, new_effect)
+            carrier = self._claim()
+            reserved = self._reserve_or_claimed(directive, carrier)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
-            # The runtime completed; the NEW effect itself failed.
+            new_effect = self._claim()
+            self._binding_mark_started(directive, carrier)
+            # The runtime completed; the NEW SUBJECT effect itself
+            # failed (the carrier still terminates SUCCEEDED).
             self._complete(new_effect, "FAILED_FINAL")
             self._binding_complete(directive, "SUCCEEDED", new_effect)
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=new_effect,
-                execution_effect_ids=(new_effect,),
+                execution_effect_ids=(carrier,),
             )
 
         readiness = self._reverify()
@@ -1215,7 +1240,7 @@ class TestGenerationBudgetMultiEntry(RepairLoopE2EBase):
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
+            self._binding_mark_started(directive, effect.effect_id)
             good = self._passed_manifest(
                 docx_bytes("字" * 300),
                 filename="report.docx",
@@ -1286,15 +1311,33 @@ class TestCoordinatorRace(RepairLoopE2EBase):
         import threading
 
         readiness = self._reverify()
+        # Pre-issue ONE directive D; both workers race to reserve THE
+        # SAME D with different invocation-scoped claims.
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                dispositions[0].failure_evidence_id
+            )
+        )
+        shared_directive = self.coordinator.issue_repair_directive(
+            disposition=dispositions[0],
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
         produce_calls = []
+        reserve_outcomes = []
         calls_lock = threading.Lock()
 
         def dispatch(directive: RepairDirective):
             effect = self._claim_repair_effect()
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
+            with calls_lock:
+                reserve_outcomes.append(reserved["outcome"])
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
+            self._binding_mark_started(directive, effect.effect_id)
             with calls_lock:
                 produce_calls.append(directive.repair_directive_id)
                 good = self._passed_manifest(
@@ -1326,12 +1369,18 @@ class TestCoordinatorRace(RepairLoopE2EBase):
                 # state is what must stay consistent
                 pass
 
+        assert shared_directive is not None
+
         threads = [threading.Thread(target=run, daemon=True) for _ in range(2)]
         for thread in threads:
             thread.start()
         for thread in threads:
             thread.join(timeout=60)
 
+        # Exactly one EXECUTE and (when both raced) exactly one FOLLOW —
+        # never two EXECUTEs for the SAME directive.
+        self.assertEqual(reserve_outcomes.count("EXECUTE"), 1)
+        self.assertLessEqual(reserve_outcomes.count("FOLLOW"), 1)
         # EXACTLY ONE runtime execution crossed the boundary.
         self.assertEqual(len(produce_calls), 1)
         attempts = self.gateway_store.list_repair_attempts(
@@ -1360,7 +1409,7 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
         effect = self._claim_repair_effect()
         reserved = self._reserve_or_claimed(directive, effect.effect_id)
         assert reserved["outcome"] == "EXECUTE"
-        self._binding_mark_started(directive)
+        self._binding_mark_started(directive, effect.effect_id)
         good = self._passed_manifest(
             docx_bytes("字" * 300),
             filename="report.docx",
@@ -1396,8 +1445,15 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
         )
         # Runtime already executed; produced subject PERSISTED in the
         # binding; then CRASH (no successor, no re-verification, no
-        # attempt record).
+        # attempt record). Both authorities committed SUCCEEDED
+        # atomically before the crash.
         effect, good = self._crashed_binding(directive)
+        binding_after = self.gateway_store.get_repair_execution_binding(
+            directive.repair_directive_id
+        )
+        self.assertEqual(binding_after["state"], "SUCCEEDED")
+        effect_after = self.gateway_store.get_effect(effect.effect_id)
+        self.assertEqual(effect_after.state, "SUCCEEDED")
 
         # New process/coordinator: reads only the Store.
         final, _ = self.coordinator.execute_repair_loop(
@@ -1459,8 +1515,17 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
         effect = self._claim_repair_effect()
         reserved = self._reserve_or_claimed(directive, effect.effect_id)
         assert reserved["outcome"] == "EXECUTE"
-        # CRASH exactly after crossing the side-effect boundary:
-        self._binding_mark_started(directive)
+        # CRASH exactly after the ONE atomic boundary transition — both
+        # authorities are SIDE_EFFECT_STARTED or neither is.
+        self._binding_mark_started(directive, effect.effect_id)
+        started_binding = self.gateway_store.get_repair_execution_binding(
+            directive.repair_directive_id
+        )
+        self.assertEqual(started_binding["state"], "SIDE_EFFECT_STARTED")
+        self.assertEqual(
+            self.gateway_store.get_effect(effect.effect_id).state,
+            "SIDE_EFFECT_STARTED",
+        )
 
         final, disposition = self.coordinator.execute_repair_loop(
             plan=self.plan,
@@ -1689,7 +1754,7 @@ class TestGateAuthorityChecks(RepairLoopE2EBase):
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
+            self._binding_mark_started(directive, effect.effect_id)
             still_bad = self._passed_manifest(
                 docx_bytes("字" * 10),
                 filename="report.docx",
@@ -1957,7 +2022,7 @@ class TestRepositoryRepairE2E(_RepairBindingMixin, _M31RepositoryBase):
             reserved = self._reserve_or_claimed(directive, new_subject)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive)
+            self._binding_mark_started(directive, new_subject)
             # The observation window is bound BEFORE the binding is
             # terminalized (production semantics).
             self._window(subject=new_subject, delta=True)
@@ -2007,6 +2072,274 @@ class TestRepositoryRepairE2E(_RepairBindingMixin, _M31RepositoryBase):
         self.assertTrue(
             self.store.list_repository_bindings_for_subject(new_subject)
         )
+
+
+class TestDispatchClaimLease(RepairLoopE2EBase):
+    """Final P0-1 B: the invocation-scoped dispatch claim lease."""
+
+    def _issued_directive(self):
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                dispositions[0].failure_evidence_id
+            )
+        )
+        directive = self.coordinator.issue_repair_directive(
+            disposition=dispositions[0],
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
+        return directive
+
+    def _reserve(self, directive, effect_id, claim_id, *, now, expiry):
+        return self.gateway_store.reserve_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            repair_directive_sha256=directive.directive_sha256,
+            plan_entry_id=directive.plan_entry_id,
+            repair_attempt_no=directive.repair_attempt_no,
+            request_id=directive.request_id,
+            run_id=directive.run_id,
+            generation=directive.generation,
+            effect_id=effect_id,
+            effect_intent_sha256="9" * 64,
+            reserved_at_ms=now,
+            dispatch_claim_id=claim_id,
+            claim_expires_at_ms=expiry,
+        )
+
+    def test_live_claim_cannot_be_stolen(self) -> None:
+        import time as _time
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        first = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now, expiry=now + 120_000,
+        )
+        self.assertEqual(first["outcome"], "EXECUTE")
+        second = self._reserve(
+            directive, effect.effect_id, "claim-b",
+            now=now + 1, expiry=now + 120_000,
+        )
+        self.assertEqual(second["outcome"], "FOLLOW")
+        # idempotent re-entry by the SAME live claim
+        again = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now + 2, expiry=now + 120_000,
+        )
+        self.assertEqual(again["outcome"], "EXECUTE")
+
+    def test_expired_pre_start_claim_may_be_taken_over(self) -> None:
+        import sqlite3
+        import time as _time
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        first = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now, expiry=now + 120_000,
+        )
+        self.assertEqual(first["outcome"], "EXECUTE")
+        # the lease expires (wall clock moves past it)
+        connection = sqlite3.connect(self.temporary.name + "/gateway.sqlite3")
+        connection.execute(
+            "UPDATE repair_execution_binding SET claim_expires_at_ms = 1"
+            " WHERE repair_directive_id = ?",
+            (directive.repair_directive_id,),
+        )
+        connection.commit()
+        connection.close()
+        takeover = self._reserve(
+            directive, effect.effect_id, "claim-b",
+            now=now + 1, expiry=now + 120_000,
+        )
+        self.assertEqual(takeover["outcome"], "EXECUTE")
+        self.assertEqual(
+            takeover["binding"]["dispatch_claim_id"], "claim-b"
+        )
+        self.assertGreater(
+            int(takeover["binding"]["claim_revision"]),
+            int(first["binding"]["claim_revision"]),
+        )
+
+    def test_started_claim_can_never_be_taken_over(self) -> None:
+        import time as _time
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        first = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now, expiry=now + 120_000,
+        )
+        self.assertEqual(first["outcome"], "EXECUTE")
+        self.gateway_store.start_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            effect_id=effect.effect_id,
+            started_at_ms=now + 1,
+        )
+        # even with the lease expired, a STARTED binding is FOLLOW-only
+        takeover = self._reserve(
+            directive, effect.effect_id, "claim-b",
+            now=now + 2, expiry=now + 120_000,
+        )
+        self.assertEqual(takeover["outcome"], "FOLLOW")
+        self.assertEqual(
+            takeover["binding"]["state"], "SIDE_EFFECT_STARTED"
+        )
+
+    def test_reserve_rejects_drifted_directive_payload(self) -> None:
+        import time as _time
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        with self.assertRaises(ValueError):
+            self.gateway_store.reserve_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                repair_directive_sha256="1" * 64,  # drifted digest
+                plan_entry_id=directive.plan_entry_id,
+                repair_attempt_no=directive.repair_attempt_no,
+                request_id=directive.request_id,
+                run_id=directive.run_id,
+                generation=directive.generation,
+                effect_id=effect.effect_id,
+                effect_intent_sha256="9" * 64,
+                reserved_at_ms=now,
+                dispatch_claim_id="claim-a",
+                claim_expires_at_ms=now + 120_000,
+            )
+
+
+class TestAtomicStartCrash(RepairLoopE2EBase):
+    """Final P0-2 C: after the atomic start and a reopen there is NO
+    observable (Effect STARTED, Binding RESERVED) state."""
+
+    def test_no_split_state_after_reopen(self) -> None:
+        import time as _time
+        from total_gateway.store import GatewayStateStore
+
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                dispositions[0].failure_evidence_id
+            )
+        )
+        directive = self.coordinator.issue_repair_directive(
+            disposition=dispositions[0],
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
+        effect = self._claim_repair_effect()
+        reserved = self._reserve_or_claimed(directive, effect.effect_id)
+        self.assertEqual(reserved["outcome"], "EXECUTE")
+
+        self.gateway_store.start_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            effect_id=effect.effect_id,
+            started_at_ms=_time.time_ns() // 1_000_000,
+        )
+        # CRASH: close and reopen a fresh Store instance over the same
+        # database file.
+        self.gateway_store.close()
+        from pathlib import Path as _Path
+
+        reopened = GatewayStateStore.open(
+            _Path(self.temporary.name) / "gateway.sqlite3",
+            now_ms=_time.time_ns() // 1_000_000,
+        )
+        self.gateway_store = reopened
+        binding = reopened.get_repair_execution_binding(
+            directive.repair_directive_id
+        )
+        effect_record = reopened.get_effect(effect.effect_id)
+        self.assertEqual(binding["state"], "SIDE_EFFECT_STARTED")
+        self.assertEqual(effect_record.state, "SIDE_EFFECT_STARTED")
+        # the invariant under test: never effect-started + binding-RESERVED
+        self.assertNotEqual(
+            (effect_record.state, binding["state"]),
+            ("SIDE_EFFECT_STARTED", "RESERVED"),
+        )
+
+
+class TestPolicyDenyPath(RepairLoopE2EBase):
+    """Final P0-2 E: policy deny terminalizes BOTH authorities
+    atomically; the RepairAttempt(EXECUTION_FAILED) persists and the
+    runtime callback count stays zero."""
+
+    def test_policy_deny_atomic_failed_final(self) -> None:
+        produce_calls: list[str] = []
+
+        def dispatch(directive: RepairDirective):
+            effect = self._claim_repair_effect()
+            reserved = self._reserve_or_claimed(directive, effect.effect_id)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            # policy DENY: the runtime is NEVER entered; both
+            # authorities move atomically to FAILED_FINAL.
+            self._binding_complete(
+                directive,
+                "FAILED_FINAL",
+                "",
+                ref="policy-rejected",
+                error_code="repair.policy_denied",
+            )
+            return RepairDispatchResult(
+                execution_outcome="EXECUTION_FAILED",
+                produced_subject_identity=(
+                    directive.effective_subject_identity
+                ),
+                execution_effect_ids=(effect.effect_id,),
+            )
+
+        readiness = self._reverify()
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch,
+            reverify=self._reverify,
+        )
+        # runtime was never entered
+        self.assertEqual(produce_calls, [])
+        self.assertFalse(final.verification_ready)
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "REVIEW")
+        # attempts persisted as EXECUTION_FAILED (the per-entry budget
+        # lets the policy deny retry once, then REVIEW)
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertGreaterEqual(len(attempts), 1)
+        self.assertTrue(
+            all(a.execution_outcome == "EXECUTION_FAILED" for a in attempts)
+        )
+        # EVERY binding is atomically FAILED_FINAL with its effect
+        for attempt in attempts:
+            binding = self.gateway_store.get_repair_execution_binding(
+                attempt.repair_directive_id
+            )
+            self.assertEqual(binding["state"], "FAILED_FINAL")
+            effect_record = self.gateway_store.get_effect(
+                binding["effect_id"]
+            )
+            self.assertEqual(effect_record.state, "FAILED_FINAL")
+        # no successor for a never-executed repair
+        self.assertEqual(
+            self.gateway_store.list_verification_subject_successors(
+                self.entry.plan_entry_id
+            ),
+            (),
+        )
+
+
 
 
 if __name__ == "__main__":

--- a/tests/test_p19_m5_repair_loop.py
+++ b/tests/test_p19_m5_repair_loop.py
@@ -1,0 +1,754 @@
+"""P19-R2 M5 Final #2/#4/#8: the FULL evidence-driven repair loop.
+
+Real Store + real oracles + real readiness builder + real deterministic
+policy. The only scripted piece is the runtime dispatch callback (the
+runtime is an LLM backend — scripted here exactly like every other
+backend-transport test), and even that produces its repaired artifact
+through the REAL ArtifactGate/QC pipeline and claims a REAL effect in
+the one EffectLedger.
+
+Coverage:
+- FAIL → REPAIR directive → real execution → successor binding →
+  SAME predicate re-verified with NEW independent evidence → PASS.
+- Budget termination (permanent failure → REVIEW, bounded directives).
+- Crash recovery (directive issued, attempt never recorded → resume
+  without exceeding budgets).
+- Concurrency (idempotent identical writes under threads).
+- Adversarial Store v28 revalidation (forged evidence / decision /
+  linkage / reality rejected at the write boundary).
+- Desktop production wiring (source-structure assertions).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import tempfile
+import unittest
+from pathlib import Path
+
+from contracts import derive_effect_identity
+from contracts.verification import (
+    AcceptancePredicate,
+    FailureEvidence,
+    RepairDirective,
+    VerificationDisposition,
+    VerificationPlan,
+    VerificationPlanEntryV2,
+)
+from contracts.verification_repair import (
+    RepairAttemptRecord,
+    VerificationSubjectSuccessor,
+)
+from total_gateway.effects import EffectClaim
+from total_gateway.verification_plan_executor import VerificationPlanExecutor
+from total_gateway.verification_repair_coordinator import (
+    RepairDispatchResult,
+    VerificationRepairCoordinator,
+)
+from tests.test_docx_qc import docx_bytes
+from tests.test_p19_m2_1_artifact_oracle import M21OracleTestBase
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument"
+    ".wordprocessingml.document"
+)
+
+
+class RepairLoopE2EBase(M21OracleTestBase):
+    """Real gateway stack + one failing artifact predicate."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._register_lineage_request()
+        self.gateway_store.put_registry_snapshot(
+            self.snapshot, recorded_at_ms=1_500
+        )
+        self.manifests: list = []
+        self._clock = 30_000
+        self._effect_ordinal = 50
+
+        # Bad artifact: 50 visible chars against a 200-char minimum.
+        self.bad_manifest = self._passed_manifest(
+            docx_bytes("字" * 50),
+            filename="report.docx",
+            format_id="docx",
+            declared_mime=DOCX_MIME,
+        )
+        self.manifests.append(self.bad_manifest)
+
+        predicate = AcceptancePredicate.create(
+            predicate_type="artifact.min_visible_text_chars",
+            subject_kind="artifact",
+            params={"min_chars": 200},
+        )
+        entry = VerificationPlanEntryV2(
+            plan_entry_id="vpe_" + "0" * 64,
+            verifier_id="verifier.artifact_content",
+            verifier_version="3",
+            predicate=predicate,
+            subject_identity=self.bad_manifest.artifact_revision_id,
+            evaluation_phase="POST_EXECUTION",
+            required=True,
+            entry_sha256="0" * 64,
+        ).with_computed_sha256()
+        self.plan = VerificationPlan(
+            verification_plan_id="vpl_" + "0" * 64,
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            entries=(entry,),
+            plan_sha256="0" * 64,
+        ).with_computed_sha256()
+        self.entry = self.plan.entries[0]
+        assert self.gateway_store.put_verification_plan(
+            self.plan, recorded_at_ms=1_600
+        )
+        self.gateway_store.activate_verification_plan(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            verification_plan_id=self.plan.verification_plan_id,
+            verification_plan_sha256=self.plan.plan_sha256,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            activated_at_ms=1_700,
+        )
+        self.coordinator = VerificationRepairCoordinator(
+            store=self.gateway_store
+        )
+
+    # -- helpers ----------------------------------------------------------
+
+    def _next_ms(self) -> int:
+        self._clock += 1_000
+        return self._clock
+
+    def _claim_repair_effect(self):
+        self._effect_ordinal += 1
+        effect = derive_effect_identity(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            run_sequence=1,
+            generation=2,
+            effect_kind="execution",
+            ordinal=self._effect_ordinal,
+            intent_sha256="9" * 64,
+        )
+        self.gateway_store.claim_effect(
+            EffectClaim(
+                effect_id=effect.effect_id,
+                request_id=self.request.request_id,
+                run_id=self.run.run_id,
+                run_sequence=1,
+                generation=2,
+                effect_kind="execution",
+                ordinal=effect.ordinal,
+                intent_sha256="9" * 64,
+                owner_component_id="tiangong-backend",
+                claimed_at_ms=self._next_ms(),
+                claim_sha256="0" * 64,
+            ).with_computed_sha256()
+        )
+        return effect
+
+    def _reverify(self):
+        executor = VerificationPlanExecutor(
+            snapshot=self.snapshot,
+            store=self.gateway_store,
+            object_store=self.object_store,
+            fact_ledger=self.fact_ledger,
+            plan=self.plan,
+        )
+        return executor.execute(
+            evaluated_at_ms=self._next_ms(),
+            artifact_manifests=tuple(self.manifests),
+        )
+
+    def _dispatch_success(self, directive: RepairDirective):
+        """Scripted runtime: repairs through the REAL gate/QC pipeline."""
+        good = self._passed_manifest(
+            docx_bytes("字" * 300),
+            filename="report.docx",
+            format_id="docx",
+            declared_mime=DOCX_MIME,
+        )
+        self.manifests.append(good)
+        effect = self._claim_repair_effect()
+        return RepairDispatchResult(
+            execution_outcome="DISPATCHED",
+            produced_subject_identity=good.artifact_revision_id,
+            execution_effect_ids=(effect.effect_id,),
+        )
+
+    def _entry_records(self):
+        records = self.gateway_store.list_verification_records(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+        )
+        return [
+            r
+            for r in records
+            if r.predicate_id == self.entry.predicate.predicate_id
+        ]
+
+
+class TestFullRepairLoopE2E(RepairLoopE2EBase):
+    """#8: FAIL → REPAIR → real execution → successor → same
+    predicate → PASS, end to end."""
+
+    def test_fail_repair_successor_same_predicate_pass(self) -> None:
+        readiness = self._reverify()
+        self.assertFalse(readiness.verification_ready)
+
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=self._dispatch_success,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+        self.assertIsNone(disposition)
+
+        good_revision = self.manifests[-1].artifact_revision_id
+
+        # Successor chain: original → repaired, depth 1.
+        resolution = self.gateway_store.resolve_verification_subject(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(
+            resolution["effective_subject_identity"], good_revision
+        )
+        self.assertEqual(resolution["successor_depth"], 1)
+
+        # SAME predicate, NEW subject, NEW evaluated_at_ms.
+        records = self._entry_records()
+        pass_records = [r for r in records if r.status == "PASS"]
+        fail_records = [r for r in records if r.status == "FAIL"]
+        self.assertEqual(len(pass_records), 1)
+        self.assertGreaterEqual(len(fail_records), 1)
+        self.assertEqual(pass_records[0].subject_identity, good_revision)
+        self.assertEqual(
+            pass_records[0].predicate_id,
+            self.entry.predicate.predicate_id,
+        )
+        self.assertGreater(
+            pass_records[0].evaluated_at_ms,
+            max(r.evaluated_at_ms for r in fail_records),
+        )
+
+        # Attempt audit bound to the NEW independent evidence.
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(attempts[0].execution_outcome, "REVERIFY_PASS")
+        self.assertEqual(
+            attempts[0].reverify_record_id,
+            pass_records[0].verification_record_id,
+        )
+        self.assertTrue(attempts[0].execution_effect_ids)
+        self.assertEqual(
+            attempts[0].prior_subject_identity,
+            self.bad_manifest.artifact_revision_id,
+        )
+        self.assertEqual(
+            attempts[0].produced_subject_identity, good_revision
+        )
+
+        # Gate consumption: a PASSING final readiness carries no
+        # disposition (get_current returns None).
+        self.assertIsNone(
+            self.gateway_store.get_current_verification_disposition(
+                request_id=self.request.request_id,
+                run_id=self.run.run_id,
+                generation=2,
+                verification_plan_id=self.plan.verification_plan_id,
+                readiness_sha256=final.readiness_sha256,
+            )
+        )
+
+    def test_executor_rejects_superseded_subject_after_repair(self) -> None:
+        """#6/#2: once a successor exists the executor dispatches the
+        EFFECTIVE subject only — the original manifest no longer
+        satisfies the entry."""
+        readiness = self._reverify()
+        final, _ = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=self._dispatch_success,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+
+        stale = VerificationPlanExecutor(
+            snapshot=self.snapshot,
+            store=self.gateway_store,
+            object_store=self.object_store,
+            fact_ledger=self.fact_ledger,
+            plan=self.plan,
+        ).execute(
+            evaluated_at_ms=self._next_ms(),
+            artifact_manifests=(self.bad_manifest,),  # superseded subject
+        )
+        self.assertFalse(stale.verification_ready)
+        latest = self._entry_records()[-1]
+        self.assertEqual(latest.status, "ERROR")
+
+
+class TestBudgetTermination(RepairLoopE2EBase):
+    """#5/#8: permanent failure terminates in REVIEW within budgets."""
+
+    def test_permanent_failure_terminates_with_review(self) -> None:
+        def dispatch_always_bad(directive: RepairDirective):
+            still_bad = self._passed_manifest(
+                docx_bytes("字" * 10),
+                filename="report.docx",
+                format_id="docx",
+                declared_mime=DOCX_MIME,
+            )
+            self.manifests.append(still_bad)
+            effect = self._claim_repair_effect()
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=(
+                    still_bad.artifact_revision_id
+                ),
+                execution_effect_ids=(effect.effect_id,),
+            )
+
+        readiness = self._reverify()
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch_always_bad,
+            reverify=self._reverify,
+        )
+        self.assertFalse(final.verification_ready)
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "REVIEW")
+        self.assertIn(
+            "repair_policy.entry_budget_exhausted",
+            disposition.reason_codes,
+        )
+
+        # Per-entry budget = 2 REPAIR directives, then REVIEW.
+        directives = self.gateway_store.list_repair_directives(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(directives), 2)
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 2)
+        self.assertTrue(
+            all(a.execution_outcome == "REVERIFY_FAIL" for a in attempts)
+        )
+
+        # Successor chain advanced exactly budget-many times.
+        resolution = self.gateway_store.resolve_verification_subject(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(resolution["successor_depth"], 2)
+
+        # The Gate-visible disposition is bound to the FINAL readiness.
+        current = self.gateway_store.get_current_verification_disposition(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            verification_plan_id=self.plan.verification_plan_id,
+            readiness_sha256=final.readiness_sha256,
+        )
+        self.assertIsNotNone(current)
+        self.assertEqual(current.action, "REVIEW")
+
+
+class TestCrashRecovery(RepairLoopE2EBase):
+    """#8: crash after directive issuance, before the attempt — the
+    loop resumes from Store state without exceeding budgets."""
+
+    def test_resume_after_directive_without_attempt(self) -> None:
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        self.assertEqual(len(dispositions), 1)
+        self.assertEqual(dispositions[0].action, "REPAIR")
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                dispositions[0].failure_evidence_id
+            )
+        )
+        self.assertIsNotNone(evidence)
+        directive = self.coordinator.issue_repair_directive(
+            disposition=dispositions[0],
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
+        self.assertIsNotNone(directive)
+        # --- crash: no attempt, no successor, no re-verification ---
+
+        final, _ = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=self._dispatch_success,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+
+        # Exactly one executed attempt; the pre-crash directive plus one
+        # re-issued directive — per-entry budget respected.
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 1)
+        directives = self.gateway_store.list_repair_directives(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(directives), 2)
+
+
+class TestConcurrency(RepairLoopE2EBase):
+    """#8: identical concurrent writes stay idempotent."""
+
+    def test_concurrent_identical_successor_put(self) -> None:
+        readiness = self._reverify()
+        final, _ = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=self._dispatch_success,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+        bindings = self.gateway_store.list_verification_subject_successors(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(bindings), 1)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            outcomes = list(
+                pool.map(
+                    lambda _: (
+                        self.gateway_store.put_verification_subject_successor(
+                            bindings[0], recorded_at_ms=self._next_ms()
+                        )
+                    ),
+                    range(4),
+                )
+            )
+        self.assertEqual(sum(1 for ok in outcomes if ok), 0)
+        self.assertEqual(
+            len(
+                self.gateway_store.list_verification_subject_successors(
+                    self.entry.plan_entry_id
+                )
+            ),
+            1,
+        )
+
+    def test_concurrent_identical_disposition_put(self) -> None:
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        self.assertEqual(len(dispositions), 1)
+        stored = self.gateway_store.get_verification_disposition_by_id(
+            dispositions[0].verification_disposition_id
+        )
+        self.assertIsNotNone(stored)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            outcomes = list(
+                pool.map(
+                    lambda _: (
+                        self.gateway_store.put_verification_disposition(
+                            stored, recorded_at_ms=self._next_ms()
+                        )
+                    ),
+                    range(4),
+                )
+            )
+        self.assertEqual(sum(1 for ok in outcomes if ok), 0)
+
+
+class TestStoreRevalidationAdversarial(RepairLoopE2EBase):
+    """#4: the v28 write boundary rejects everything the Store cannot
+    re-derive from its own state."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        self.disposition = dispositions[0]
+        self.assertEqual(self.disposition.action, "REPAIR")
+        self.evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                self.disposition.failure_evidence_id
+            )
+        )
+        self.directive = self.coordinator.issue_repair_directive(
+            disposition=self.disposition,
+            failure_evidence=self.evidence,
+            plan=self.plan,
+        )
+        self.assertIsNotNone(self.directive)
+
+    def _forged(self, model, **changes):
+        payload = model.model_dump(mode="json")
+        payload.update(changes)
+        for key in (
+            "reason_codes",
+            "evidence_refs",
+            "execution_effect_ids",
+            "allowed_target_refs",
+            "forbidden_target_refs",
+            "repair_constraints",
+        ):
+            if key in payload and isinstance(payload[key], list):
+                payload[key] = tuple(payload[key])
+        return type(model).model_validate(payload).with_computed_sha256()
+
+    def test_forged_failure_evidence_rejected(self) -> None:
+        from contracts.verification import derive_failure_signature
+
+        forged_reasons = ("forged.reason",)
+        payload = self.evidence.model_dump(mode="json")
+        payload.update(
+            {
+                "reason_codes": forged_reasons,
+                "failure_signature_sha256": derive_failure_signature(
+                    plan_entry_id=self.evidence.plan_entry_id,
+                    effective_subject_identity=(
+                        self.evidence.effective_subject_identity
+                    ),
+                    predicate_sha256=self.evidence.predicate_sha256,
+                    verification_status=self.evidence.verification_status,
+                    reason_codes=forged_reasons,
+                    verification_evidence_sha256=(
+                        self.evidence.verification_evidence_sha256
+                    ),
+                ),
+                "failure_evidence_id": "vfe_" + "0" * 64,
+                "failure_evidence_sha256": "0" * 64,
+            }
+        )
+        for key in ("reason_codes", "evidence_refs"):
+            if isinstance(payload.get(key), list):
+                payload[key] = tuple(payload[key])
+        forged = FailureEvidence.model_validate(payload).with_computed_sha256()
+        # Contract-level integrity holds — only the Store re-derivation
+        # can catch this forgery.
+        self.assertTrue(forged.has_valid_identity())
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_failure_evidence(
+                forged, recorded_at_ms=self._next_ms()
+            )
+
+    def test_forged_disposition_action_rejected(self) -> None:
+        forged = self._forged(
+            self.disposition,
+            action="BLOCK",
+            verification_disposition_id="vds_" + "0" * 64,
+            disposition_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_disposition(
+                forged, recorded_at_ms=self._next_ms()
+            )
+
+    def test_forged_disposition_attempt_no_rejected(self) -> None:
+        forged = self._forged(
+            self.disposition,
+            attempt_no=5,
+            verification_disposition_id="vds_" + "0" * 64,
+            disposition_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_disposition(
+                forged, recorded_at_ms=self._next_ms()
+            )
+
+    def test_directive_with_absent_disposition_rejected(self) -> None:
+        forged = self._forged(
+            self.directive,
+            disposition_id="vds_" + "9" * 64,
+            disposition_sha256="9" * 64,
+            repair_directive_id="vrd_" + "0" * 64,
+            directive_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_directive(
+                forged, recorded_at_ms=self._next_ms()
+            )
+
+    def test_directive_with_wrong_predicate_rejected(self) -> None:
+        forged = self._forged(
+            self.directive,
+            predicate_sha256="1" * 64,
+            repair_directive_id="vrd_" + "0" * 64,
+            directive_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_directive(
+                forged, recorded_at_ms=self._next_ms()
+            )
+
+    def test_attempt_with_phantom_effect_rejected(self) -> None:
+        attempt = RepairAttemptRecord(
+            repair_attempt_id="vra_" + "0" * 64,
+            repair_directive_id=self.directive.repair_directive_id,
+            repair_attempt_no=self.directive.repair_attempt_no,
+            request_id=self.directive.request_id,
+            run_id=self.directive.run_id,
+            generation=self.directive.generation,
+            plan_entry_id=self.directive.plan_entry_id,
+            prior_subject_identity=(
+                self.directive.effective_subject_identity
+            ),
+            produced_subject_identity=(
+                self.directive.effective_subject_identity
+            ),
+            execution_effect_ids=("eff_" + "9" * 64,),
+            execution_outcome="EXECUTION_FAILED",
+            reverify_record_id=None,
+            started_at_ms=self._next_ms(),
+            finished_at_ms=self._next_ms(),
+            attempt_sha256="0" * 64,
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_attempt(
+                attempt, recorded_at_ms=self._next_ms()
+            )
+
+    def test_attempt_with_wrong_prior_subject_rejected(self) -> None:
+        effect = self._claim_repair_effect()
+        attempt = RepairAttemptRecord(
+            repair_attempt_id="vra_" + "0" * 64,
+            repair_directive_id=self.directive.repair_directive_id,
+            repair_attempt_no=self.directive.repair_attempt_no,
+            request_id=self.directive.request_id,
+            run_id=self.directive.run_id,
+            generation=self.directive.generation,
+            plan_entry_id=self.directive.plan_entry_id,
+            prior_subject_identity="arv_" + "7" * 61,
+            produced_subject_identity=(
+                self.directive.effective_subject_identity
+            ),
+            execution_effect_ids=(effect.effect_id,),
+            execution_outcome="EXECUTION_FAILED",
+            reverify_record_id=None,
+            started_at_ms=self._next_ms(),
+            finished_at_ms=self._next_ms(),
+            attempt_sha256="0" * 64,
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_attempt(
+                attempt, recorded_at_ms=self._next_ms()
+            )
+
+    def _successor_payload(self, **overrides) -> dict:
+        payload = dict(
+            successor_binding_id="vss_" + "0" * 64,
+            request_id=self.directive.request_id,
+            run_id=self.directive.run_id,
+            generation=self.directive.generation,
+            verification_plan_id=self.directive.verification_plan_id,
+            plan_entry_id=self.directive.plan_entry_id,
+            subject_kind=self.directive.subject_kind,
+            predecessor_subject_identity=(
+                self.directive.effective_subject_identity
+            ),
+            successor_subject_identity="arv_" + "5" * 61,
+            repair_directive_id=self.directive.repair_directive_id,
+            repair_directive_sha256=self.directive.directive_sha256,
+            produced_by_effect_id="eff_placeholder",
+            repair_attempt_no=self.directive.repair_attempt_no,
+            bound_at_ms=95_000,
+            successor_binding_sha256="0" * 64,
+        )
+        payload.update(overrides)
+        return payload
+
+    def test_successor_fork_chain_rejected(self) -> None:
+        effect = self._claim_repair_effect()
+        successor = VerificationSubjectSuccessor(
+            **self._successor_payload(
+                predecessor_subject_identity="arv_" + "7" * 61,
+                produced_by_effect_id=effect.effect_id,
+            )
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_subject_successor(
+                successor, recorded_at_ms=self._next_ms()
+            )
+
+    def test_successor_phantom_producing_effect_rejected(self) -> None:
+        successor = VerificationSubjectSuccessor(
+            **self._successor_payload(
+                produced_by_effect_id="eff_" + "9" * 64,
+            )
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_subject_successor(
+                successor, recorded_at_ms=self._next_ms()
+            )
+
+    def test_successor_phantom_effect_subject_rejected(self) -> None:
+        effect = self._claim_repair_effect()
+        successor = VerificationSubjectSuccessor(
+            **self._successor_payload(
+                subject_kind="effect",
+                successor_subject_identity="eff_" + "9" * 64,
+                produced_by_effect_id=effect.effect_id,
+            )
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_subject_successor(
+                successor, recorded_at_ms=self._next_ms()
+            )
+
+
+class TestDesktopProductionWiring(unittest.TestCase):
+    """#2: the Desktop branch runs the FULL loop and the dispatch
+    bridges to the EXISTING runtime authorities."""
+
+    def _desktop_branch(self) -> str:
+        source = (
+            ROOT / "src" / "total_gateway" / "orchestration.py"
+        ).read_text(encoding="utf-8")
+        branch = source[
+            source.index('if envelope.channel == "desktop":') :
+        ]
+        return branch[: branch.index("delivery_now =")]
+
+    def test_desktop_branch_calls_the_full_repair_loop(self) -> None:
+        branch = self._desktop_branch()
+        self.assertIn("execute_repair_loop(", branch)
+        self.assertIn("_dispatch_repair_directive(", branch)
+        self.assertIn("_repair_reverify", branch)
+        self.assertIn("get_current_verification_disposition(", branch)
+
+    def test_dispatch_bridges_to_existing_runtime_authorities(self) -> None:
+        source = (
+            ROOT / "src" / "total_gateway" / "orchestration.py"
+        ).read_text(encoding="utf-8")
+        start = source.index("def _dispatch_repair_directive")
+        end = source.index("def process(", start)
+        method = source[start:end]
+        for needle in (
+            "PolicyEngine(",
+            "ExecutionTicketPayload(",
+            "sign_execution",
+            "BackendClient(",
+            "claim_effect",
+            "complete_effect",
+            "_register_repair_artifacts(",
+            "ArtifactGate(",
+        ):
+            self.assertIn(needle, method)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_p19_m5_repair_loop.py
+++ b/tests/test_p19_m5_repair_loop.py
@@ -59,7 +59,66 @@ DOCX_MIME = (
 )
 
 
-class RepairLoopE2EBase(M21OracleTestBase):
+class _RepairBindingMixin:
+    """Shared Store dispatch-boundary plumbing for test runtime bridges.
+
+    Test bridges mirror the production bridge contract: reserve BEFORE
+    claiming the effect (a loser never executes the runtime), mark the
+    side-effect boundary BEFORE producing, persist the produced subject
+    BEFORE returning.
+    """
+
+    def _binding_store(self):
+        return getattr(self, "gateway_store", None) or self.store
+
+    def _reserve_or_claimed(self, directive, effect_id, intent=None):
+        import time as _time
+
+        return self._binding_store().reserve_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            repair_directive_sha256=directive.directive_sha256,
+            plan_entry_id=directive.plan_entry_id,
+            repair_attempt_no=directive.repair_attempt_no,
+            request_id=directive.request_id,
+            run_id=directive.run_id,
+            generation=directive.generation,
+            effect_id=effect_id,
+            effect_intent_sha256=intent or "9" * 64,
+            reserved_at_ms=_time.time_ns() // 1_000_000,
+        )
+
+    def _binding_mark_started(self, directive):
+        import time as _time
+
+        self._binding_store().mark_repair_execution_started(
+            repair_directive_id=directive.repair_directive_id,
+            started_at_ms=_time.time_ns() // 1_000_000,
+        )
+
+    def _binding_complete(self, directive, state, produced, ref="test"):
+        import time as _time
+
+        self._binding_store().complete_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            state=state,
+            produced_subject_identity=produced,
+            produced_subject_kind=directive.subject_kind,
+            runtime_result_ref=ref,
+            completed_at_ms=_time.time_ns() // 1_000_000,
+        )
+
+    @staticmethod
+    def _already_claimed(directive):
+        return RepairDispatchResult(
+            execution_outcome="ALREADY_CLAIMED",
+            produced_subject_identity=(
+                directive.effective_subject_identity
+            ),
+            execution_effect_ids=(),
+        )
+
+
+class RepairLoopE2EBase(_RepairBindingMixin, M21OracleTestBase):
     """Real gateway stack + one failing artifact predicate."""
 
     def setUp(self) -> None:
@@ -208,7 +267,12 @@ class RepairLoopE2EBase(M21OracleTestBase):
         )
 
     def _dispatch_success(self, directive: RepairDirective):
-        """Scripted runtime: repairs through the REAL gate/QC pipeline."""
+        """Scripted runtime through the REAL Store dispatch boundary."""
+        effect = self._claim_repair_effect()
+        reserved = self._reserve_or_claimed(directive, effect.effect_id)
+        if reserved["outcome"] != "EXECUTE":
+            return self._already_claimed(directive)
+        self._binding_mark_started(directive)
         good = self._passed_manifest(
             docx_bytes("字" * 300),
             filename="report.docx",
@@ -216,7 +280,9 @@ class RepairLoopE2EBase(M21OracleTestBase):
             declared_mime=DOCX_MIME,
         )
         self.manifests.append(good)
-        effect = self._claim_repair_effect()
+        self._binding_complete(
+            directive, "SUCCEEDED", good.artifact_revision_id
+        )
         return RepairDispatchResult(
             execution_outcome="DISPATCHED",
             produced_subject_identity=good.artifact_revision_id,
@@ -344,6 +410,11 @@ class TestBudgetTermination(RepairLoopE2EBase):
 
     def test_permanent_failure_terminates_with_review(self) -> None:
         def dispatch_always_bad(directive: RepairDirective):
+            effect = self._claim_repair_effect()
+            reserved = self._reserve_or_claimed(directive, effect.effect_id)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
             still_bad = self._passed_manifest(
                 docx_bytes("字" * 10),
                 filename="report.docx",
@@ -351,7 +422,9 @@ class TestBudgetTermination(RepairLoopE2EBase):
                 declared_mime=DOCX_MIME,
             )
             self.manifests.append(still_bad)
-            effect = self._claim_repair_effect()
+            self._binding_complete(
+                directive, "SUCCEEDED", still_bad.artifact_revision_id
+            )
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=(
@@ -804,10 +877,17 @@ class TestAmbiguousRepairSafety(RepairLoopE2EBase):
 
         def dispatch_ambiguous(directive: RepairDirective):
             started_effect = self._claim_repair_effect()
+            reserved = self._reserve_or_claimed(
+                directive, started_effect.effect_id
+            )
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
             self.gateway_store.mark_effect_started(
                 started_effect.effect_id,
                 started_at_ms=_time.time_ns() // 1_000_000,
             )
+            self._binding_mark_started(directive)
+            self._binding_complete(directive, "AMBIGUOUS", "")
             return RepairDispatchResult(
                 execution_outcome="EXECUTION_AMBIGUOUS",
                 produced_subject_identity=(
@@ -868,7 +948,7 @@ class TestAmbiguousRepairSafety(RepairLoopE2EBase):
         )
 
 
-class TestEffectRepairE2E(M21OracleTestBase):
+class TestEffectRepairE2E(_RepairBindingMixin, M21OracleTestBase):
     """P0-2: effect repair → NEW effect successor → SAME predicate PASS."""
 
     def setUp(self) -> None:
@@ -998,7 +1078,12 @@ class TestEffectRepairE2E(M21OracleTestBase):
     def test_effect_repair_new_effect_successor_same_predicate(self) -> None:
         def dispatch(directive: RepairDirective):
             new_effect = self._claim()
+            reserved = self._reserve_or_claimed(directive, new_effect)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
             self._complete(new_effect, "SUCCEEDED")
+            self._binding_complete(directive, "SUCCEEDED", new_effect)
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=new_effect,
@@ -1051,7 +1136,13 @@ class TestEffectRepairE2E(M21OracleTestBase):
 
         def dispatch_fails_again(directive: RepairDirective):
             new_effect = self._claim()
+            reserved = self._reserve_or_claimed(directive, new_effect)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
+            # The runtime completed; the NEW effect itself failed.
             self._complete(new_effect, "FAILED_FINAL")
+            self._binding_complete(directive, "SUCCEEDED", new_effect)
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=new_effect,
@@ -1120,6 +1211,11 @@ class TestGenerationBudgetMultiEntry(RepairLoopE2EBase):
 
     def test_five_entries_four_repairs_then_generation_review(self) -> None:
         def dispatch(directive: RepairDirective):
+            effect = self._claim_repair_effect()
+            reserved = self._reserve_or_claimed(directive, effect.effect_id)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
             good = self._passed_manifest(
                 docx_bytes("字" * 300),
                 filename="report.docx",
@@ -1127,7 +1223,9 @@ class TestGenerationBudgetMultiEntry(RepairLoopE2EBase):
                 declared_mime=DOCX_MIME,
             )
             self.manifests.append(good)
-            effect = self._claim_repair_effect()
+            self._binding_complete(
+                directive, "SUCCEEDED", good.artifact_revision_id
+            )
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=good.artifact_revision_id,
@@ -1180,21 +1278,40 @@ class TestGenerationBudgetMultiEntry(RepairLoopE2EBase):
 
 
 class TestCoordinatorRace(RepairLoopE2EBase):
-    """P1-5/#8: two coordinators racing for attempt #1 — exactly one
-    lands it (Store uniqueness), no double successor."""
+    """Final P0-1: two coordinators racing for attempt #1 — the Store
+    dispatch boundary lets EXACTLY ONE cross into the runtime (produce
+    count == 1), one attempt, one successor."""
 
-    def test_two_coordinators_single_attempt(self) -> None:
+    def test_two_coordinators_single_runtime_execution(self) -> None:
         import threading
 
         readiness = self._reverify()
-        barrier = threading.Barrier(2, timeout=10)
-        errors: list[Exception] = []
-        dispatch_calls = threading.Semaphore(0)
+        produce_calls = []
+        calls_lock = threading.Lock()
 
         def dispatch(directive: RepairDirective):
-            barrier.wait()
-            dispatch_calls.release()
-            return self._dispatch_success(directive)
+            effect = self._claim_repair_effect()
+            reserved = self._reserve_or_claimed(directive, effect.effect_id)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
+            with calls_lock:
+                produce_calls.append(directive.repair_directive_id)
+                good = self._passed_manifest(
+                    docx_bytes("字" * 300),
+                    filename="report.docx",
+                    format_id="docx",
+                    declared_mime=DOCX_MIME,
+                )
+                self.manifests.append(good)
+            self._binding_complete(
+                directive, "SUCCEEDED", good.artifact_revision_id
+            )
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=good.artifact_revision_id,
+                execution_effect_ids=(effect.effect_id,),
+            )
 
         def run() -> None:
             try:
@@ -1204,17 +1321,19 @@ class TestCoordinatorRace(RepairLoopE2EBase):
                     dispatch=dispatch,
                     reverify=self._reverify,
                 )
-            except Exception as exc:  # competitive loser may fail closed
-                errors.append(exc)
+            except Exception:
+                # the competitive loser may fail closed; the final Store
+                # state is what must stay consistent
+                pass
 
-        threads = [
-            threading.Thread(target=run, daemon=True) for _ in range(2)
-        ]
+        threads = [threading.Thread(target=run, daemon=True) for _ in range(2)]
         for thread in threads:
             thread.start()
         for thread in threads:
-            thread.join(timeout=30)
+            thread.join(timeout=60)
 
+        # EXACTLY ONE runtime execution crossed the boundary.
+        self.assertEqual(len(produce_calls), 1)
         attempts = self.gateway_store.list_repair_attempts(
             self.entry.plan_entry_id
         )
@@ -1224,21 +1343,42 @@ class TestCoordinatorRace(RepairLoopE2EBase):
             self.entry.plan_entry_id
         )
         self.assertEqual(len(bindings), 1)
+        binding = self.gateway_store.get_repair_execution_binding_by_attempt(
+            self.entry.plan_entry_id, 1
+        )
+        self.assertIsNotNone(binding)
+        self.assertEqual(binding["state"], "SUCCEEDED")
 
 
 class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
-    """#8: crash after the runtime executed but before successor /
-    re-verification — recovery reuses the SAME directive and completes."""
+    """Final P0-2: runtime succeeded, binding persisted the produced
+    subject, then CRASH before successor/re-verification. Recovery reads
+    ONLY the Store (no in-process dict), never calls the runtime, and
+    completes successor -> re-verify."""
 
-    def test_recover_after_dispatch_before_successor(self) -> None:
-        executed: dict[str, RepairDispatchResult] = {}
+    def _crashed_binding(self, directive):
+        effect = self._claim_repair_effect()
+        reserved = self._reserve_or_claimed(directive, effect.effect_id)
+        assert reserved["outcome"] == "EXECUTE"
+        self._binding_mark_started(directive)
+        good = self._passed_manifest(
+            docx_bytes("字" * 300),
+            filename="report.docx",
+            format_id="docx",
+            declared_mime=DOCX_MIME,
+        )
+        self.manifests.append(good)
+        self._binding_complete(
+            directive, "SUCCEEDED", good.artifact_revision_id
+        )
+        return effect, good
 
-        def idempotent_dispatch(directive: RepairDirective):
-            if directive.repair_directive_id in executed:
-                return executed[directive.repair_directive_id]
-            result = self._dispatch_success(directive)
-            executed[directive.repair_directive_id] = result
-            return result
+    def test_recover_after_succeeded_binding_before_successor(self) -> None:
+        runtime_calls: list[str] = []
+
+        def dispatch(directive: RepairDirective):
+            runtime_calls.append(directive.repair_directive_id)
+            return self._dispatch_success(directive)
 
         readiness = self._reverify()
         dispositions = self.coordinator.process_readiness(
@@ -1254,18 +1394,21 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
             failure_evidence=evidence,
             plan=self.plan,
         )
-        # runtime already executed (result cached), then CRASH before
-        # successor binding / re-verification / attempt record:
-        idempotent_dispatch(directive)
-        self.assertEqual(len(executed), 1)
+        # Runtime already executed; produced subject PERSISTED in the
+        # binding; then CRASH (no successor, no re-verification, no
+        # attempt record).
+        effect, good = self._crashed_binding(directive)
 
+        # New process/coordinator: reads only the Store.
         final, _ = self.coordinator.execute_repair_loop(
             plan=self.plan,
             readiness=readiness,
-            dispatch=idempotent_dispatch,
+            dispatch=dispatch,
             reverify=self._reverify,
         )
         self.assertTrue(final.verification_ready)
+        # The runtime was NEVER called again.
+        self.assertEqual(runtime_calls, [])
         directives = self.gateway_store.list_repair_directives(
             self.entry.plan_entry_id
         )
@@ -1279,6 +1422,74 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
         )
         self.assertEqual(len(attempts), 1)
         self.assertEqual(attempts[0].execution_outcome, "REVERIFY_PASS")
+        self.assertEqual(
+            attempts[0].execution_effect_ids, (effect.effect_id,)
+        )
+        resolution = self.gateway_store.resolve_verification_subject(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(
+            resolution["effective_subject_identity"],
+            good.artifact_revision_id,
+        )
+
+    def test_recover_after_side_effect_started_reconciles(self) -> None:
+        """Final P0-2: crash exactly after the side-effect boundary —
+        recovery must NOT call the runtime and must land on RECONCILE."""
+        runtime_calls: list[str] = []
+
+        def dispatch(directive: RepairDirective):
+            runtime_calls.append(directive.repair_directive_id)
+            return self._dispatch_success(directive)
+
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                dispositions[0].failure_evidence_id
+            )
+        )
+        directive = self.coordinator.issue_repair_directive(
+            disposition=dispositions[0],
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
+        effect = self._claim_repair_effect()
+        reserved = self._reserve_or_claimed(directive, effect.effect_id)
+        assert reserved["outcome"] == "EXECUTE"
+        # CRASH exactly after crossing the side-effect boundary:
+        self._binding_mark_started(directive)
+
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch,
+            reverify=self._reverify,
+        )
+        self.assertFalse(final.verification_ready)
+        self.assertEqual(runtime_calls, [])
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "RECONCILE")
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(
+            attempts[0].execution_outcome, "EXECUTION_AMBIGUOUS"
+        )
+        binding = self.gateway_store.get_repair_execution_binding_by_attempt(
+            self.entry.plan_entry_id, 1
+        )
+        self.assertEqual(binding["state"], "SIDE_EFFECT_STARTED")
+        # Zero successors were bound for an unproven reality.
+        self.assertEqual(
+            self.gateway_store.list_verification_subject_successors(
+                self.entry.plan_entry_id
+            ),
+            (),
+        )
 
 
 class TestDirectiveBoundaryHardening(RepairLoopE2EBase):
@@ -1359,6 +1570,79 @@ class TestDirectiveBoundaryHardening(RepairLoopE2EBase):
                 // 1_000_000
             )
 
+    def test_unrelated_effect_cannot_impersonate_repair(self) -> None:
+        """Final P0: a same-lineage, time-valid but UNRELATED effect
+        must be rejected as a RepairAttempt execution effect and as a
+        Successor producing effect — only the repair execution binding's
+        own effect counts."""
+        # Run one real repair so a SUCCEEDED binding exists.
+        readiness = self._reverify()
+        final, _ = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=self._dispatch_success,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+        binding = self.gateway_store.get_repair_execution_binding_by_attempt(
+            self.entry.plan_entry_id, 1
+        )
+        self.assertEqual(binding["state"], "SUCCEEDED")
+        directive = self.gateway_store.list_repair_directives(
+            self.entry.plan_entry_id
+        )[0]
+
+        # An unrelated effect: same lineage, claimable AFTER the
+        # directive — but never authorized by the binding.
+        attacker_effect = self._claim_repair_effect()
+        good_revision = self.manifests[-1].artifact_revision_id
+
+        forged_attempt = RepairAttemptRecord(
+            repair_attempt_id="vra_" + "0" * 64,
+            repair_directive_id=directive.repair_directive_id,
+            repair_attempt_no=directive.repair_attempt_no,
+            request_id=directive.request_id,
+            run_id=directive.run_id,
+            generation=directive.generation,
+            plan_entry_id=directive.plan_entry_id,
+            prior_subject_identity=directive.effective_subject_identity,
+            produced_subject_identity=good_revision,
+            execution_effect_ids=(attacker_effect.effect_id,),
+            execution_outcome="EXECUTION_FAILED",
+            reverify_record_id=None,
+            started_at_ms=__import__("time").time_ns() // 1_000_000,
+            finished_at_ms=__import__("time").time_ns() // 1_000_000,
+            attempt_sha256="0" * 64,
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_attempt(
+                forged_attempt,
+                recorded_at_ms=__import__("time").time_ns() // 1_000_000,
+            )
+
+        forged_successor = VerificationSubjectSuccessor(
+            successor_binding_id="vss_" + "0" * 64,
+            request_id=directive.request_id,
+            run_id=directive.run_id,
+            generation=directive.generation,
+            verification_plan_id=directive.verification_plan_id,
+            plan_entry_id=directive.plan_entry_id,
+            subject_kind=directive.subject_kind,
+            predecessor_subject_identity=directive.effective_subject_identity,
+            successor_subject_identity=good_revision,
+            repair_directive_id=directive.repair_directive_id,
+            repair_directive_sha256=directive.directive_sha256,
+            produced_by_effect_id=attacker_effect.effect_id,
+            repair_attempt_no=directive.repair_attempt_no + 1,
+            bound_at_ms=__import__("time").time_ns() // 1_000_000,
+            successor_binding_sha256="0" * 64,
+        ).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_subject_successor(
+                forged_successor,
+                recorded_at_ms=__import__("time").time_ns() // 1_000_000,
+            )
+
     def test_successor_cycle_rejected(self) -> None:
         effect = self._claim_repair_effect()
         payload = dict(
@@ -1401,6 +1685,11 @@ class TestGateAuthorityChecks(RepairLoopE2EBase):
         )
 
         def dispatch_always_bad(directive: RepairDirective):
+            effect = self._claim_repair_effect()
+            reserved = self._reserve_or_claimed(directive, effect.effect_id)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
             still_bad = self._passed_manifest(
                 docx_bytes("字" * 10),
                 filename="report.docx",
@@ -1408,7 +1697,9 @@ class TestGateAuthorityChecks(RepairLoopE2EBase):
                 declared_mime=DOCX_MIME,
             )
             self.manifests.append(still_bad)
-            effect = self._claim_repair_effect()
+            self._binding_complete(
+                directive, "SUCCEEDED", still_bad.artifact_revision_id
+            )
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=still_bad.artifact_revision_id,
@@ -1544,7 +1835,7 @@ class TestChannelSafetySemantics(RepairLoopE2EBase):
         self.assertIn("dispatchable_subject_kinds=dispatchable", loop_body)
         self.assertNotIn("send_message", loop_body)
 
-class TestRepositoryRepairE2E(_M31RepositoryBase):
+class TestRepositoryRepairE2E(_RepairBindingMixin, _M31RepositoryBase):
     """P0-2: repository repair -> new mutation effect + PRE/POST window
     -> SAME predicate re-verified -> PASS."""
 
@@ -1663,7 +1954,14 @@ class TestRepositoryRepairE2E(_M31RepositoryBase):
             _git(self._repo, "add", ".")
             _git(self._repo, "commit", "-q", "-m", "repair marker")
             new_subject = self._create_effect(101)
+            reserved = self._reserve_or_claimed(directive, new_subject)
+            if reserved["outcome"] != "EXECUTE":
+                return self._already_claimed(directive)
+            self._binding_mark_started(directive)
+            # The observation window is bound BEFORE the binding is
+            # terminalized (production semantics).
             self._window(subject=new_subject, delta=True)
+            self._binding_complete(directive, "SUCCEEDED", new_subject)
             return RepairDispatchResult(
                 execution_outcome="DISPATCHED",
                 produced_subject_identity=new_subject,

--- a/tests/test_p19_m5_repair_loop.py
+++ b/tests/test_p19_m5_repair_loop.py
@@ -47,6 +47,9 @@ from total_gateway.verification_repair_coordinator import (
 )
 from tests.test_docx_qc import docx_bytes
 from tests.test_p19_m2_1_artifact_oracle import M21OracleTestBase
+from tests.test_p19_m3_1_repository_binding import (
+    RepositoryOracleTestBase as _M31RepositoryBase,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -78,30 +81,7 @@ class RepairLoopE2EBase(M21OracleTestBase):
         )
         self.manifests.append(self.bad_manifest)
 
-        predicate = AcceptancePredicate.create(
-            predicate_type="artifact.min_visible_text_chars",
-            subject_kind="artifact",
-            params={"min_chars": 200},
-        )
-        entry = VerificationPlanEntryV2(
-            plan_entry_id="vpe_" + "0" * 64,
-            verifier_id="verifier.artifact_content",
-            verifier_version="3",
-            predicate=predicate,
-            subject_identity=self.bad_manifest.artifact_revision_id,
-            evaluation_phase="POST_EXECUTION",
-            required=True,
-            entry_sha256="0" * 64,
-        ).with_computed_sha256()
-        self.plan = VerificationPlan(
-            verification_plan_id="vpl_" + "0" * 64,
-            request_id=self.request.request_id,
-            run_id=self.run.run_id,
-            generation=2,
-            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
-            entries=(entry,),
-            plan_sha256="0" * 64,
-        ).with_computed_sha256()
+        self.plan = self._build_plan()
         self.entry = self.plan.entries[0]
         assert self.gateway_store.put_verification_plan(
             self.plan, recorded_at_ms=1_600
@@ -119,11 +99,68 @@ class RepairLoopE2EBase(M21OracleTestBase):
             store=self.gateway_store
         )
 
+    def _build_plan(self):
+        predicate = AcceptancePredicate.create(
+            predicate_type="artifact.min_visible_text_chars",
+            subject_kind="artifact",
+            params={"min_chars": 200},
+        )
+        entry = VerificationPlanEntryV2(
+            plan_entry_id="vpe_" + "0" * 64,
+            verifier_id="verifier.artifact_content",
+            verifier_version="3",
+            predicate=predicate,
+            subject_identity=self.bad_manifest.artifact_revision_id,
+            evaluation_phase="POST_EXECUTION",
+            required=True,
+            entry_sha256="0" * 64,
+        ).with_computed_sha256()
+        return VerificationPlan(
+            verification_plan_id="vpl_" + "0" * 64,
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            entries=(entry,),
+            plan_sha256="0" * 64,
+        ).with_computed_sha256()
+
     # -- helpers ----------------------------------------------------------
 
     def _next_ms(self) -> int:
         self._clock += 1_000
         return self._clock
+
+    def _passed_manifest(
+        self,
+        data: bytes,
+        *,
+        filename: str,
+        format_id: str,
+        declared_mime: str,
+        docx_min_words: int = 1,
+    ):
+        manifest = super()._passed_manifest(
+            data,
+            filename=filename,
+            format_id=format_id,
+            declared_mime=declared_mime,
+            docx_min_words=docx_min_words,
+        )
+        # P1-6: every QC-passed manifest enters the Store's artifact
+        # authority projection (mirrors the production gate pipeline).
+        import time as _time
+
+        self.gateway_store.register_artifact_subject(
+            artifact_revision_id=manifest.artifact_revision_id,
+            object_id=manifest.content_object_id,
+            artifact_sha256=manifest.sha256,
+            request_id=manifest.request_id,
+            run_id=manifest.run_id,
+            generation=manifest.generation,
+            registered_at_ms=_time.time_ns() // 1_000_000,
+        )
+        return manifest
 
     def _claim_repair_effect(self):
         self._effect_ordinal += 1
@@ -136,6 +173,10 @@ class RepairLoopE2EBase(M21OracleTestBase):
             ordinal=self._effect_ordinal,
             intent_sha256="9" * 64,
         )
+        # Real wall clock: the producing effect must be claimable at/after
+        # the directive's wall-clock issued_at_ms.
+        import time as _time
+
         self.gateway_store.claim_effect(
             EffectClaim(
                 effect_id=effect.effect_id,
@@ -147,7 +188,7 @@ class RepairLoopE2EBase(M21OracleTestBase):
                 ordinal=effect.ordinal,
                 intent_sha256="9" * 64,
                 owner_component_id="tiangong-backend",
-                claimed_at_ms=self._next_ms(),
+                claimed_at_ms=_time.time_ns() // 1_000_000,
                 claim_sha256="0" * 64,
             ).with_computed_sha256()
         )
@@ -398,8 +439,9 @@ class TestCrashRecovery(RepairLoopE2EBase):
         )
         self.assertTrue(final.verification_ready)
 
-        # Exactly one executed attempt; the pre-crash directive plus one
-        # re-issued directive — per-entry budget respected.
+        # P1-7: the pre-crash directive is REUSED (same identity), not
+        # re-issued — repeated crashes before dispatch cannot burn the
+        # budget.
         attempts = self.gateway_store.list_repair_attempts(
             self.entry.plan_entry_id
         )
@@ -407,7 +449,11 @@ class TestCrashRecovery(RepairLoopE2EBase):
         directives = self.gateway_store.list_repair_directives(
             self.entry.plan_entry_id
         )
-        self.assertEqual(len(directives), 2)
+        self.assertEqual(len(directives), 1)
+        self.assertEqual(
+            directives[0].repair_directive_id,
+            directive.repair_directive_id,
+        )
 
 
 class TestConcurrency(RepairLoopE2EBase):
@@ -748,6 +794,921 @@ class TestDesktopProductionWiring(unittest.TestCase):
             "ArtifactGate(",
         ):
             self.assertIn(needle, method)
+
+
+class TestAmbiguousRepairSafety(RepairLoopE2EBase):
+    """P0-1: EXECUTION_AMBIGUOUS → immediate RECONCILE, zero replay."""
+
+    def test_ambiguous_dispatch_stops_with_reconcile_zero_replay(self) -> None:
+        import time as _time
+
+        def dispatch_ambiguous(directive: RepairDirective):
+            started_effect = self._claim_repair_effect()
+            self.gateway_store.mark_effect_started(
+                started_effect.effect_id,
+                started_at_ms=_time.time_ns() // 1_000_000,
+            )
+            return RepairDispatchResult(
+                execution_outcome="EXECUTION_AMBIGUOUS",
+                produced_subject_identity=(
+                    directive.effective_subject_identity
+                ),
+                execution_effect_ids=(started_effect.effect_id,),
+            )
+
+        readiness = self._reverify()
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch_ambiguous,
+            reverify=self._reverify,
+        )
+        self.assertFalse(final.verification_ready)
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "RECONCILE")
+        self.assertIn(
+            "repair_policy.ambiguous_effect_no_replay",
+            disposition.reason_codes,
+        )
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(attempts[0].execution_outcome, "EXECUTION_AMBIGUOUS")
+        self.assertIsNone(attempts[0].reverify_record_id)
+        directives = self.gateway_store.list_repair_directives(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(directives), 1)
+
+        # Zero replay: a second loop pass still sees RECONCILE and never
+        # issues another directive (the ambiguous attempt is permanent).
+        final2, disposition2 = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=final,
+            dispatch=dispatch_ambiguous,
+            reverify=self._reverify,
+        )
+        self.assertEqual(disposition2.action, "RECONCILE")
+        self.assertEqual(
+            len(
+                self.gateway_store.list_repair_directives(
+                    self.entry.plan_entry_id
+                )
+            ),
+            1,
+        )
+        self.assertEqual(
+            len(
+                self.gateway_store.list_repair_attempts(
+                    self.entry.plan_entry_id
+                )
+            ),
+            1,
+        )
+
+
+class TestEffectRepairE2E(M21OracleTestBase):
+    """P0-2: effect repair → NEW effect successor → SAME predicate PASS."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._register_lineage_request()
+        self.gateway_store.put_registry_snapshot(
+            self.snapshot, recorded_at_ms=1_500
+        )
+        self._clock = 30_000
+        self._effect_ordinal = 50
+        from contracts.verification import (
+            VerificationPlan as _Plan,
+            VerificationPlanEntryV2 as _Entry,
+        )
+
+        predicate = AcceptancePredicate.create(
+            predicate_type="effect.terminal_succeeded",
+            subject_kind="effect",
+        )
+        self.old_effect = self._failed_effect()
+        entry = _Entry(
+            plan_entry_id="vpe_" + "0" * 64,
+            verifier_id="verifier.effect_state",
+            verifier_version="2",
+            predicate=predicate,
+            subject_identity=self.old_effect,
+            evaluation_phase="POST_EXECUTION",
+            required=True,
+            entry_sha256="0" * 64,
+        ).with_computed_sha256()
+        self.plan = _Plan(
+            verification_plan_id="vpl_" + "0" * 64,
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            entries=(entry,),
+            plan_sha256="0" * 64,
+        ).with_computed_sha256()
+        self.entry = self.plan.entries[0]
+        assert self.gateway_store.put_verification_plan(
+            self.plan, recorded_at_ms=1_600
+        )
+        self.gateway_store.activate_verification_plan(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            verification_plan_id=self.plan.verification_plan_id,
+            verification_plan_sha256=self.plan.plan_sha256,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            activated_at_ms=1_700,
+        )
+        self.coordinator = VerificationRepairCoordinator(
+            store=self.gateway_store
+        )
+
+    def _claim(self) -> str:
+        from contracts import derive_effect_identity
+
+        self._effect_ordinal += 1
+        identity = derive_effect_identity(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            run_sequence=1,
+            generation=2,
+            effect_kind="execution",
+            ordinal=self._effect_ordinal,
+            intent_sha256="8" * 64,
+        )
+        self.gateway_store.claim_effect(
+            EffectClaim(
+                effect_id=identity.effect_id,
+                request_id=self.request.request_id,
+                run_id=self.run.run_id,
+                run_sequence=1,
+                generation=2,
+                effect_kind="execution",
+                ordinal=identity.ordinal,
+                intent_sha256="8" * 64,
+                owner_component_id="tiangong-backend",
+                claimed_at_ms=__import__("time").time_ns() // 1_000_000,
+                claim_sha256="0" * 64,
+            ).with_computed_sha256()
+        )
+        return identity.effect_id
+
+    def _complete(self, effect_id: str, status: str) -> None:
+        import time as _time
+
+        from contracts import canonical_sha256 as _sha
+        from total_gateway.effects import EffectResult
+
+        self.gateway_store.mark_effect_started(
+            effect_id, started_at_ms=_time.time_ns() // 1_000_000
+        )
+        self.gateway_store.complete_effect(
+            EffectResult(
+                result_id="effect-result-" + effect_id[4:20],
+                effect_id=effect_id,
+                status=status,
+                fact_id="fact-effect-" + effect_id[4:20],
+                evidence_sha256=_sha({"status": status}),
+                error_code=None if status == "SUCCEEDED" else "exec.failed",
+                observed_at_ms=_time.time_ns() // 1_000_000,
+                result_sha256="0" * 64,
+            ).with_computed_sha256()
+        )
+
+    def _failed_effect(self) -> str:
+        effect_id = self._claim()
+        self._complete(effect_id, "FAILED_FINAL")
+        return effect_id
+
+    def _reverify(self):
+        executor = VerificationPlanExecutor(
+            snapshot=self.snapshot,
+            store=self.gateway_store,
+            object_store=self.object_store,
+            fact_ledger=self.fact_ledger,
+            plan=self.plan,
+        )
+        self._clock += 1_000
+        return executor.execute(
+            evaluated_at_ms=self._clock, artifact_manifests=()
+        )
+
+    def test_effect_repair_new_effect_successor_same_predicate(self) -> None:
+        def dispatch(directive: RepairDirective):
+            new_effect = self._claim()
+            self._complete(new_effect, "SUCCEEDED")
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=new_effect,
+                execution_effect_ids=(new_effect,),
+            )
+
+        readiness = self._reverify()
+        self.assertFalse(readiness.verification_ready)
+
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+        self.assertIsNone(disposition)
+
+        resolution = self.gateway_store.resolve_verification_subject(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(resolution["successor_depth"], 1)
+        self.assertNotEqual(
+            resolution["effective_subject_identity"], self.old_effect
+        )
+
+        records = [
+            r
+            for r in self.gateway_store.list_verification_records(
+                request_id=self.request.request_id,
+                run_id=self.run.run_id,
+                generation=2,
+            )
+            if r.predicate_id == self.entry.predicate.predicate_id
+        ]
+        pass_records = [r for r in records if r.status == "PASS"]
+        self.assertEqual(len(pass_records), 1)
+        self.assertEqual(
+            pass_records[0].subject_identity,
+            resolution["effective_subject_identity"],
+        )
+        self.assertEqual(
+            pass_records[0].evaluated_at_ms,
+            max(r.evaluated_at_ms for r in records),
+        )
+
+    def test_effect_side_effect_budget_caps_at_one(self) -> None:
+        """P1-5: effect repairs are capped by the side-effect budget
+        (1) BEFORE the per-entry budget (2)."""
+
+        def dispatch_fails_again(directive: RepairDirective):
+            new_effect = self._claim()
+            self._complete(new_effect, "FAILED_FINAL")
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=new_effect,
+                execution_effect_ids=(new_effect,),
+            )
+
+        readiness = self._reverify()
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch_fails_again,
+            reverify=self._reverify,
+        )
+        self.assertFalse(final.verification_ready)
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "REVIEW")
+        self.assertIn(
+            "repair_policy.side_effect_budget_exhausted",
+            disposition.reason_codes,
+        )
+        directives = self.gateway_store.list_repair_directives(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(directives), 1)
+
+
+class TestGenerationBudgetMultiEntry(RepairLoopE2EBase):
+    """P1-8: one readiness, N repairable entries — the generation budget
+    turns the (N+1)-th into a normal REVIEW, not a write rejection."""
+
+    def _build_plan(self):
+        entries = []
+        for index in range(5):
+            manifest = self._passed_manifest(
+                docx_bytes("字" * 50),
+                filename=f"report{index}.docx",
+                format_id="docx",
+                declared_mime=DOCX_MIME,
+            )
+            self.manifests.append(manifest)
+            predicate = AcceptancePredicate.create(
+                predicate_type="artifact.min_visible_text_chars",
+                subject_kind="artifact",
+                params={"min_chars": 200},
+            )
+            entry = VerificationPlanEntryV2(
+                plan_entry_id="vpe_" + "0" * 63 + str(index),
+                verifier_id="verifier.artifact_content",
+                verifier_version="3",
+                predicate=predicate,
+                subject_identity=manifest.artifact_revision_id,
+                evaluation_phase="POST_EXECUTION",
+                required=True,
+                entry_sha256="0" * 64,
+            ).with_computed_sha256()
+            entries.append(entry)
+        return VerificationPlan(
+            verification_plan_id="vpl_" + "0" * 64,
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            entries=tuple(sorted(entries, key=lambda e: e.plan_entry_id)),
+            plan_sha256="0" * 64,
+        ).with_computed_sha256()
+
+    def test_five_entries_four_repairs_then_generation_review(self) -> None:
+        def dispatch(directive: RepairDirective):
+            good = self._passed_manifest(
+                docx_bytes("字" * 300),
+                filename="report.docx",
+                format_id="docx",
+                declared_mime=DOCX_MIME,
+            )
+            self.manifests.append(good)
+            effect = self._claim_repair_effect()
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=good.artifact_revision_id,
+                execution_effect_ids=(effect.effect_id,),
+            )
+
+        def reverify():
+            executor = VerificationPlanExecutor(
+                snapshot=self.snapshot,
+                store=self.gateway_store,
+                object_store=self.object_store,
+                fact_ledger=self.fact_ledger,
+                plan=self.plan,
+            )
+            return executor.execute(
+                evaluated_at_ms=self._next_ms(),
+                artifact_manifests=tuple(self.manifests),
+            )
+
+        readiness = reverify()
+        self.assertEqual(
+            len(
+                [
+                    a
+                    for a in readiness.entry_assessments
+                    if a.status != "PASS"
+                ]
+            ),
+            5,
+        )
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch,
+            reverify=reverify,
+        )
+        self.assertFalse(final.verification_ready)
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "REVIEW")
+        self.assertIn(
+            "repair_policy.generation_budget_exhausted",
+            disposition.reason_codes,
+        )
+        # exactly the generation budget of REPAIR directives was issued
+        total_directives = sum(
+            len(self.gateway_store.list_repair_directives(e.plan_entry_id))
+            for e in self.plan.entries
+        )
+        self.assertEqual(total_directives, 4)
+
+
+class TestCoordinatorRace(RepairLoopE2EBase):
+    """P1-5/#8: two coordinators racing for attempt #1 — exactly one
+    lands it (Store uniqueness), no double successor."""
+
+    def test_two_coordinators_single_attempt(self) -> None:
+        import threading
+
+        readiness = self._reverify()
+        barrier = threading.Barrier(2, timeout=10)
+        errors: list[Exception] = []
+        dispatch_calls = threading.Semaphore(0)
+
+        def dispatch(directive: RepairDirective):
+            barrier.wait()
+            dispatch_calls.release()
+            return self._dispatch_success(directive)
+
+        def run() -> None:
+            try:
+                self.coordinator.execute_repair_loop(
+                    plan=self.plan,
+                    readiness=readiness,
+                    dispatch=dispatch,
+                    reverify=self._reverify,
+                )
+            except Exception as exc:  # competitive loser may fail closed
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=run, daemon=True) for _ in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(attempts[0].repair_attempt_no, 1)
+        bindings = self.gateway_store.list_verification_subject_successors(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(bindings), 1)
+
+
+class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
+    """#8: crash after the runtime executed but before successor /
+    re-verification — recovery reuses the SAME directive and completes."""
+
+    def test_recover_after_dispatch_before_successor(self) -> None:
+        executed: dict[str, RepairDispatchResult] = {}
+
+        def idempotent_dispatch(directive: RepairDirective):
+            if directive.repair_directive_id in executed:
+                return executed[directive.repair_directive_id]
+            result = self._dispatch_success(directive)
+            executed[directive.repair_directive_id] = result
+            return result
+
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                dispositions[0].failure_evidence_id
+            )
+        )
+        directive = self.coordinator.issue_repair_directive(
+            disposition=dispositions[0],
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
+        # runtime already executed (result cached), then CRASH before
+        # successor binding / re-verification / attempt record:
+        idempotent_dispatch(directive)
+        self.assertEqual(len(executed), 1)
+
+        final, _ = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=idempotent_dispatch,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+        directives = self.gateway_store.list_repair_directives(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(directives), 1)
+        self.assertEqual(
+            directives[0].repair_directive_id,
+            directive.repair_directive_id,
+        )
+        attempts = self.gateway_store.list_repair_attempts(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(attempts[0].execution_outcome, "REVERIFY_PASS")
+
+
+class TestDirectiveBoundaryHardening(RepairLoopE2EBase):
+    """P1-4 adversarial: expired / widened / over-budget directives are
+    rejected at the Store write boundary."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        readiness = self._reverify()
+        dispositions = self.coordinator.process_readiness(
+            plan=self.plan, readiness=readiness
+        )
+        self.disposition = dispositions[0]
+        evidence = (
+            self.gateway_store.get_verification_failure_evidence_by_id(
+                self.disposition.failure_evidence_id
+            )
+        )
+        self.directive = self.coordinator.issue_repair_directive(
+            disposition=self.disposition,
+            failure_evidence=evidence,
+            plan=self.plan,
+        )
+
+    def _forged_directive(self, **changes):
+        payload = self.directive.model_dump(mode="json")
+        payload.update(changes)
+        for key in (
+            "allowed_target_refs",
+            "forbidden_target_refs",
+            "repair_constraints",
+        ):
+            if key in payload and isinstance(payload[key], list):
+                payload[key] = tuple(payload[key])
+        return (
+            RepairDirective.model_validate(payload).with_computed_sha256()
+        )
+
+    def test_expired_directive_rejected(self) -> None:
+        import time as _time
+
+        now = _time.time_ns() // 1_000_000
+        forged = self._forged_directive(
+            issued_at_ms=now - 10_000,
+            expires_at_ms=now - 1_000,
+            repair_directive_id="vrd_" + "0" * 64,
+            directive_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_directive(
+                forged, recorded_at_ms=now
+            )
+
+    def test_widened_target_scope_rejected(self) -> None:
+        forged = self._forged_directive(
+            allowed_target_refs=(
+                self.directive.effective_subject_identity,
+                "arv_" + "3" * 61,
+            ),
+            repair_directive_id="vrd_" + "0" * 64,
+            directive_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_directive(
+                forged, recorded_at_ms=__import__("time").time_ns()
+                // 1_000_000
+            )
+
+    def test_over_budget_directive_rejected(self) -> None:
+        forged = self._forged_directive(
+            execution_budget_ms=6_000_000,
+            repair_directive_id="vrd_" + "0" * 64,
+            directive_sha256="0" * 64,
+        )
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_repair_directive(
+                forged, recorded_at_ms=__import__("time").time_ns()
+                // 1_000_000
+            )
+
+    def test_successor_cycle_rejected(self) -> None:
+        effect = self._claim_repair_effect()
+        payload = dict(
+            successor_binding_id="vss_" + "0" * 64,
+            request_id=self.directive.request_id,
+            run_id=self.directive.run_id,
+            generation=self.directive.generation,
+            verification_plan_id=self.directive.verification_plan_id,
+            plan_entry_id=self.directive.plan_entry_id,
+            subject_kind=self.directive.subject_kind,
+            predecessor_subject_identity=(
+                self.directive.effective_subject_identity
+            ),
+            successor_subject_identity=(
+                self.bad_manifest.artifact_revision_id
+            ),  # already on the chain (it IS the original subject)
+            repair_directive_id=self.directive.repair_directive_id,
+            repair_directive_sha256=self.directive.directive_sha256,
+            produced_by_effect_id=effect.effect_id,
+            repair_attempt_no=self.directive.repair_attempt_no,
+            bound_at_ms=__import__("time").time_ns() // 1_000_000,
+            successor_binding_sha256="0" * 64,
+        )
+        binding = VerificationSubjectSuccessor(**payload).with_computed_sha256()
+        with self.assertRaises(ValueError):
+            self.gateway_store.put_verification_subject_successor(
+                binding, recorded_at_ms=__import__("time").time_ns()
+                // 1_000_000
+            )
+
+
+class TestGateAuthorityChecks(RepairLoopE2EBase):
+    """P1-9: the Gate validates the full disposition ↔ evidence ↔
+    readiness ↔ plan binding itself."""
+
+    def _failing_state(self):
+        from total_gateway.completion_gate import (
+            CompletionGate,
+            CompletionRequirements,
+        )
+
+        def dispatch_always_bad(directive: RepairDirective):
+            still_bad = self._passed_manifest(
+                docx_bytes("字" * 10),
+                filename="report.docx",
+                format_id="docx",
+                declared_mime=DOCX_MIME,
+            )
+            self.manifests.append(still_bad)
+            effect = self._claim_repair_effect()
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=still_bad.artifact_revision_id,
+                execution_effect_ids=(effect.effect_id,),
+            )
+
+        readiness = self._reverify()
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch_always_bad,
+            reverify=self._reverify,
+        )
+        evidence = self.gateway_store.get_verification_failure_evidence_by_id(
+            disposition.failure_evidence_id
+        )
+        requirements = CompletionRequirements(
+            request_id=self.request.request_id,
+            run_id=self.run.run_id,
+            generation=2,
+            text_required=False,
+            required_artifact_revision_ids=(
+                self.bad_manifest.artifact_revision_id,
+            ),
+            delivery_requirement="NONE",
+            verification_mode="PLAN_BOUND",
+        )
+        gate = CompletionGate(
+            self.object_store,
+            self.fact_ledger,
+            head_state_reader=self.gateway_store.get_effect_head_state,
+        )
+        return gate, requirements, final, disposition, evidence
+
+    def test_disposition_without_evidence_rejected(self) -> None:
+        from total_gateway.completion_gate import CompletionGateError
+
+        gate, requirements, final, disposition, _ = self._failing_state()
+        with self.assertRaisesRegex(
+            CompletionGateError,
+            "completion.verification.disposition_without_evidence",
+        ):
+            gate.evaluate(
+                requirements,
+                active_plan=self.plan,
+                verification_readiness=final,
+                verification_disposition=disposition,
+            )
+
+    def test_stale_evidence_rejected(self) -> None:
+        from total_gateway.completion_gate import CompletionGateError
+
+        gate, requirements, final, disposition, evidence = (
+            self._failing_state()
+        )
+        stale = self.gateway_store.list_verification_failure_evidence(
+            self.entry.plan_entry_id
+        )[0]
+        if stale.failure_evidence_id == evidence.failure_evidence_id:
+            self.skipTest("no earlier evidence row in this run")
+        with self.assertRaisesRegex(
+            CompletionGateError,
+            "completion.verification.disposition_evidence_mismatch",
+        ):
+            gate.evaluate(
+                requirements,
+                active_plan=self.plan,
+                verification_readiness=final,
+                verification_disposition=disposition,
+                verification_failure_evidence=stale,
+            )
+
+    def test_fully_bound_disposition_drives_in_progress(self) -> None:
+        gate, requirements, final, disposition, evidence = (
+            self._failing_state()
+        )
+        decision = gate.evaluate(
+            requirements,
+            active_plan=self.plan,
+            verification_readiness=final,
+            verification_disposition=disposition,
+            verification_failure_evidence=evidence,
+        )
+        self.assertEqual(decision.outcome, "IN_PROGRESS")
+
+
+class TestChannelSafetySemantics(RepairLoopE2EBase):
+    """P0-3: channel-side gating — nothing auto-executes when the
+    dispatchable kinds are empty; the delivery is never replayed."""
+
+    def test_empty_kinds_never_dispatch_and_keep_repair_pending(self) -> None:
+        calls: list[str] = []
+
+        def dispatch(directive: RepairDirective):
+            calls.append(directive.repair_directive_id)
+            return self._dispatch_success(directive)
+
+        readiness = self._reverify()
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch,
+            reverify=self._reverify,
+            dispatchable_subject_kinds=(),
+        )
+        self.assertEqual(calls, [])
+        self.assertFalse(final.verification_ready)
+        self.assertIsNotNone(disposition)
+        self.assertEqual(disposition.action, "REPAIR")
+        # No directive was issued for a non-dispatchable kind.
+        self.assertEqual(
+            self.gateway_store.list_repair_directives(
+                self.entry.plan_entry_id
+            ),
+            (),
+        )
+        self.assertEqual(
+            self.gateway_store.list_repair_attempts(self.entry.plan_entry_id),
+            (),
+        )
+
+    def test_outbox_finalization_uses_safe_repair_loop(self) -> None:
+        source = (
+            ROOT / "src" / "total_gateway" / "delivery_outbox.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("_run_channel_repair_loop(", source)
+        self.assertIn("repair_dispatch: Callable[..., object] | None = None", source)
+        # The delivery itself is never re-sent by the repair loop.
+        loop_body = source[
+            source.index("def _run_channel_repair_loop") :
+        ]
+        loop_body = loop_body[: loop_body.index("def _load_payload")]
+        self.assertIn("dispatchable_subject_kinds=dispatchable", loop_body)
+        self.assertNotIn("send_message", loop_body)
+
+class TestRepositoryRepairE2E(_M31RepositoryBase):
+    """P0-2: repository repair -> new mutation effect + PRE/POST window
+    -> SAME predicate re-verified -> PASS."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.store.put_registry_snapshot(self.snapshot, recorded_at_ms=1_500)
+        # Original subject: a repository mutation effect whose window
+        # changes the WRONG path -> FAIL. (Observations are wall-clock
+        # stamped, so every capture in this test observes a NEW repo
+        # state — re-observing an unchanged state is a content conflict.)
+        from tests.test_p19_m3_1_repository_binding import _git
+
+        self.old_subject = self._create_effect(100)
+        pre = self._capture_observation()
+        self._store_content(pre)
+        self._bind(pre, role="PRE", subject_effect_id=self.old_subject)
+        (self._repo / "docs").mkdir(exist_ok=True)
+        (self._repo / "docs" / "x.md").write_text(
+            "noise" + chr(10), encoding="utf-8"
+        )
+        _git(self._repo, "add", ".")
+        _git(self._repo, "commit", "-q", "-m", "wrong path")
+        post = self._capture_observation(delta_from=pre)
+        self._store_content(post)
+        self._bind(post, role="POST", subject_effect_id=self.old_subject)
+
+        predicate = AcceptancePredicate.create(
+            predicate_type="repository.required_paths_changed",
+            subject_kind="repository",
+            params={"paths": ["src/main.py"]},
+        )
+        entry = VerificationPlanEntryV2(
+            plan_entry_id="vpe_" + "0" * 64,
+            verifier_id="verifier.repository_state",
+            verifier_version="2",
+            predicate=predicate,
+            subject_identity=self.old_subject,
+            evaluation_phase="POST_EXECUTION",
+            required=True,
+            entry_sha256="0" * 64,
+        ).with_computed_sha256()
+        self.plan = VerificationPlan(
+            verification_plan_id="vpl_" + "0" * 64,
+            request_id=self.request_id,
+            run_id=self.run_id,
+            generation=2,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            entries=(entry,),
+            plan_sha256="0" * 64,
+        ).with_computed_sha256()
+        self.entry = self.plan.entries[0]
+        assert self.store.put_verification_plan(
+            self.plan, recorded_at_ms=1_600
+        )
+        self.store.activate_verification_plan(
+            request_id=self.request_id,
+            run_id=self.run_id,
+            generation=2,
+            verification_plan_id=self.plan.verification_plan_id,
+            verification_plan_sha256=self.plan.plan_sha256,
+            registry_snapshot_sha256=self.snapshot.snapshot_sha256,
+            activated_at_ms=1_700,
+        )
+        self.coordinator = VerificationRepairCoordinator(store=self.store)
+        self._clock = 30_000
+
+    def _create_effect(self, ordinal: int = 0) -> str:
+        """Wall-clock claim: repair effects must be claimable at/after
+        the directive's wall-clock issued_at_ms (Store boundary)."""
+        from contracts import derive_effect_identity
+
+        identity = derive_effect_identity(
+            request_id=self.request_id, run_id=self.run_id,
+            run_sequence=1, generation=2, effect_kind="execution",
+            ordinal=ordinal, intent_sha256="6" * 64,
+        )
+        import time as _time
+
+        self.store.claim_effect(
+            EffectClaim(
+                effect_id=identity.effect_id, request_id=self.request_id,
+                run_id=self.run_id, run_sequence=1, generation=2,
+                effect_kind="execution", ordinal=ordinal,
+                intent_sha256="6" * 64,
+                owner_component_id="tiangong-backend",
+                claimed_at_ms=_time.time_ns() // 1_000_000,
+                claim_sha256="0" * 64,
+            ).with_computed_sha256()
+        )
+        return identity.effect_id
+
+    def _reverify(self):
+        executor = VerificationPlanExecutor(
+            snapshot=self.snapshot,
+            store=self.store,
+            object_store=None,
+            fact_ledger=None,
+            plan=self.plan,
+        )
+        self._clock += 1_000
+        return executor.execute(
+            evaluated_at_ms=self._clock, artifact_manifests=()
+        )
+
+    def test_repository_repair_new_mutation_effect_successor_pass(self) -> None:
+        def dispatch(directive: RepairDirective):
+            # The repaired mutation: a NEW effect with a PRE/POST window
+            # that DOES change the required path. The marker commit first
+            # moves the repo to a fresh state so the PRE observation is
+            # new content.
+            from tests.test_p19_m3_1_repository_binding import _git
+
+            (self._repo / "marker.txt").write_text(
+                "repair" + chr(10), encoding="utf-8"
+            )
+            _git(self._repo, "add", ".")
+            _git(self._repo, "commit", "-q", "-m", "repair marker")
+            new_subject = self._create_effect(101)
+            self._window(subject=new_subject, delta=True)
+            return RepairDispatchResult(
+                execution_outcome="DISPATCHED",
+                produced_subject_identity=new_subject,
+                execution_effect_ids=(new_subject,),
+            )
+
+        readiness = self._reverify()
+        self.assertFalse(readiness.verification_ready)
+
+        final, disposition = self.coordinator.execute_repair_loop(
+            plan=self.plan,
+            readiness=readiness,
+            dispatch=dispatch,
+            reverify=self._reverify,
+        )
+        self.assertTrue(final.verification_ready)
+        self.assertIsNone(disposition)
+
+        resolution = self.store.resolve_verification_subject(
+            self.entry.plan_entry_id
+        )
+        self.assertEqual(resolution["successor_depth"], 1)
+        new_subject = resolution["effective_subject_identity"]
+        self.assertNotEqual(new_subject, self.old_subject)
+
+        records = [
+            r
+            for r in self.store.list_verification_records(
+                request_id=self.request_id,
+                run_id=self.run_id,
+                generation=2,
+            )
+            if r.predicate_id == self.entry.predicate.predicate_id
+        ]
+        pass_records = [r for r in records if r.status == "PASS"]
+        self.assertEqual(len(pass_records), 1)
+        self.assertEqual(pass_records[0].subject_identity, new_subject)
+        self.assertEqual(
+            pass_records[0].evaluated_at_ms,
+            max(r.evaluated_at_ms for r in records),
+        )
+        # the successor's PRE/POST window is bound in the Store
+        self.assertTrue(
+            self.store.list_repository_bindings_for_subject(new_subject)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_p19_m5_repair_loop.py
+++ b/tests/test_p19_m5_repair_loop.py
@@ -894,10 +894,15 @@ class TestDesktopProductionWiring(unittest.TestCase):
             "dispatch_claim_id",
             "expected_claim_revision",
             'start_outcome["outcome"] != "STARTED"',
+            "start_at_ms = time.time_ns() // 1_000_000",
+            "started_at_ms=start_at_ms",
+            "except StoreCasConflict:",
             "_register_repair_artifacts(",
             "ArtifactGate(",
         ):
             self.assertIn(needle, method)
+        # the boundary timestamp is NEVER the stale reservation time
+        self.assertNotIn("started_at_ms=issued_at", method)
 
     def test_repository_evidence_comes_from_independent_sensor(self) -> None:
         source = (
@@ -2238,6 +2243,42 @@ class TestDispatchClaimLease(RepairLoopE2EBase):
             ),
         )
         self.assertEqual(again["outcome"], "ALREADY_STARTED")
+
+    def test_expired_lease_cannot_start_at_real_time(self) -> None:
+        """Final P0 (real-time fencing): a lease that expired in the
+        wall-clock world is rejected even WITHOUT a takeover — the CAS
+        compares claim_expires_at_ms against the REAL crossing time."""
+        import time as _time
+
+        from total_gateway.store import StoreCasConflict
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        first = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now, expiry=now + 100,
+        )
+        self.assertEqual(first["outcome"], "EXECUTE")
+        # no takeover — the lease simply expires in real time
+        with self.assertRaises(StoreCasConflict):
+            self.gateway_store.start_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                effect_id=effect.effect_id,
+                started_at_ms=now + 101,
+                dispatch_claim_id="claim-a",
+                expected_claim_revision=int(
+                    first["binding"]["claim_revision"]
+                ),
+            )
+        binding = self.gateway_store.get_repair_execution_binding(
+            directive.repair_directive_id
+        )
+        self.assertEqual(binding["state"], "RESERVED")
+        self.assertEqual(
+            self.gateway_store.get_effect(effect.effect_id).state,
+            "CLAIMED",
+        )
 
     def test_stale_claim_cannot_start_after_takeover(self) -> None:
         """Final P0-1: A's lease expires, B takes over — A's stale

--- a/tests/test_p19_m5_repair_loop.py
+++ b/tests/test_p19_m5_repair_loop.py
@@ -93,16 +93,26 @@ class _RepairBindingMixin:
             claim_expires_at_ms=now + 120_000,
         )
 
-    def _binding_mark_started(self, directive, effect_id):
-        """ONE atomic transition: EffectLedger CLAIMED->STARTED and
-        Binding RESERVED->STARTED in the same transaction."""
+    def _binding_mark_started(self, directive, effect_id, reserved):
+        """ONE atomic, CLAIM-FENCED transition: EffectLedger
+        CLAIMED->STARTED and Binding RESERVED->STARTED in the same
+        transaction; only the current claim owner with the current
+        fencing revision may cross."""
         import time as _time
 
-        self._binding_store().start_repair_execution(
+        outcome = self._binding_store().start_repair_execution(
             repair_directive_id=directive.repair_directive_id,
             effect_id=effect_id,
             started_at_ms=_time.time_ns() // 1_000_000,
+            dispatch_claim_id=str(
+                reserved["binding"]["dispatch_claim_id"]
+            ),
+            expected_claim_revision=int(
+                reserved["binding"]["claim_revision"]
+            ),
         )
+        assert outcome["outcome"] == "STARTED", outcome["outcome"]
+        return outcome
 
     def _binding_complete(
         self, directive, state, produced, ref="test", error_code=None
@@ -286,7 +296,7 @@ class RepairLoopE2EBase(_RepairBindingMixin, M21OracleTestBase):
         reserved = self._reserve_or_claimed(directive, effect.effect_id)
         if reserved["outcome"] != "EXECUTE":
             return self._already_claimed(directive)
-        self._binding_mark_started(directive, effect.effect_id)
+        self._binding_mark_started(directive, effect.effect_id, reserved)
         good = self._passed_manifest(
             docx_bytes("字" * 300),
             filename="report.docx",
@@ -428,7 +438,7 @@ class TestBudgetTermination(RepairLoopE2EBase):
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive, effect.effect_id)
+            self._binding_mark_started(directive, effect.effect_id, reserved)
             still_bad = self._passed_manifest(
                 docx_bytes("字" * 10),
                 filename="report.docx",
@@ -882,10 +892,29 @@ class TestDesktopProductionWiring(unittest.TestCase):
             "complete_repair_execution(",
             "reserve_repair_execution(",
             "dispatch_claim_id",
+            "expected_claim_revision",
+            'start_outcome["outcome"] != "STARTED"',
             "_register_repair_artifacts(",
             "ArtifactGate(",
         ):
             self.assertIn(needle, method)
+
+    def test_repository_evidence_comes_from_independent_sensor(self) -> None:
+        source = (
+            ROOT / "src" / "total_gateway" / "orchestration.py"
+        ).read_text(encoding="utf-8")
+        # the runtime payload path is GONE
+        self.assertNotIn('"repository_observations"', source)
+        self.assertNotIn(
+            "result_payload.get(\"repository_observations\")", source
+        )
+        # the independent read-only sensor captures PRE and POST
+        self.assertIn("_capture_repository_sensor_pre(", source)
+        self.assertIn("_bind_repository_sensor_post(", source)
+        self.assertIn("observe_delta(", source)
+        self.assertIn(
+            "from v3.repository_perception import", source
+        )
 
 
 class TestAmbiguousRepairSafety(RepairLoopE2EBase):
@@ -902,7 +931,7 @@ class TestAmbiguousRepairSafety(RepairLoopE2EBase):
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
             self._binding_mark_started(
-                directive, started_effect.effect_id
+                directive, started_effect.effect_id, reserved
             )
             self._binding_complete(
                 directive, "AMBIGUOUS", "", error_code="repair.ambiguous"
@@ -1104,7 +1133,7 @@ class TestEffectRepairE2E(_RepairBindingMixin, M21OracleTestBase):
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
             new_effect = self._claim()
-            self._binding_mark_started(directive, carrier)
+            self._binding_mark_started(directive, carrier, reserved)
             self._complete(new_effect, "SUCCEEDED")
             self._binding_complete(directive, "SUCCEEDED", new_effect)
             return RepairDispatchResult(
@@ -1163,7 +1192,7 @@ class TestEffectRepairE2E(_RepairBindingMixin, M21OracleTestBase):
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
             new_effect = self._claim()
-            self._binding_mark_started(directive, carrier)
+            self._binding_mark_started(directive, carrier, reserved)
             # The runtime completed; the NEW SUBJECT effect itself
             # failed (the carrier still terminates SUCCEEDED).
             self._complete(new_effect, "FAILED_FINAL")
@@ -1240,7 +1269,7 @@ class TestGenerationBudgetMultiEntry(RepairLoopE2EBase):
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive, effect.effect_id)
+            self._binding_mark_started(directive, effect.effect_id, reserved)
             good = self._passed_manifest(
                 docx_bytes("字" * 300),
                 filename="report.docx",
@@ -1337,7 +1366,7 @@ class TestCoordinatorRace(RepairLoopE2EBase):
                 reserve_outcomes.append(reserved["outcome"])
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive, effect.effect_id)
+            self._binding_mark_started(directive, effect.effect_id, reserved)
             with calls_lock:
                 produce_calls.append(directive.repair_directive_id)
                 good = self._passed_manifest(
@@ -1409,7 +1438,7 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
         effect = self._claim_repair_effect()
         reserved = self._reserve_or_claimed(directive, effect.effect_id)
         assert reserved["outcome"] == "EXECUTE"
-        self._binding_mark_started(directive, effect.effect_id)
+        self._binding_mark_started(directive, effect.effect_id, reserved)
         good = self._passed_manifest(
             docx_bytes("字" * 300),
             filename="report.docx",
@@ -1517,7 +1546,7 @@ class TestCrashAfterExecutionSuccess(RepairLoopE2EBase):
         assert reserved["outcome"] == "EXECUTE"
         # CRASH exactly after the ONE atomic boundary transition — both
         # authorities are SIDE_EFFECT_STARTED or neither is.
-        self._binding_mark_started(directive, effect.effect_id)
+        self._binding_mark_started(directive, effect.effect_id, reserved)
         started_binding = self.gateway_store.get_repair_execution_binding(
             directive.repair_directive_id
         )
@@ -1754,7 +1783,7 @@ class TestGateAuthorityChecks(RepairLoopE2EBase):
             reserved = self._reserve_or_claimed(directive, effect.effect_id)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive, effect.effect_id)
+            self._binding_mark_started(directive, effect.effect_id, reserved)
             still_bad = self._passed_manifest(
                 docx_bytes("字" * 10),
                 filename="report.docx",
@@ -2022,7 +2051,7 @@ class TestRepositoryRepairE2E(_RepairBindingMixin, _M31RepositoryBase):
             reserved = self._reserve_or_claimed(directive, new_subject)
             if reserved["outcome"] != "EXECUTE":
                 return self._already_claimed(directive)
-            self._binding_mark_started(directive, new_subject)
+            self._binding_mark_started(directive, new_subject, reserved)
             # The observation window is bound BEFORE the binding is
             # terminalized (production semantics).
             self._window(subject=new_subject, delta=True)
@@ -2178,11 +2207,16 @@ class TestDispatchClaimLease(RepairLoopE2EBase):
             now=now, expiry=now + 120_000,
         )
         self.assertEqual(first["outcome"], "EXECUTE")
-        self.gateway_store.start_repair_execution(
+        started = self.gateway_store.start_repair_execution(
             repair_directive_id=directive.repair_directive_id,
             effect_id=effect.effect_id,
             started_at_ms=now + 1,
+            dispatch_claim_id="claim-a",
+            expected_claim_revision=int(
+                first["binding"]["claim_revision"]
+            ),
         )
+        self.assertEqual(started["outcome"], "STARTED")
         # even with the lease expired, a STARTED binding is FOLLOW-only
         takeover = self._reserve(
             directive, effect.effect_id, "claim-b",
@@ -2191,6 +2225,89 @@ class TestDispatchClaimLease(RepairLoopE2EBase):
         self.assertEqual(takeover["outcome"], "FOLLOW")
         self.assertEqual(
             takeover["binding"]["state"], "SIDE_EFFECT_STARTED"
+        )
+        # re-start by ANYONE (even the original owner) is
+        # ALREADY_STARTED — never a second runtime execution
+        again = self.gateway_store.start_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            effect_id=effect.effect_id,
+            started_at_ms=now + 3,
+            dispatch_claim_id="claim-a",
+            expected_claim_revision=int(
+                first["binding"]["claim_revision"]
+            ),
+        )
+        self.assertEqual(again["outcome"], "ALREADY_STARTED")
+
+    def test_stale_claim_cannot_start_after_takeover(self) -> None:
+        """Final P0-1: A's lease expires, B takes over — A's stale
+        start is REJECTED, only B crosses, runtime stays single."""
+        import sqlite3
+        import time as _time
+
+        from total_gateway.store import StoreCasConflict
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        a = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now, expiry=now + 120_000,
+        )
+        self.assertEqual(a["outcome"], "EXECUTE")
+        self.assertEqual(int(a["binding"]["claim_revision"]), 1)
+        # A stalls; the lease expires
+        connection = sqlite3.connect(self.temporary.name + "/gateway.sqlite3")
+        connection.execute(
+            "UPDATE repair_execution_binding SET claim_expires_at_ms = 1"
+            " WHERE repair_directive_id = ?",
+            (directive.repair_directive_id,),
+        )
+        connection.commit()
+        connection.close()
+        b = self._reserve(
+            directive, effect.effect_id, "claim-b",
+            now=now + 1, expiry=now + 120_000,
+        )
+        self.assertEqual(b["outcome"], "EXECUTE")
+        self.assertEqual(int(b["binding"]["claim_revision"]), 2)
+        # A resumes with its stale fencing token → rejected
+        with self.assertRaises(StoreCasConflict):
+            self.gateway_store.start_repair_execution(
+                repair_directive_id=directive.repair_directive_id,
+                effect_id=effect.effect_id,
+                started_at_ms=now + 2,
+                dispatch_claim_id="claim-a",
+                expected_claim_revision=1,
+            )
+        # the CURRENT owner crosses exactly once
+        started = self.gateway_store.start_repair_execution(
+            repair_directive_id=directive.repair_directive_id,
+            effect_id=effect.effect_id,
+            started_at_ms=now + 3,
+            dispatch_claim_id="claim-b",
+            expected_claim_revision=2,
+        )
+        self.assertEqual(started["outcome"], "STARTED")
+
+    def test_idempotent_reserve_does_not_bump_revision(self) -> None:
+        import time as _time
+
+        directive = self._issued_directive()
+        effect = self._claim_repair_effect()
+        now = _time.time_ns() // 1_000_000
+        first = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now, expiry=now + 120_000,
+        )
+        again = self._reserve(
+            directive, effect.effect_id, "claim-a",
+            now=now + 1, expiry=now + 120_000,
+        )
+        self.assertEqual(again["outcome"], "EXECUTE")
+        self.assertEqual(
+            int(again["binding"]["claim_revision"]),
+            int(first["binding"]["claim_revision"]),
         )
 
     def test_reserve_rejects_drifted_directive_payload(self) -> None:
@@ -2242,11 +2359,18 @@ class TestAtomicStartCrash(RepairLoopE2EBase):
         reserved = self._reserve_or_claimed(directive, effect.effect_id)
         self.assertEqual(reserved["outcome"], "EXECUTE")
 
-        self.gateway_store.start_repair_execution(
+        started = self.gateway_store.start_repair_execution(
             repair_directive_id=directive.repair_directive_id,
             effect_id=effect.effect_id,
             started_at_ms=_time.time_ns() // 1_000_000,
+            dispatch_claim_id=str(
+                reserved["binding"]["dispatch_claim_id"]
+            ),
+            expected_claim_revision=int(
+                reserved["binding"]["claim_revision"]
+            ),
         )
+        self.assertEqual(started["outcome"], "STARTED")
         # CRASH: close and reopen a fresh Store instance over the same
         # database file.
         self.gateway_store.close()

--- a/tests/test_v21_g4_store_engine.py
+++ b/tests/test_v21_g4_store_engine.py
@@ -278,7 +278,7 @@ def test_t26b_security_surface_files_unchanged_since_g0() -> None:
         "src/contracts/security.py": "ad65e3cbb1b844333f8f873da5abfb49a2320aabe27056fb34f83baa5978c698",
         "src/contracts/scope.py": "4447d3db1f71dea26cbfd7a19704400f8d058c4fe3ec5b3bfa775de4d821f60e",
         "src/contracts/delivery_authorization.py": "95031e740a22137b5258205fe762fe408768fd3ddb947105d88fbfefa24c31ef",
-        "src/total_gateway/completion_gate.py": "aaa637f7d49e7e60c52966c373c57c9d8cf78192dbdd4d70593c35069bf0a1c4",
+        "src/total_gateway/completion_gate.py": "7fd7c3726cd11bd4db5b470b70d69581a5657cdb8c380044817fef8b83ef1409",
         "src/total_gateway/skill_authority.py": "41741c054b33cfe47752066b537c44cae2119c94c161156aceefbe734b1941ab",
     }
     root = Path(__file__).resolve().parents[1]

--- a/tests/test_v21_g4_store_engine.py
+++ b/tests/test_v21_g4_store_engine.py
@@ -278,7 +278,7 @@ def test_t26b_security_surface_files_unchanged_since_g0() -> None:
         "src/contracts/security.py": "ad65e3cbb1b844333f8f873da5abfb49a2320aabe27056fb34f83baa5978c698",
         "src/contracts/scope.py": "4447d3db1f71dea26cbfd7a19704400f8d058c4fe3ec5b3bfa775de4d821f60e",
         "src/contracts/delivery_authorization.py": "95031e740a22137b5258205fe762fe408768fd3ddb947105d88fbfefa24c31ef",
-        "src/total_gateway/completion_gate.py": "7fd7c3726cd11bd4db5b470b70d69581a5657cdb8c380044817fef8b83ef1409",
+        "src/total_gateway/completion_gate.py": "da8e3ede85036ca2386decba28211acf01fb43fce8cfd4322cb53ebbd01ca9a9",
         "src/total_gateway/skill_authority.py": "41741c054b33cfe47752066b537c44cae2119c94c161156aceefbe734b1941ab",
     }
     root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## M5 Final Closure Correction｜按 8 项审核裁决逐条落实

### #1 P0 TypeError 修复
`evaluate_desktop_completion()` 加 `verification_disposition` 参数并传到 Gate——修复 Desktop 生产路径 TypeError

### #6 Successor 语义
successor 存在时 ReadinessBuilder **只匹配** effective subject（删 OR 逻辑——旧 original record 不得在修复后重新进入 supersession）

### #5 五项 Budget 全部生效
| Budget | 默认 | 实现 |
|---|---|---|
| per-entry REPAIR | 2 | ✅ 只计 REPAIR action |
| generation total | 4 | ✅ 新增 `list_all_verification_dispositions` |
| same signature | 2 | ✅ |
| successor depth | 4 | ✅ 从 Store resolve |
| side-effect repair | 1/entry | ✅ effect/repo 更严格 |

任一耗尽 → 覆盖为 REVIEW

### #22 Effect Ambiguity Fail-Closed
Store 查询失败 → True（视为 ambiguous → RECONCILE）

### #3 Channel Coordinator 接入
outbox 两处 finalization（ambiguity + receipt）均 executor → FAIL → Coordinator → Store-read disposition → Gate（与 Desktop 同构）

### #7 Gate Disposition 验证
identity + lineage 检查（伪造 reject）；Desktop 从 Store 读 current disposition（不再 dispositions[0]）

### 验证
46 targeted passed；surface/authority/sync PASS