### PR TITLE
P2: deterministic Tool Capability World projection

### DIFF
--- a/docs/capability-composition/P2_TOOL_CAPABILITY_WORLD.md
+++ b/docs/capability-composition/P2_TOOL_CAPABILITY_WORLD.md
@@ -1,0 +1,63 @@
+# P2 — Tool Capability World
+
+Base: `main @ c0d9b5b8fede060fde2d379444c8ae56931b58dc`
+
+## Purpose
+
+P2 adds a deterministic, read-only Tool Capability World projection. It does not add a Tool Registry or any execution authority.
+
+Authority remains:
+
+`ACTIONS / BodyRuntime route reality`
+→ `fact_kernel.compile_manifest`
+→ `capability_manifest.generated.json`
+→ `total_gateway.action_registry`
+→ `ActionPermission`
+
+P2 only projects the already-authoritative manifest/registry/source facts into `ToolSourcePrimitiveV1` records and structural relations for later WorldState integration in P6.
+
+## Deterministic inputs
+
+- existing capability manifest;
+- existing `ActionRegistrySnapshot`;
+- action-scoped `SourceRevisionRefV1` supplied from source/software-world observation;
+- deterministic argument/result schema hashes.
+
+Missing or drifting inputs fail closed.
+
+## Produced relations
+
+P2 permits only mechanically derived structural relations:
+
+- `COMPILES_TO`
+- `IMPLEMENTED_BY`
+- `PROVIDED_BY`
+- `AVAILABLE_IN`
+- `ALIASES`
+- `READS`
+- `WRITES`
+- `PRODUCES`
+
+P2 deliberately does **not** produce mature semantic relations such as:
+
+- `SUITABLE_FOR`
+- `COMPOSES_WITH`
+- `PREFERRED_WHEN`
+- `CONFLICTS_WITH`
+
+Those may only grow later from shadow hypotheses and Reality-verified experience under the v1.2 plan.
+
+## Invariants preserved
+
+- no second Runtime;
+- no second Gateway;
+- no second Action Registry;
+- no permission minting;
+- no new executable action can be introduced by the projection;
+- no WorldState store is introduced in P2;
+- no Memory write occurs;
+- no generated mirror is edited manually.
+
+## P2 gate
+
+The branch must pass the repository's protected source-authority/full-regression checks. P3 starts only after this implementation is green and merged.

--- a/src/world_understanding/tool_capability_world/__init__.py
+++ b/src/world_understanding/tool_capability_world/__init__.py
@@ -1,0 +1,21 @@
+"""Deterministic Tool Capability World projection.
+
+This package is read-only and non-authorizing. It projects the existing
+Capability Manifest / Action Registry authority into capability semantics for
+World Understanding. It is not a registry, runtime, planner, or permission
+source.
+"""
+
+from .compiler import (
+    ToolCapabilityRelationV1,
+    ToolCapabilityWorldError,
+    ToolCapabilityWorldSnapshotV1,
+    compile_tool_capability_world,
+)
+
+__all__ = [
+    "ToolCapabilityRelationV1",
+    "ToolCapabilityWorldError",
+    "ToolCapabilityWorldSnapshotV1",
+    "compile_tool_capability_world",
+]

--- a/src/world_understanding/tool_capability_world/compiler.py
+++ b/src/world_understanding/tool_capability_world/compiler.py
@@ -122,6 +122,8 @@ def _validated_source_files(
         posix = PurePosixPath(path)
         if (
             not path
+            or path != path.strip()
+            or str(posix) != path
             or "\\" in path
             or posix.is_absolute()
             or ".." in posix.parts

--- a/src/world_understanding/tool_capability_world/compiler.py
+++ b/src/world_understanding/tool_capability_world/compiler.py
@@ -13,6 +13,7 @@ WorldState store, or executable route.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Any, Mapping
 
 from contracts import ActionRegistrySnapshot, canonical_sha256
@@ -20,6 +21,22 @@ from contracts.capability_composition import (
     SourceRevisionRefV1,
     SourceSpanRefV1,
     ToolSourcePrimitiveV1,
+)
+
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_CANONICAL_PROVIDER_COMPONENT_ID = "omni-body"
+_P2_RELATION_TYPES = frozenset(
+    {
+        "COMPILES_TO",
+        "IMPLEMENTED_BY",
+        "PROVIDED_BY",
+        "AVAILABLE_IN",
+        "ALIASES",
+        "READS",
+        "WRITES",
+        "PRODUCES",
+    }
 )
 
 
@@ -32,6 +49,12 @@ class ToolCapabilityRelationV1:
     relation_type: str
     source_ref: str
     target_ref: str
+
+    def __post_init__(self) -> None:
+        if self.relation_type not in _P2_RELATION_TYPES:
+            raise ToolCapabilityWorldError("P2 relation type is not mechanically authorized")
+        if not self.source_ref or not self.target_ref:
+            raise ToolCapabilityWorldError("P2 relation endpoints must be non-empty")
 
     def to_dict(self) -> dict[str, str]:
         return {
@@ -49,12 +72,30 @@ class ToolCapabilityWorldSnapshotV1:
     primitives: tuple[ToolSourcePrimitiveV1, ...]
     relations: tuple[ToolCapabilityRelationV1, ...]
     snapshot_sha256: str
+    may_authorize: bool = False
+    may_execute: bool = False
+
+    def __post_init__(self) -> None:
+        if self.schema != "tiangong.tool-capability-world.v1":
+            raise ToolCapabilityWorldError("unsupported Tool Capability World snapshot schema")
+        if self.may_authorize or self.may_execute:
+            raise ToolCapabilityWorldError("Tool Capability World is non-authorizing and non-executing")
+        primitive_ids = tuple(item.action_id for item in self.primitives)
+        if primitive_ids != tuple(sorted(set(primitive_ids))):
+            raise ToolCapabilityWorldError("Tool Capability World primitives must be sorted and unique")
+        relation_keys = tuple(
+            (item.relation_type, item.source_ref, item.target_ref) for item in self.relations
+        )
+        if relation_keys != tuple(sorted(set(relation_keys))):
+            raise ToolCapabilityWorldError("Tool Capability World relations must be sorted and unique")
 
     def payload(self) -> dict[str, Any]:
         return {
             "schema": self.schema,
             "source_manifest_sha256": self.source_manifest_sha256,
             "action_registry_sha256": self.action_registry_sha256,
+            "may_authorize": self.may_authorize,
+            "may_execute": self.may_execute,
             "primitives": [item.model_dump(mode="json") for item in self.primitives],
             "relations": [item.to_dict() for item in self.relations],
         }
@@ -64,28 +105,38 @@ class ToolCapabilityWorldSnapshotV1:
 
 
 def _implementation_refs(source: SourceRevisionRefV1) -> tuple[SourceSpanRefV1, ...]:
-    if source.source_spans:
-        return source.source_spans
-    return tuple(SourceSpanRefV1(path=path) for path in source.source_files)
+    refs = source.source_spans or tuple(
+        SourceSpanRefV1(path=path) for path in source.source_files
+    )
+    keys = tuple(
+        (item.path, item.start_line or 0, item.end_line or 0) for item in refs
+    )
+    if len(keys) != len(set(keys)):
+        raise ToolCapabilityWorldError("source revision contains duplicate implementation refs")
+    return tuple(
+        sorted(refs, key=lambda item: (item.path, item.start_line or 0, item.end_line or 0))
+    )
 
 
 def _primitive_sha256_payload(primitive: ToolSourcePrimitiveV1) -> dict[str, Any]:
     return primitive.model_dump(mode="json", exclude={"descriptor_sha256"})
 
 
+def _require_sha256(value: object, *, field: str, action_id: str) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ToolCapabilityWorldError(f"invalid {field} binding: {action_id}")
+    return value
+
+
 def _build_primitive(
     *,
     action_id: str,
-    raw: Mapping[str, Any],
     permission: Any,
     source: SourceRevisionRefV1,
     argument_schema_sha256: str,
     result_schema_sha256: str,
-    provider_component_id: str,
 ) -> ToolSourcePrimitiveV1:
     effect = str(permission.effect)
-    idempotency = "IDEMPOTENT" if effect in {"read", "verify"} else "UNKNOWN"
-    determinism = "DETERMINISTIC" if effect == "verify" else "BOUNDED_NONDETERMINISTIC"
     resources = [str(permission.path_policy)]
     if permission.allow_absolute_paths:
         resources.append("absolute_paths")
@@ -94,11 +145,14 @@ def _build_primitive(
     if permission.allow_python:
         resources.append("python")
 
+    # P2 has no independent evidence proving operational idempotency or
+    # determinism. Preserve UNKNOWN/conservative semantics instead of guessing
+    # from effect labels such as read/verify.
     primitive = ToolSourcePrimitiveV1(
         source_primitive_id=f"tool-source:{action_id}",
         action_id=action_id,
         action_version=str(permission.action_version),
-        provider_component_id=provider_component_id,
+        provider_component_id=_CANONICAL_PROVIDER_COMPONENT_ID,
         implementation_refs=_implementation_refs(source),
         implementation_hashes=(source.source_sha256,),
         action_manifest_sha256=permission.source_manifest_sha256,
@@ -109,14 +163,14 @@ def _build_primitive(
         effect_class=f"effect:{effect}",
         side_effects=tuple(str(item) for item in permission.allowed_side_effects),
         risk_floor=str(permission.effective_risk),
-        idempotency=idempotency,
-        determinism_class=determinism,
+        idempotency="UNKNOWN",
+        determinism_class="NONDETERMINISTIC",
         resource_scope=tuple(sorted(set(resources))),
         read_set_descriptor=("resource:read",) if effect in {"read", "verify"} else (),
         write_set_descriptor=("resource:write",) if effect in {"create", "write", "update", "execute"} else (),
         evidence_contract=(),
         verifier_refs=(),
-        failure_taxonomy=("unavailable", "runtime_failure", "verification_failure"),
+        failure_taxonomy=("runtime_failure", "unavailable", "verification_failure"),
         availability="AVAILABLE",
         descriptor_sha256="0" * 64,
     )
@@ -132,7 +186,6 @@ def compile_tool_capability_world(
     source_revisions: Mapping[str, SourceRevisionRefV1],
     argument_schema_hashes: Mapping[str, str],
     result_schema_hashes: Mapping[str, str],
-    provider_component_id: str = "omni-body",
 ) -> ToolCapabilityWorldSnapshotV1:
     """Project the existing execution authorities into deterministic semantics.
 
@@ -147,8 +200,10 @@ def compile_tool_capability_world(
     validation = manifest.get("validation")
     if not isinstance(capabilities, Mapping) or not isinstance(validation, Mapping):
         raise ToolCapabilityWorldError("capability manifest is incomplete")
-    if validation.get("ok") is not True:
+    if validation.get("ok") is not True or validation.get("executable_without_route") != []:
         raise ToolCapabilityWorldError("capability manifest is not healthy")
+    if validation.get("source_hash") != manifest.get("source_hash"):
+        raise ToolCapabilityWorldError("capability manifest validation hash is stale")
 
     manifest_sha256 = canonical_sha256(dict(manifest))
     if registry.source_manifest_sha256 != manifest_sha256:
@@ -161,7 +216,9 @@ def compile_tool_capability_world(
         sorted(
             action_id
             for action_id, raw in capabilities.items()
-            if isinstance(raw, Mapping) and raw.get("executable") is True
+            if isinstance(action_id, str)
+            and isinstance(raw, Mapping)
+            and raw.get("executable") is True
         )
     )
     if executable_ids != tuple(sorted(permissions)):
@@ -179,26 +236,32 @@ def compile_tool_capability_world(
             raise ToolCapabilityWorldError(f"missing deterministic source/schema binding: {action_id}")
         if source.source_kind != "TOOL_ACTION" or source.semantic_id != action_id:
             raise ToolCapabilityWorldError(f"source revision identity mismatch: {action_id}")
-        if source.manifest_sha256 not in {None, manifest_sha256}:
+        if source.manifest_sha256 != manifest_sha256:
             raise ToolCapabilityWorldError(f"source revision manifest mismatch: {action_id}")
 
         primitive = _build_primitive(
             action_id=action_id,
-            raw=raw,
             permission=permission,
             source=source,
-            argument_schema_sha256=arg_hash,
-            result_schema_sha256=result_hash,
-            provider_component_id=provider_component_id,
+            argument_schema_sha256=_require_sha256(
+                arg_hash, field="argument schema", action_id=action_id
+            ),
+            result_schema_sha256=_require_sha256(
+                result_hash, field="result schema", action_id=action_id
+            ),
         )
         primitives.append(primitive)
 
         primitive_ref = primitive.source_primitive_id
         relations.add(("COMPILES_TO", primitive_ref, f"action:{action_id}"))
-        relations.add(("PROVIDED_BY", primitive_ref, f"provider:{provider_component_id}"))
+        relations.add(
+            ("PROVIDED_BY", primitive_ref, f"provider:{_CANONICAL_PROVIDER_COMPONENT_ID}")
+        )
         relations.add(("AVAILABLE_IN", primitive_ref, f"manifest:{manifest_sha256}"))
-        for path in source.source_files:
-            relations.add(("IMPLEMENTED_BY", primitive_ref, f"source:{path}"))
+        for implementation_ref in primitive.implementation_refs:
+            relations.add(
+                ("IMPLEMENTED_BY", primitive_ref, f"source:{implementation_ref.path}")
+            )
         alias_to = str(raw.get("alias_to") or "").strip()
         if alias_to:
             relations.add(("ALIASES", f"action:{action_id}", f"action:{alias_to}"))

--- a/src/world_understanding/tool_capability_world/compiler.py
+++ b/src/world_understanding/tool_capability_world/compiler.py
@@ -1,0 +1,229 @@
+"""Compile a non-authorizing Tool Capability World snapshot.
+
+Authority boundary:
+- execution truth comes from the existing capability manifest;
+- permission/risk truth comes from the existing ActionRegistrySnapshot;
+- source truth comes from supplied SourceRevisionRefV1 records;
+- this module only projects those facts into capability semantics.
+
+It deliberately does not create a Tool Registry, Runtime, Grant, Ticket,
+WorldState store, or executable route.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from contracts import ActionRegistrySnapshot, canonical_sha256
+from contracts.capability_composition import (
+    SourceRevisionRefV1,
+    SourceSpanRefV1,
+    ToolSourcePrimitiveV1,
+)
+
+
+class ToolCapabilityWorldError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCapabilityRelationV1:
+    relation_type: str
+    source_ref: str
+    target_ref: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "relation_type": self.relation_type,
+            "source_ref": self.source_ref,
+            "target_ref": self.target_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCapabilityWorldSnapshotV1:
+    schema: str
+    source_manifest_sha256: str
+    action_registry_sha256: str
+    primitives: tuple[ToolSourcePrimitiveV1, ...]
+    relations: tuple[ToolCapabilityRelationV1, ...]
+    snapshot_sha256: str
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "source_manifest_sha256": self.source_manifest_sha256,
+            "action_registry_sha256": self.action_registry_sha256,
+            "primitives": [item.model_dump(mode="json") for item in self.primitives],
+            "relations": [item.to_dict() for item in self.relations],
+        }
+
+    def has_valid_sha256(self) -> bool:
+        return self.snapshot_sha256 == canonical_sha256(self.payload())
+
+
+def _implementation_refs(source: SourceRevisionRefV1) -> tuple[SourceSpanRefV1, ...]:
+    if source.source_spans:
+        return source.source_spans
+    return tuple(SourceSpanRefV1(path=path) for path in source.source_files)
+
+
+def _primitive_sha256_payload(primitive: ToolSourcePrimitiveV1) -> dict[str, Any]:
+    return primitive.model_dump(mode="json", exclude={"descriptor_sha256"})
+
+
+def _build_primitive(
+    *,
+    action_id: str,
+    raw: Mapping[str, Any],
+    permission: Any,
+    source: SourceRevisionRefV1,
+    argument_schema_sha256: str,
+    result_schema_sha256: str,
+    provider_component_id: str,
+) -> ToolSourcePrimitiveV1:
+    effect = str(permission.effect)
+    idempotency = "IDEMPOTENT" if effect in {"read", "verify"} else "UNKNOWN"
+    determinism = "DETERMINISTIC" if effect == "verify" else "BOUNDED_NONDETERMINISTIC"
+    resources = [str(permission.path_policy)]
+    if permission.allow_absolute_paths:
+        resources.append("absolute_paths")
+    if permission.allow_shell:
+        resources.append("shell")
+    if permission.allow_python:
+        resources.append("python")
+
+    primitive = ToolSourcePrimitiveV1(
+        source_primitive_id=f"tool-source:{action_id}",
+        action_id=action_id,
+        action_version=str(permission.action_version),
+        provider_component_id=provider_component_id,
+        implementation_refs=_implementation_refs(source),
+        implementation_hashes=(source.source_sha256,),
+        action_manifest_sha256=permission.source_manifest_sha256,
+        argument_schema_sha256=argument_schema_sha256,
+        result_schema_sha256=result_schema_sha256,
+        consumes=(),
+        produces=(f"effect:{effect}",),
+        effect_class=f"effect:{effect}",
+        side_effects=tuple(str(item) for item in permission.allowed_side_effects),
+        risk_floor=str(permission.effective_risk),
+        idempotency=idempotency,
+        determinism_class=determinism,
+        resource_scope=tuple(sorted(set(resources))),
+        read_set_descriptor=("resource:read",) if effect in {"read", "verify"} else (),
+        write_set_descriptor=("resource:write",) if effect in {"create", "write", "update", "execute"} else (),
+        evidence_contract=(),
+        verifier_refs=(),
+        failure_taxonomy=("unavailable", "runtime_failure", "verification_failure"),
+        availability="AVAILABLE",
+        descriptor_sha256="0" * 64,
+    )
+    return primitive.model_copy(
+        update={"descriptor_sha256": canonical_sha256(_primitive_sha256_payload(primitive))}
+    )
+
+
+def compile_tool_capability_world(
+    manifest: Mapping[str, Any],
+    registry: ActionRegistrySnapshot,
+    *,
+    source_revisions: Mapping[str, SourceRevisionRefV1],
+    argument_schema_hashes: Mapping[str, str],
+    result_schema_hashes: Mapping[str, str],
+    provider_component_id: str = "omni-body",
+) -> ToolCapabilityWorldSnapshotV1:
+    """Project the existing execution authorities into deterministic semantics.
+
+    All executable actions must exist in both the manifest and Action Registry.
+    Source/schema bindings must be complete. Missing authority evidence is a
+    hard error rather than a guessed capability.
+    """
+
+    if manifest.get("schema") != "tiangong.v3.capability_manifest.v1":
+        raise ToolCapabilityWorldError("unsupported capability manifest")
+    capabilities = manifest.get("capabilities")
+    validation = manifest.get("validation")
+    if not isinstance(capabilities, Mapping) or not isinstance(validation, Mapping):
+        raise ToolCapabilityWorldError("capability manifest is incomplete")
+    if validation.get("ok") is not True:
+        raise ToolCapabilityWorldError("capability manifest is not healthy")
+
+    manifest_sha256 = canonical_sha256(dict(manifest))
+    if registry.source_manifest_sha256 != manifest_sha256:
+        raise ToolCapabilityWorldError("registry is not bound to the supplied manifest")
+    if not registry.has_valid_sha256():
+        raise ToolCapabilityWorldError("action registry hash is invalid")
+
+    permissions = {item.action_id: item for item in registry.permissions}
+    executable_ids = tuple(
+        sorted(
+            action_id
+            for action_id, raw in capabilities.items()
+            if isinstance(raw, Mapping) and raw.get("executable") is True
+        )
+    )
+    if executable_ids != tuple(sorted(permissions)):
+        raise ToolCapabilityWorldError("manifest executable set differs from action registry")
+
+    primitives: list[ToolSourcePrimitiveV1] = []
+    relations: set[tuple[str, str, str]] = set()
+    for action_id in executable_ids:
+        raw = capabilities[action_id]
+        permission = permissions[action_id]
+        source = source_revisions.get(action_id)
+        arg_hash = argument_schema_hashes.get(action_id)
+        result_hash = result_schema_hashes.get(action_id)
+        if source is None or arg_hash is None or result_hash is None:
+            raise ToolCapabilityWorldError(f"missing deterministic source/schema binding: {action_id}")
+        if source.source_kind != "TOOL_ACTION" or source.semantic_id != action_id:
+            raise ToolCapabilityWorldError(f"source revision identity mismatch: {action_id}")
+        if source.manifest_sha256 not in {None, manifest_sha256}:
+            raise ToolCapabilityWorldError(f"source revision manifest mismatch: {action_id}")
+
+        primitive = _build_primitive(
+            action_id=action_id,
+            raw=raw,
+            permission=permission,
+            source=source,
+            argument_schema_sha256=arg_hash,
+            result_schema_sha256=result_hash,
+            provider_component_id=provider_component_id,
+        )
+        primitives.append(primitive)
+
+        primitive_ref = primitive.source_primitive_id
+        relations.add(("COMPILES_TO", primitive_ref, f"action:{action_id}"))
+        relations.add(("PROVIDED_BY", primitive_ref, f"provider:{provider_component_id}"))
+        relations.add(("AVAILABLE_IN", primitive_ref, f"manifest:{manifest_sha256}"))
+        for path in source.source_files:
+            relations.add(("IMPLEMENTED_BY", primitive_ref, f"source:{path}"))
+        alias_to = str(raw.get("alias_to") or "").strip()
+        if alias_to:
+            relations.add(("ALIASES", f"action:{action_id}", f"action:{alias_to}"))
+        if permission.effect in {"read", "verify"}:
+            relations.add(("READS", primitive_ref, "resource:read"))
+        else:
+            relations.add(("WRITES", primitive_ref, "resource:write"))
+        relations.add(("PRODUCES", primitive_ref, f"effect:{permission.effect}"))
+
+    ordered_relations = tuple(
+        ToolCapabilityRelationV1(*item) for item in sorted(relations)
+    )
+    snapshot = ToolCapabilityWorldSnapshotV1(
+        schema="tiangong.tool-capability-world.v1",
+        source_manifest_sha256=manifest_sha256,
+        action_registry_sha256=registry.registry_sha256,
+        primitives=tuple(primitives),
+        relations=ordered_relations,
+        snapshot_sha256="0" * 64,
+    )
+    return ToolCapabilityWorldSnapshotV1(
+        schema=snapshot.schema,
+        source_manifest_sha256=snapshot.source_manifest_sha256,
+        action_registry_sha256=snapshot.action_registry_sha256,
+        primitives=snapshot.primitives,
+        relations=snapshot.relations,
+        snapshot_sha256=canonical_sha256(snapshot.payload()),
+    )

--- a/src/world_understanding/tool_capability_world/compiler.py
+++ b/src/world_understanding/tool_capability_world/compiler.py
@@ -13,6 +13,7 @@ WorldState store, or executable route.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 import re
 from typing import Any, Mapping
 
@@ -104,15 +105,49 @@ class ToolCapabilityWorldSnapshotV1:
         return self.snapshot_sha256 == canonical_sha256(self.payload())
 
 
-def _implementation_refs(source: SourceRevisionRefV1) -> tuple[SourceSpanRefV1, ...]:
-    refs = source.source_spans or tuple(
-        SourceSpanRefV1(path=path) for path in source.source_files
-    )
-    keys = tuple(
-        (item.path, item.start_line or 0, item.end_line or 0) for item in refs
-    )
-    if len(keys) != len(set(keys)):
-        raise ToolCapabilityWorldError("source revision contains duplicate implementation refs")
+def _validated_source_files(
+    source: SourceRevisionRefV1,
+    *,
+    action_id: str,
+) -> tuple[str, ...]:
+    files = tuple(source.source_files)
+    if files != tuple(sorted(set(files))):
+        # SourceRevisionRef is an immutable identity record; accepting multiple
+        # byte representations for the same file set would make replay hashes
+        # caller-order dependent.
+        raise ToolCapabilityWorldError(
+            f"source revision files must be sorted and unique: {action_id}"
+        )
+    for path in files:
+        posix = PurePosixPath(path)
+        if (
+            not path
+            or "\\" in path
+            or posix.is_absolute()
+            or ".." in posix.parts
+            or "." in posix.parts
+        ):
+            raise ToolCapabilityWorldError(
+                f"source revision contains an unsafe repository path: {action_id}"
+            )
+    return files
+
+
+def _implementation_refs(
+    source: SourceRevisionRefV1,
+    *,
+    action_id: str,
+) -> tuple[SourceSpanRefV1, ...]:
+    files = _validated_source_files(source, action_id=action_id)
+    refs = source.source_spans or tuple(SourceSpanRefV1(path=path) for path in files)
+    keys = tuple((item.path, item.start_line or 0, item.end_line or 0) for item in refs)
+    if (
+        len(keys) != len(set(keys))
+        or any(item.path not in files for item in refs)
+    ):
+        raise ToolCapabilityWorldError(
+            f"source revision implementation refs are invalid: {action_id}"
+        )
     return tuple(
         sorted(refs, key=lambda item: (item.path, item.start_line or 0, item.end_line or 0))
     )
@@ -153,7 +188,7 @@ def _build_primitive(
         action_id=action_id,
         action_version=str(permission.action_version),
         provider_component_id=_CANONICAL_PROVIDER_COMPONENT_ID,
-        implementation_refs=_implementation_refs(source),
+        implementation_refs=_implementation_refs(source, action_id=action_id),
         implementation_hashes=(source.source_sha256,),
         action_manifest_sha256=permission.source_manifest_sha256,
         argument_schema_sha256=argument_schema_sha256,
@@ -167,7 +202,9 @@ def _build_primitive(
         determinism_class="NONDETERMINISTIC",
         resource_scope=tuple(sorted(set(resources))),
         read_set_descriptor=("resource:read",) if effect in {"read", "verify"} else (),
-        write_set_descriptor=("resource:write",) if effect in {"create", "write", "update", "execute"} else (),
+        write_set_descriptor=("resource:write",)
+        if effect in {"create", "write", "update", "execute"}
+        else (),
         evidence_contract=(),
         verifier_refs=(),
         failure_taxonomy=("runtime_failure", "unavailable", "verification_failure"),
@@ -233,11 +270,21 @@ def compile_tool_capability_world(
         arg_hash = argument_schema_hashes.get(action_id)
         result_hash = result_schema_hashes.get(action_id)
         if source is None or arg_hash is None or result_hash is None:
-            raise ToolCapabilityWorldError(f"missing deterministic source/schema binding: {action_id}")
-        if source.source_kind != "TOOL_ACTION" or source.semantic_id != action_id:
-            raise ToolCapabilityWorldError(f"source revision identity mismatch: {action_id}")
+            raise ToolCapabilityWorldError(
+                f"missing deterministic source/schema binding: {action_id}"
+            )
+        if (
+            source.source_kind != "TOOL_ACTION"
+            or source.semantic_id != action_id
+            or source.version != str(permission.action_version)
+        ):
+            raise ToolCapabilityWorldError(
+                f"source revision identity/version mismatch: {action_id}"
+            )
         if source.manifest_sha256 != manifest_sha256:
-            raise ToolCapabilityWorldError(f"source revision manifest mismatch: {action_id}")
+            raise ToolCapabilityWorldError(
+                f"source revision manifest mismatch: {action_id}"
+            )
 
         primitive = _build_primitive(
             action_id=action_id,

--- a/tests/test_tool_capability_world_p2.py
+++ b/tests/test_tool_capability_world_p2.py
@@ -6,6 +6,7 @@ from contracts import canonical_sha256
 from contracts.capability_composition import SourceRevisionRefV1
 from total_gateway.action_registry import compile_action_registry
 from world_understanding.tool_capability_world import (
+    ToolCapabilityRelationV1,
     ToolCapabilityWorldError,
     compile_tool_capability_world,
 )
@@ -46,12 +47,19 @@ def manifest() -> dict:
     }
 
 
-def source_ref(action_id: str, manifest_sha: str) -> SourceRevisionRefV1:
+def source_ref(
+    action_id: str,
+    manifest_sha: str | None,
+    *,
+    source_files: tuple[str, ...] = (
+        "src/omni_body_skill/tools/omni_body_tool.py",
+    ),
+) -> SourceRevisionRefV1:
     return SourceRevisionRefV1(
         source_kind="TOOL_ACTION",
         semantic_id=action_id,
         version="omni-registry-v1",
-        source_files=("src/omni_body_skill/tools/omni_body_tool.py",),
+        source_files=source_files,
         source_sha256=H,
         descriptor_sha256=H,
         manifest_sha256=manifest_sha,
@@ -62,7 +70,10 @@ def compile_snapshot():
     document = manifest()
     registry = compile_action_registry(document, generated_at_ms=1)
     manifest_sha = canonical_sha256(document)
-    sources = {action_id: source_ref(action_id, manifest_sha) for action_id in document["capabilities"]}
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
     schemas = {action_id: H for action_id in document["capabilities"]}
     return document, registry, compile_tool_capability_world(
         document,
@@ -78,9 +89,23 @@ def test_projection_is_deterministic_and_bound_to_existing_registry() -> None:
     assert snapshot.source_manifest_sha256 == registry.source_manifest_sha256
     assert snapshot.action_registry_sha256 == registry.registry_sha256
     assert snapshot.has_valid_sha256()
-    assert tuple(item.action_id for item in snapshot.primitives) == ("file.inspect", "file.read")
+    assert snapshot.may_authorize is False
+    assert snapshot.may_execute is False
+    assert tuple(item.action_id for item in snapshot.primitives) == (
+        "file.inspect",
+        "file.read",
+    )
     assert all(item.availability == "AVAILABLE" for item in snapshot.primitives)
-    assert all(item.action_manifest_sha256 == registry.source_manifest_sha256 for item in snapshot.primitives)
+    assert all(
+        item.action_manifest_sha256 == registry.source_manifest_sha256
+        for item in snapshot.primitives
+    )
+    assert all(item.provider_component_id == "omni-body" for item in snapshot.primitives)
+    assert all(item.idempotency == "UNKNOWN" for item in snapshot.primitives)
+    assert all(
+        item.determinism_class == "NONDETERMINISTIC"
+        for item in snapshot.primitives
+    )
 
     second = compile_tool_capability_world(
         document,
@@ -89,20 +114,74 @@ def test_projection_is_deterministic_and_bound_to_existing_registry() -> None:
             action_id: source_ref(action_id, registry.source_manifest_sha256)
             for action_id in document["capabilities"]
         },
-        argument_schema_hashes={action_id: H for action_id in document["capabilities"]},
-        result_schema_hashes={action_id: H for action_id in document["capabilities"]},
+        argument_schema_hashes={
+            action_id: H for action_id in document["capabilities"]
+        },
+        result_schema_hashes={
+            action_id: H for action_id in document["capabilities"]
+        },
     )
     assert second.snapshot_sha256 == snapshot.snapshot_sha256
 
 
+def test_source_file_order_cannot_change_snapshot_identity() -> None:
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    manifest_sha = canonical_sha256(document)
+    files_a = (
+        "src/omni_body_skill/tools/omni_body_tool.py",
+        "app/backend/tiangong-backend/v3/fact_kernel/__init__.py",
+    )
+    files_b = tuple(reversed(files_a))
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    first = compile_tool_capability_world(
+        document,
+        registry,
+        source_revisions={
+            action_id: source_ref(action_id, manifest_sha, source_files=files_a)
+            for action_id in document["capabilities"]
+        },
+        argument_schema_hashes=schemas,
+        result_schema_hashes=schemas,
+    )
+    second = compile_tool_capability_world(
+        document,
+        registry,
+        source_revisions={
+            action_id: source_ref(action_id, manifest_sha, source_files=files_b)
+            for action_id in document["capabilities"]
+        },
+        argument_schema_hashes=schemas,
+        result_schema_hashes=schemas,
+    )
+    assert first.snapshot_sha256 == second.snapshot_sha256
+
+
 def test_projection_contains_only_deterministic_structural_relations() -> None:
     _document, _registry, snapshot = compile_snapshot()
-    relations = {(item.relation_type, item.source_ref, item.target_ref) for item in snapshot.relations}
+    relations = {
+        (item.relation_type, item.source_ref, item.target_ref)
+        for item in snapshot.relations
+    }
     assert ("ALIASES", "action:file.inspect", "action:file.read") in relations
     assert ("COMPILES_TO", "tool-source:file.read", "action:file.read") in relations
     assert ("PRODUCES", "tool-source:file.read", "effect:read") in relations
-    forbidden = {"SUITABLE_FOR", "COMPOSES_WITH", "PREFERRED_WHEN", "CONFLICTS_WITH"}
-    assert forbidden.isdisjoint({item.relation_type for item in snapshot.relations})
+    forbidden = {
+        "SUITABLE_FOR",
+        "COMPOSES_WITH",
+        "PREFERRED_WHEN",
+        "CONFLICTS_WITH",
+    }
+    assert forbidden.isdisjoint(
+        {item.relation_type for item in snapshot.relations}
+    )
+
+    with pytest.raises(ToolCapabilityWorldError, match="relation type"):
+        ToolCapabilityRelationV1(
+            "SUITABLE_FOR",
+            "tool-source:file.read",
+            "goal:read-file",
+        )
 
 
 def test_projection_fails_closed_on_registry_manifest_drift() -> None:
@@ -111,7 +190,10 @@ def test_projection_fails_closed_on_registry_manifest_drift() -> None:
     changed = manifest()
     changed["capabilities"]["file.read"]["risk"] = "A1"
     manifest_sha = canonical_sha256(changed)
-    sources = {action_id: source_ref(action_id, manifest_sha) for action_id in changed["capabilities"]}
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in changed["capabilities"]
+    }
     schemas = {action_id: H for action_id in changed["capabilities"]}
     with pytest.raises(ToolCapabilityWorldError, match="registry is not bound"):
         compile_tool_capability_world(
@@ -123,25 +205,97 @@ def test_projection_fails_closed_on_registry_manifest_drift() -> None:
         )
 
 
+def test_projection_fails_closed_on_stale_manifest_validation_hash() -> None:
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    document["validation"]["source_hash"] = "b" * 64
+    manifest_sha = canonical_sha256(document)
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    with pytest.raises(ToolCapabilityWorldError, match="validation hash is stale"):
+        compile_tool_capability_world(
+            document,
+            registry,
+            source_revisions={
+                action_id: source_ref(action_id, manifest_sha)
+                for action_id in document["capabilities"]
+            },
+            argument_schema_hashes=schemas,
+            result_schema_hashes=schemas,
+        )
+
+
 def test_projection_fails_closed_when_source_binding_is_missing() -> None:
     document = manifest()
     registry = compile_action_registry(document, generated_at_ms=1)
     manifest_sha = canonical_sha256(document)
     schemas = {action_id: H for action_id in document["capabilities"]}
-    with pytest.raises(ToolCapabilityWorldError, match="missing deterministic source/schema binding"):
+    with pytest.raises(
+        ToolCapabilityWorldError,
+        match="missing deterministic source/schema binding",
+    ):
         compile_tool_capability_world(
             document,
             registry,
-            source_revisions={"file.read": source_ref("file.read", manifest_sha)},
+            source_revisions={
+                "file.read": source_ref("file.read", manifest_sha)
+            },
             argument_schema_hashes=schemas,
             result_schema_hashes=schemas,
+        )
+
+
+def test_projection_requires_exact_tool_source_manifest_binding() -> None:
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    manifest_sha = canonical_sha256(document)
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
+    sources["file.read"] = source_ref("file.read", None)
+    with pytest.raises(
+        ToolCapabilityWorldError,
+        match="source revision manifest mismatch",
+    ):
+        compile_tool_capability_world(
+            document,
+            registry,
+            source_revisions=sources,
+            argument_schema_hashes=schemas,
+            result_schema_hashes=schemas,
+        )
+
+
+def test_projection_rejects_malformed_schema_hash_binding() -> None:
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    manifest_sha = canonical_sha256(document)
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    schemas["file.read"] = "not-a-sha256"
+    with pytest.raises(ToolCapabilityWorldError, match="argument schema"):
+        compile_tool_capability_world(
+            document,
+            registry,
+            source_revisions=sources,
+            argument_schema_hashes=schemas,
+            result_schema_hashes={
+                action_id: H for action_id in document["capabilities"]
+            },
         )
 
 
 def test_projection_cannot_create_new_executable_action() -> None:
     document, registry, _snapshot = compile_snapshot()
     manifest_sha = canonical_sha256(document)
-    sources = {action_id: source_ref(action_id, manifest_sha) for action_id in document["capabilities"]}
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
     sources["invented.action"] = source_ref("invented.action", manifest_sha)
     schemas = {action_id: H for action_id in sources}
     snapshot = compile_tool_capability_world(
@@ -151,4 +305,6 @@ def test_projection_cannot_create_new_executable_action() -> None:
         argument_schema_hashes=schemas,
         result_schema_hashes=schemas,
     )
-    assert "invented.action" not in {item.action_id for item in snapshot.primitives}
+    assert "invented.action" not in {
+        item.action_id for item in snapshot.primitives
+    }

--- a/tests/test_tool_capability_world_p2.py
+++ b/tests/test_tool_capability_world_p2.py
@@ -326,7 +326,18 @@ def test_projection_rejects_source_span_outside_declared_files() -> None:
         compile_with_sources(sources)
 
 
-def test_projection_rejects_unsafe_repository_source_path() -> None:
+@pytest.mark.parametrize(
+    "unsafe_path",
+    (
+        "../outside.py",
+        "src//double-separator.py",
+        "src/./dot-segment.py",
+        " src/leading-space.py",
+    ),
+)
+def test_projection_rejects_unsafe_repository_source_path(
+    unsafe_path: str,
+) -> None:
     document = manifest()
     manifest_sha = canonical_sha256(document)
     sources = {
@@ -336,7 +347,7 @@ def test_projection_rejects_unsafe_repository_source_path() -> None:
     sources["file.read"] = source_ref(
         "file.read",
         manifest_sha,
-        source_files=("../outside.py",),
+        source_files=(unsafe_path,),
     )
     with pytest.raises(
         ToolCapabilityWorldError,

--- a/tests/test_tool_capability_world_p2.py
+++ b/tests/test_tool_capability_world_p2.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+from contracts import canonical_sha256
+from contracts.capability_composition import SourceRevisionRefV1
+from total_gateway.action_registry import compile_action_registry
+from world_understanding.tool_capability_world import (
+    ToolCapabilityWorldError,
+    compile_tool_capability_world,
+)
+
+
+H = "a" * 64
+
+
+def manifest() -> dict:
+    capabilities = {
+        "file.read": {
+            "id": "file.read",
+            "risk": "A0",
+            "effect": "read",
+            "handler": "_action_file_read",
+            "alias_to": "",
+            "executable": True,
+        },
+        "file.inspect": {
+            "id": "file.inspect",
+            "risk": "A1",
+            "effect": "read",
+            "handler": "alias:file.read",
+            "alias_to": "file.read",
+            "executable": True,
+        },
+    }
+    return {
+        "schema": "tiangong.v3.capability_manifest.v1",
+        "runtime_class": "demo.BodyRuntime",
+        "source_hash": H,
+        "total": 2,
+        "executable": 2,
+        "unavailable": 0,
+        "dynamic_actions": [],
+        "capabilities": capabilities,
+        "validation": {"ok": True, "source_hash": H, "executable_without_route": []},
+    }
+
+
+def source_ref(action_id: str, manifest_sha: str) -> SourceRevisionRefV1:
+    return SourceRevisionRefV1(
+        source_kind="TOOL_ACTION",
+        semantic_id=action_id,
+        version="omni-registry-v1",
+        source_files=("src/omni_body_skill/tools/omni_body_tool.py",),
+        source_sha256=H,
+        descriptor_sha256=H,
+        manifest_sha256=manifest_sha,
+    )
+
+
+def compile_snapshot():
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    manifest_sha = canonical_sha256(document)
+    sources = {action_id: source_ref(action_id, manifest_sha) for action_id in document["capabilities"]}
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    return document, registry, compile_tool_capability_world(
+        document,
+        registry,
+        source_revisions=sources,
+        argument_schema_hashes=schemas,
+        result_schema_hashes=schemas,
+    )
+
+
+def test_projection_is_deterministic_and_bound_to_existing_registry() -> None:
+    document, registry, snapshot = compile_snapshot()
+    assert snapshot.source_manifest_sha256 == registry.source_manifest_sha256
+    assert snapshot.action_registry_sha256 == registry.registry_sha256
+    assert snapshot.has_valid_sha256()
+    assert tuple(item.action_id for item in snapshot.primitives) == ("file.inspect", "file.read")
+    assert all(item.availability == "AVAILABLE" for item in snapshot.primitives)
+    assert all(item.action_manifest_sha256 == registry.source_manifest_sha256 for item in snapshot.primitives)
+
+    second = compile_tool_capability_world(
+        document,
+        registry,
+        source_revisions={
+            action_id: source_ref(action_id, registry.source_manifest_sha256)
+            for action_id in document["capabilities"]
+        },
+        argument_schema_hashes={action_id: H for action_id in document["capabilities"]},
+        result_schema_hashes={action_id: H for action_id in document["capabilities"]},
+    )
+    assert second.snapshot_sha256 == snapshot.snapshot_sha256
+
+
+def test_projection_contains_only_deterministic_structural_relations() -> None:
+    _document, _registry, snapshot = compile_snapshot()
+    relations = {(item.relation_type, item.source_ref, item.target_ref) for item in snapshot.relations}
+    assert ("ALIASES", "action:file.inspect", "action:file.read") in relations
+    assert ("COMPILES_TO", "tool-source:file.read", "action:file.read") in relations
+    assert ("PRODUCES", "tool-source:file.read", "effect:read") in relations
+    forbidden = {"SUITABLE_FOR", "COMPOSES_WITH", "PREFERRED_WHEN", "CONFLICTS_WITH"}
+    assert forbidden.isdisjoint({item.relation_type for item in snapshot.relations})
+
+
+def test_projection_fails_closed_on_registry_manifest_drift() -> None:
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    changed = manifest()
+    changed["capabilities"]["file.read"]["risk"] = "A1"
+    manifest_sha = canonical_sha256(changed)
+    sources = {action_id: source_ref(action_id, manifest_sha) for action_id in changed["capabilities"]}
+    schemas = {action_id: H for action_id in changed["capabilities"]}
+    with pytest.raises(ToolCapabilityWorldError, match="registry is not bound"):
+        compile_tool_capability_world(
+            changed,
+            registry,
+            source_revisions=sources,
+            argument_schema_hashes=schemas,
+            result_schema_hashes=schemas,
+        )
+
+
+def test_projection_fails_closed_when_source_binding_is_missing() -> None:
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    manifest_sha = canonical_sha256(document)
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    with pytest.raises(ToolCapabilityWorldError, match="missing deterministic source/schema binding"):
+        compile_tool_capability_world(
+            document,
+            registry,
+            source_revisions={"file.read": source_ref("file.read", manifest_sha)},
+            argument_schema_hashes=schemas,
+            result_schema_hashes=schemas,
+        )
+
+
+def test_projection_cannot_create_new_executable_action() -> None:
+    document, registry, _snapshot = compile_snapshot()
+    manifest_sha = canonical_sha256(document)
+    sources = {action_id: source_ref(action_id, manifest_sha) for action_id in document["capabilities"]}
+    sources["invented.action"] = source_ref("invented.action", manifest_sha)
+    schemas = {action_id: H for action_id in sources}
+    snapshot = compile_tool_capability_world(
+        document,
+        registry,
+        source_revisions=sources,
+        argument_schema_hashes=schemas,
+        result_schema_hashes=schemas,
+    )
+    assert "invented.action" not in {item.action_id for item in snapshot.primitives}

--- a/tests/test_tool_capability_world_p2.py
+++ b/tests/test_tool_capability_world_p2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from contracts import canonical_sha256
-from contracts.capability_composition import SourceRevisionRefV1
+from contracts.capability_composition import SourceRevisionRefV1, SourceSpanRefV1
 from total_gateway.action_registry import compile_action_registry
 from world_understanding.tool_capability_world import (
     ToolCapabilityRelationV1,
@@ -43,7 +43,11 @@ def manifest() -> dict:
         "unavailable": 0,
         "dynamic_actions": [],
         "capabilities": capabilities,
-        "validation": {"ok": True, "source_hash": H, "executable_without_route": []},
+        "validation": {
+            "ok": True,
+            "source_hash": H,
+            "executable_without_route": [],
+        },
     }
 
 
@@ -51,15 +55,18 @@ def source_ref(
     action_id: str,
     manifest_sha: str | None,
     *,
+    version: str = "omni-registry-v1",
     source_files: tuple[str, ...] = (
         "src/omni_body_skill/tools/omni_body_tool.py",
     ),
+    source_spans: tuple[SourceSpanRefV1, ...] = (),
 ) -> SourceRevisionRefV1:
     return SourceRevisionRefV1(
         source_kind="TOOL_ACTION",
         semantic_id=action_id,
-        version="omni-registry-v1",
+        version=version,
         source_files=source_files,
+        source_spans=source_spans,
         source_sha256=H,
         descriptor_sha256=H,
         manifest_sha256=manifest_sha,
@@ -84,6 +91,24 @@ def compile_snapshot():
     )
 
 
+def compile_with_sources(
+    sources: dict[str, SourceRevisionRefV1],
+    *,
+    argument_schema_hashes: dict[str, str] | None = None,
+    result_schema_hashes: dict[str, str] | None = None,
+):
+    document = manifest()
+    registry = compile_action_registry(document, generated_at_ms=1)
+    schemas = {action_id: H for action_id in document["capabilities"]}
+    return compile_tool_capability_world(
+        document,
+        registry,
+        source_revisions=sources,
+        argument_schema_hashes=argument_schema_hashes or schemas,
+        result_schema_hashes=result_schema_hashes or schemas,
+    )
+
+
 def test_projection_is_deterministic_and_bound_to_existing_registry() -> None:
     document, registry, snapshot = compile_snapshot()
     assert snapshot.source_manifest_sha256 == registry.source_manifest_sha256
@@ -100,7 +125,10 @@ def test_projection_is_deterministic_and_bound_to_existing_registry() -> None:
         item.action_manifest_sha256 == registry.source_manifest_sha256
         for item in snapshot.primitives
     )
-    assert all(item.provider_component_id == "omni-body" for item in snapshot.primitives)
+    assert all(
+        item.provider_component_id == "omni-body"
+        for item in snapshot.primitives
+    )
     assert all(item.idempotency == "UNKNOWN" for item in snapshot.primitives)
     assert all(
         item.determinism_class == "NONDETERMINISTIC"
@@ -124,37 +152,32 @@ def test_projection_is_deterministic_and_bound_to_existing_registry() -> None:
     assert second.snapshot_sha256 == snapshot.snapshot_sha256
 
 
-def test_source_file_order_cannot_change_snapshot_identity() -> None:
+def test_source_file_order_is_rejected_instead_of_creating_two_identities() -> None:
     document = manifest()
-    registry = compile_action_registry(document, generated_at_ms=1)
     manifest_sha = canonical_sha256(document)
-    files_a = (
-        "src/omni_body_skill/tools/omni_body_tool.py",
+    files = (
         "app/backend/tiangong-backend/v3/fact_kernel/__init__.py",
+        "src/omni_body_skill/tools/omni_body_tool.py",
     )
-    files_b = tuple(reversed(files_a))
-    schemas = {action_id: H for action_id in document["capabilities"]}
-    first = compile_tool_capability_world(
-        document,
-        registry,
-        source_revisions={
-            action_id: source_ref(action_id, manifest_sha, source_files=files_a)
-            for action_id in document["capabilities"]
-        },
-        argument_schema_hashes=schemas,
-        result_schema_hashes=schemas,
-    )
-    second = compile_tool_capability_world(
-        document,
-        registry,
-        source_revisions={
-            action_id: source_ref(action_id, manifest_sha, source_files=files_b)
-            for action_id in document["capabilities"]
-        },
-        argument_schema_hashes=schemas,
-        result_schema_hashes=schemas,
-    )
-    assert first.snapshot_sha256 == second.snapshot_sha256
+    sources = {
+        action_id: source_ref(action_id, manifest_sha, source_files=files)
+        for action_id in document["capabilities"]
+    }
+    compile_with_sources(sources)
+
+    reversed_sources = {
+        action_id: source_ref(
+            action_id,
+            manifest_sha,
+            source_files=tuple(reversed(files)),
+        )
+        for action_id in document["capabilities"]
+    }
+    with pytest.raises(
+        ToolCapabilityWorldError,
+        match="files must be sorted and unique",
+    ):
+        compile_with_sources(reversed_sources)
 
 
 def test_projection_contains_only_deterministic_structural_relations() -> None:
@@ -246,9 +269,7 @@ def test_projection_fails_closed_when_source_binding_is_missing() -> None:
 
 def test_projection_requires_exact_tool_source_manifest_binding() -> None:
     document = manifest()
-    registry = compile_action_registry(document, generated_at_ms=1)
     manifest_sha = canonical_sha256(document)
-    schemas = {action_id: H for action_id in document["capabilities"]}
     sources = {
         action_id: source_ref(action_id, manifest_sha)
         for action_id in document["capabilities"]
@@ -258,18 +279,74 @@ def test_projection_requires_exact_tool_source_manifest_binding() -> None:
         ToolCapabilityWorldError,
         match="source revision manifest mismatch",
     ):
-        compile_tool_capability_world(
-            document,
-            registry,
-            source_revisions=sources,
-            argument_schema_hashes=schemas,
-            result_schema_hashes=schemas,
-        )
+        compile_with_sources(sources)
+
+
+def test_projection_requires_exact_action_version_binding() -> None:
+    document = manifest()
+    manifest_sha = canonical_sha256(document)
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
+    sources["file.read"] = source_ref(
+        "file.read",
+        manifest_sha,
+        version="stale-action-version",
+    )
+    with pytest.raises(
+        ToolCapabilityWorldError,
+        match="identity/version mismatch",
+    ):
+        compile_with_sources(sources)
+
+
+def test_projection_rejects_source_span_outside_declared_files() -> None:
+    document = manifest()
+    manifest_sha = canonical_sha256(document)
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
+    sources["file.read"] = source_ref(
+        "file.read",
+        manifest_sha,
+        source_spans=(
+            SourceSpanRefV1(
+                path="src/unrelated.py",
+                start_line=1,
+                end_line=10,
+            ),
+        ),
+    )
+    with pytest.raises(
+        ToolCapabilityWorldError,
+        match="implementation refs are invalid",
+    ):
+        compile_with_sources(sources)
+
+
+def test_projection_rejects_unsafe_repository_source_path() -> None:
+    document = manifest()
+    manifest_sha = canonical_sha256(document)
+    sources = {
+        action_id: source_ref(action_id, manifest_sha)
+        for action_id in document["capabilities"]
+    }
+    sources["file.read"] = source_ref(
+        "file.read",
+        manifest_sha,
+        source_files=("../outside.py",),
+    )
+    with pytest.raises(
+        ToolCapabilityWorldError,
+        match="unsafe repository path",
+    ):
+        compile_with_sources(sources)
 
 
 def test_projection_rejects_malformed_schema_hash_binding() -> None:
     document = manifest()
-    registry = compile_action_registry(document, generated_at_ms=1)
     manifest_sha = canonical_sha256(document)
     sources = {
         action_id: source_ref(action_id, manifest_sha)
@@ -278,14 +355,9 @@ def test_projection_rejects_malformed_schema_hash_binding() -> None:
     schemas = {action_id: H for action_id in document["capabilities"]}
     schemas["file.read"] = "not-a-sha256"
     with pytest.raises(ToolCapabilityWorldError, match="argument schema"):
-        compile_tool_capability_world(
-            document,
-            registry,
-            source_revisions=sources,
+        compile_with_sources(
+            sources,
             argument_schema_hashes=schemas,
-            result_schema_hashes={
-                action_id: H for action_id in document["capabilities"]
-            },
         )
 
 


### PR DESCRIPTION
Implements P2 of the world-understanding-driven capability composition plan on top of `main @ c0d9b5b8fede060fde2d379444c8ae56931b58dc`.

Scope:
- adds `world_understanding.tool_capability_world` as a read-only semantic projection;
- compiles only from the existing capability manifest + ActionRegistrySnapshot + deterministic source/schema bindings;
- produces ToolSourcePrimitiveV1 and mechanically permitted structural relations only;
- fails closed on manifest/registry drift, stale manifest validation, missing Tool Source manifest binding, Action-version drift, malformed schema hashes, duplicate refs, source-span escape, or non-canonical repository paths;
- requires sorted, unique, canonical repository source identities for deterministic replay;
- marks idempotency as UNKNOWN and determinism conservatively instead of guessing from read/verify effect labels;
- fixes the provider identity to the existing Omni Body authority rather than accepting a caller-minted provider;
- proves the projection cannot invent executable actions or construct semantic relations such as SUITABLE_FOR / COMPOSES_WITH / PREFERRED_WHEN / CONFLICTS_WITH;
- exposes explicit `may_authorize=false` and `may_execute=false` snapshot invariants.

Non-goals:
- no new Tool Registry, Runtime, Gateway, permissions, grants, tickets, WorldState store, Memory write, Planner, or execution path;
- no P6 WorldState integration yet.

Gate: source-authority/full-regression and P19 golden checks must be green before P3 begins.