### PR TITLE
P4: bounded Proposal compiler and Tri-State Validator

### DIFF
--- a/docs/capability-composition/P4_PROPOSAL_COMPILER_VALIDATOR.md
+++ b/docs/capability-composition/P4_PROPOSAL_COMPILER_VALIDATOR.md
@@ -1,0 +1,191 @@
+# P4 — Proposal ABI, System Compiler, Tri-State Validator
+
+Base: `main @ 3ce15faf8d463a8c5b5b3bfaa855b10ec94a1b2e`.
+
+## Purpose
+
+P4 implements the bounded reasoning-to-plan boundary:
+
+`P2 Tool Capability World + P3 Skill Method World`
+→ bounded candidate snapshot
+→ model-authored `CompositionProposalV1`
+→ deterministic system compiler
+→ `CapabilityCompositionPlanV1`
+→ conservative Tri-State Validator
+
+P4 does not activate or execute the Plan. No Grant, Ticket, Runtime call,
+Effect, Fact, P19 decision, Completion decision, or Memory write is produced.
+
+## Candidate boundary
+
+Candidate IDs are assigned by the system:
+
+- Methods: `M01`–`M15`
+- Actions: `A01`–`A30`
+
+The candidate snapshot is content-addressed and explicitly:
+
+- `may_authorize = false`
+- `may_execute = false`
+
+It binds exact P2/P3 snapshot hashes, Tool/Method descriptors, Tool source
+revisions, Action versions, and the existing Action Registry identity. Candidate
+selection is bounded; P4 does not expose the full Tool or Static Skill catalog to
+the model.
+
+## Small model ABI
+
+The model may provide only:
+
+- goal reference;
+- selected Method candidate IDs;
+- selected Action candidate IDs;
+- ordered/DAG steps;
+- dependency edges;
+- output bindings;
+- control-flow mode;
+- optional rationale tags.
+
+The raw proposal supports two provider tiers:
+
+1. strict JSON using `proposal_schema = tiangong.composition-proposal.v1`;
+2. a strict, bounded text DSL for providers without guaranteed structured output.
+
+The parser rejects:
+
+- duplicate or unknown fields;
+- caller-supplied hash, risk, permission, version, Registry, Grant, Ticket, Fact,
+  or Completion fields;
+- unknown/hallucinated candidate IDs;
+- Method candidates used as executable steps;
+- inconsistent selected Action and step sets;
+- invalid dependency identities;
+- JSON numbers and non-finite values;
+- oversized proposal output.
+
+Exactly one externally produced repair proposal may be parsed. A second parse
+failure is final and fail-closed; there is no unbounded retry loop.
+
+## System compiler
+
+The compiler, not the model, derives:
+
+- request/run/generation and principal bindings;
+- WorldState and context bindings;
+- Method and Action `SourceRevisionRefV1` records;
+- Action IDs and versions;
+- dependency-graph hash;
+- source-manifest hash;
+- candidate/context/Registry binding hash;
+- leaf permission union;
+- expected effects and resource classes;
+- leaf risk floor;
+- composition risk and information-flow findings;
+- verification intents;
+- immutable Plan ID and Plan SHA-256.
+
+The compiler cannot expand beyond Action candidates already present in the
+existing `ActionRegistrySnapshot` and bound to the exact capability manifest.
+Memory experience references remain empty until P5.
+
+## Composition risk
+
+P4 does not use only `max(leaf risk)`. It performs deterministic composition
+checks, including:
+
+- multiple writes;
+- sensitive/credential/private source to external sink;
+- privileged shell/Python result to external sink;
+- destructive sequence with external sink;
+- execution result flowing to an external sink.
+
+A prohibited composition is raised to `A5`. P4 still does not execute it; the
+Validator returns `PROVED_INVALID`.
+
+## Tri-State Validator
+
+The fixed result set is:
+
+- `PROVED_VALID`
+- `PROVED_INVALID`
+- `UNKNOWN`
+
+The Validator validates mechanically decidable properties only. It does not
+claim to prove that natural-language output must satisfy the user's goal.
+
+Checks include:
+
+- Proposal, Candidate, Context, Registry, Plan and source hashes;
+- compiler reconstruction equality;
+- exact Action/version/manifest bindings;
+- permission expansion;
+- dependency type compatibility;
+- unordered overlapping write sets;
+- Action availability;
+- verifier availability;
+- idempotency/determinism uncertainty;
+- composition risk and information flow.
+
+An attacker cannot make a modified Plan valid merely by recalculating its Plan
+hash: the Validator reconstructs the expected Plan from the original Proposal,
+Candidate Snapshot, Compile Context, and current Action Registry.
+
+### UNKNOWN policy
+
+`PROVISIONAL_ALLOW + mandatory verification` is possible only when all of the
+following hold:
+
+- risk is A0/A1;
+- every Action is read/verify only;
+- no credential, private, shell, Python, destructive, external-send, or external-
+  write class is present;
+- all declared verification intents have an available verifier.
+
+All other UNKNOWN states are `REJECT` in P4. In particular, A2+ UNKNOWN is never
+silently treated as valid.
+
+## Early evaluation
+
+The repository includes a deterministic 24-task × 3-protocol-profile preflight:
+
+- structured JSON;
+- JSON requiring exactly one repair;
+- strict DSL.
+
+This produces per-profile parse, repair, compile, and validation metrics without
+executing any Action.
+
+The CI preflight is explicitly tagged `RECORDED_FIXTURE`. It proves protocol and
+implementation behavior, not live performance of any named model. Live provider
+outputs can be fed into the same harness under `LIVE_PROVIDER`; those measurements
+must be reported separately before claiming cross-model production performance.
+
+## Preserved authorities
+
+P4 does not modify or replace:
+
+- Total Gateway;
+- Policy Engine;
+- Action Manifest / Action Registry / ActionPermission;
+- ExecutionTicket or CapabilityGrant;
+- Omni Body or BodyRuntime;
+- WorldState authority;
+- Memory SSoT;
+- P19 Verification Plane;
+- CompletionGate;
+- current Static Skill planner/context path.
+
+## Gate
+
+Before P5 begins, this branch must pass:
+
+- P4 focused parser/compiler/validator tests;
+- 24 × 3 recorded protocol preflight;
+- source-authority Ubuntu/Windows;
+- full-regression Ubuntu/Windows;
+- P14 repository-perception validation;
+- P19-R2 Verification Plane Golden Gate.
+
+A live three-model benchmark is an evidence task, not something CI may fabricate.
+Its results must identify exact provider/model revisions and be stored separately
+from the recorded protocol preflight.

--- a/src/world_understanding/capability_composition/__init__.py
+++ b/src/world_understanding/capability_composition/__init__.py
@@ -1,0 +1,76 @@
+"""P4 proposal, compiler, validator, and early-evaluation core.
+
+This package is side-effect free and non-authorizing. Execution continues to be
+owned exclusively by the existing Total Gateway / Policy / Ticket / Grant /
+Omni Body / Runtime / P19 chain.
+"""
+
+from .compiler import (
+    analyze_composition_risk,
+    compile_capability_composition_plan,
+    computed_plan_sha256,
+    plan_has_valid_sha256,
+)
+from .evaluation import (
+    P4EarlyEvaluationReportV1,
+    P4EvaluationCaseResultV1,
+    P4EvaluationInputV1,
+    P4ModelMetricsV1,
+    run_p4_early_evaluation,
+)
+from .models import (
+    ActionCandidateBindingV1,
+    CapabilityCompositionError,
+    CompositionCandidateSnapshotV1,
+    CompositionCompileContextV1,
+    MAX_ACTION_CANDIDATES,
+    MAX_METHOD_CANDIDATES,
+    MethodCandidateBindingV1,
+    build_candidate_snapshot,
+    derive_action_source_revision,
+    validate_registry_binding,
+)
+from .parser import (
+    CompositionProposalParseError,
+    ProposalParseOutcomeV1,
+    computed_proposal_sha256,
+    parse_composition_proposal,
+    parse_with_single_repair,
+    proposal_has_valid_sha256,
+)
+from .validator import (
+    computed_validation_sha256,
+    validate_capability_composition_plan,
+    validation_has_valid_sha256,
+)
+
+__all__ = [
+    "ActionCandidateBindingV1",
+    "CapabilityCompositionError",
+    "CompositionCandidateSnapshotV1",
+    "CompositionCompileContextV1",
+    "CompositionProposalParseError",
+    "MAX_ACTION_CANDIDATES",
+    "MAX_METHOD_CANDIDATES",
+    "MethodCandidateBindingV1",
+    "P4EarlyEvaluationReportV1",
+    "P4EvaluationCaseResultV1",
+    "P4EvaluationInputV1",
+    "P4ModelMetricsV1",
+    "ProposalParseOutcomeV1",
+    "analyze_composition_risk",
+    "build_candidate_snapshot",
+    "compile_capability_composition_plan",
+    "computed_plan_sha256",
+    "computed_proposal_sha256",
+    "computed_validation_sha256",
+    "derive_action_source_revision",
+    "parse_composition_proposal",
+    "parse_with_single_repair",
+    "plan_has_valid_sha256",
+    "proposal_has_valid_sha256",
+    "run_p4_early_evaluation",
+    "validate_capability_composition_plan",
+    "validate_registry_binding",
+    "validation_has_valid_sha256",
+]

--- a/src/world_understanding/capability_composition/compiler.py
+++ b/src/world_understanding/capability_composition/compiler.py
@@ -1,0 +1,451 @@
+"""Deterministic system compiler from model proposal to authoritative Plan IR.
+
+The compiler derives all hashes, source/version bindings, permission
+requirements, and composition risk. It does not issue a Grant, Ticket, execute
+an Action, or decide Completion.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from contracts import ActionRegistrySnapshot, canonical_sha256
+from contracts.capability_composition import (
+    CapabilityCompositionPlanV1,
+    CompositionPlanStepV1,
+    CompositionProposalV1,
+    SourceRevisionRefV1,
+    ToolSourcePrimitiveV1,
+)
+
+from .models import (
+    ActionCandidateBindingV1,
+    CapabilityCompositionError,
+    CompositionCandidateSnapshotV1,
+    CompositionCompileContextV1,
+    validate_registry_binding,
+)
+from .parser import proposal_has_valid_sha256
+
+
+_RISK_ORDER = {
+    "A0": 0,
+    "A1": 1,
+    "A2": 2,
+    "A3": 3,
+    "A4": 4,
+    "A5": 5,
+}
+_RISK_BY_VALUE = {value: key for key, value in _RISK_ORDER.items()}
+_WRITE_EFFECTS = {"create", "write", "update", "execute"}
+_EXTERNAL_SIDE_EFFECTS = {"external_write", "external_send"}
+_SENSITIVE_RESOURCE_CLASSES = {
+    "credential",
+    "credentials",
+    "secret",
+    "secrets",
+    "user_private",
+    "private_data",
+    "sensitive_source",
+}
+_PRIVILEGED_RESOURCE_CLASSES = {"shell", "python"}
+_DESTRUCTIVE_SIDE_EFFECTS = {"destructive", "irreversible"}
+
+
+def computed_plan_sha256(plan: CapabilityCompositionPlanV1) -> str:
+    return canonical_sha256(
+        plan.model_dump(mode="json", exclude={"plan_sha256"})
+    )
+
+
+def plan_has_valid_sha256(plan: CapabilityCompositionPlanV1) -> bool:
+    return plan.plan_sha256 == computed_plan_sha256(plan)
+
+
+def _risk_max(values: Iterable[str]) -> str:
+    materialized = tuple(values)
+    if not materialized or any(value not in _RISK_ORDER for value in materialized):
+        raise CapabilityCompositionError("compiler.risk.invalid")
+    return _RISK_BY_VALUE[max(_RISK_ORDER[value] for value in materialized)]
+
+
+def _risk_at_least(value: str, floor: str) -> str:
+    return _RISK_BY_VALUE[max(_RISK_ORDER[value], _RISK_ORDER[floor])]
+
+
+def analyze_composition_risk(
+    primitives: tuple[ToolSourcePrimitiveV1, ...],
+) -> tuple[str, str, tuple[str, ...]]:
+    """Return leaf floor, composition risk, and deterministic flow findings."""
+
+    if not primitives:
+        raise CapabilityCompositionError("compiler.actions.empty")
+    risk_floor = _risk_max(item.risk_floor for item in primitives)
+    composition_risk = risk_floor
+    findings: set[str] = set()
+
+    resources = {
+        value.casefold()
+        for primitive in primitives
+        for value in primitive.resource_scope
+    }
+    side_effects = {
+        value.casefold()
+        for primitive in primitives
+        for value in primitive.side_effects
+    }
+    effects = {
+        primitive.effect_class.removeprefix("effect:").casefold()
+        for primitive in primitives
+    }
+    write_count = sum(
+        1
+        for primitive in primitives
+        if primitive.effect_class.removeprefix("effect:").casefold()
+        in _WRITE_EFFECTS
+    )
+    has_external_sink = bool(side_effects & _EXTERNAL_SIDE_EFFECTS)
+    has_sensitive_source = bool(resources & _SENSITIVE_RESOURCE_CLASSES)
+    has_privileged_source = bool(resources & _PRIVILEGED_RESOURCE_CLASSES)
+    has_destructive = bool(side_effects & _DESTRUCTIVE_SIDE_EFFECTS)
+
+    if write_count > 1:
+        findings.add("composition:multiple-writes")
+        composition_risk = _risk_at_least(composition_risk, "A3")
+    if has_sensitive_source and has_external_sink:
+        findings.add("flow:sensitive-source-to-external-sink")
+        composition_risk = "A5"
+    if has_privileged_source and has_external_sink:
+        findings.add("flow:privileged-execution-to-external-sink")
+        composition_risk = "A5"
+    if has_destructive and has_external_sink:
+        findings.add("flow:destructive-sequence-with-external-sink")
+        composition_risk = "A5"
+    if "execute" in effects and has_external_sink:
+        findings.add("flow:execution-result-to-external-sink")
+        composition_risk = "A5"
+
+    return risk_floor, composition_risk, tuple(sorted(findings))
+
+
+def _topological_step_ids(
+    proposal: CompositionProposalV1,
+) -> tuple[str, ...]:
+    steps = {item.step_id: item for item in proposal.steps}
+    indegree = {step_id: 0 for step_id in steps}
+    outgoing: dict[str, set[str]] = defaultdict(set)
+    for left, right in proposal.dependency_edges:
+        if left not in steps or right not in steps or left == right:
+            raise CapabilityCompositionError(
+                "compiler.dependency.invalid", f"{left}>{right}"
+            )
+        if right not in outgoing[left]:
+            outgoing[left].add(right)
+            indegree[right] += 1
+
+    ready = sorted(step_id for step_id, degree in indegree.items() if degree == 0)
+    ordered: list[str] = []
+    while ready:
+        step_id = ready.pop(0)
+        ordered.append(step_id)
+        for target in sorted(outgoing.get(step_id, ())):
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                ready.append(target)
+                ready.sort()
+    if len(ordered) != len(steps):
+        raise CapabilityCompositionError("compiler.dependency.cycle")
+    return tuple(ordered)
+
+
+def _source_sort_key(source: SourceRevisionRefV1) -> tuple[str, str, str, str]:
+    return (
+        source.source_kind,
+        source.semantic_id,
+        source.version,
+        source.source_sha256,
+    )
+
+
+def _selected_action_bindings(
+    proposal: CompositionProposalV1,
+    candidates: CompositionCandidateSnapshotV1,
+) -> tuple[ActionCandidateBindingV1, ...]:
+    by_id = candidates.action_by_candidate()
+    try:
+        selected = tuple(
+            by_id[candidate_id]
+            for candidate_id in proposal.selected_action_candidate_ids
+        )
+    except KeyError as exc:
+        raise CapabilityCompositionError(
+            "compiler.action_candidate.unknown", str(exc)
+        ) from exc
+    return tuple(
+        sorted(selected, key=lambda item: item.primitive.action_id)
+    )
+
+
+def _source_manifest_sha256(
+    *,
+    action_sources: tuple[SourceRevisionRefV1, ...],
+    method_sources: tuple[SourceRevisionRefV1, ...],
+) -> str:
+    return canonical_sha256(
+        {
+            "domain": "tiangong.capability-composition.source-manifest.v1",
+            "action_sources": [
+                item.model_dump(mode="json") for item in action_sources
+            ],
+            "method_sources": [
+                item.model_dump(mode="json") for item in method_sources
+            ],
+        }
+    )
+
+
+def compile_capability_composition_plan(
+    proposal: CompositionProposalV1,
+    candidates: CompositionCandidateSnapshotV1,
+    context: CompositionCompileContextV1,
+    registry: ActionRegistrySnapshot,
+) -> CapabilityCompositionPlanV1:
+    """Compile the bounded model proposal into a fully system-derived Plan."""
+
+    if not proposal_has_valid_sha256(proposal):
+        raise CapabilityCompositionError("compiler.proposal.hash_invalid")
+    if not candidates.has_valid_sha256():
+        raise CapabilityCompositionError("compiler.candidates.hash_invalid")
+    if not context.has_valid_sha256():
+        raise CapabilityCompositionError("compiler.context.hash_invalid")
+    if not registry.has_valid_sha256():
+        raise CapabilityCompositionError("compiler.registry.hash_invalid")
+    if proposal.goal_ref != context.goal_ref:
+        raise CapabilityCompositionError("compiler.goal_ref.mismatch")
+    if (
+        context.capability_manifest_sha256
+        != registry.source_manifest_sha256
+    ):
+        raise CapabilityCompositionError(
+            "compiler.capability_manifest.mismatch"
+        )
+    validate_registry_binding(candidates, registry)
+
+    methods_by_candidate = candidates.method_by_candidate()
+    try:
+        selected_methods = tuple(
+            methods_by_candidate[candidate_id]
+            for candidate_id in proposal.selected_method_candidate_ids
+        )
+        selected_actions = _selected_action_bindings(proposal, candidates)
+    except KeyError as exc:
+        raise CapabilityCompositionError(
+            "compiler.candidate.unknown", str(exc)
+        ) from exc
+    if not selected_actions:
+        raise CapabilityCompositionError("compiler.actions.empty")
+
+    selected_action_ids = {
+        item.candidate_id for item in selected_actions
+    }
+    used_action_ids = {item.candidate_id for item in proposal.steps}
+    if selected_action_ids != used_action_ids:
+        raise CapabilityCompositionError(
+            "compiler.action_selection.step_mismatch"
+        )
+
+    permission_by_action = {
+        permission.action_id: permission for permission in registry.permissions
+    }
+    for selected in selected_actions:
+        primitive = selected.primitive
+        permission = permission_by_action.get(primitive.action_id)
+        if (
+            permission is None
+            or permission.action_version != primitive.action_version
+            or permission.source_manifest_sha256
+            != context.capability_manifest_sha256
+            or selected.source_revision.manifest_sha256
+            != context.capability_manifest_sha256
+        ):
+            raise CapabilityCompositionError(
+                "compiler.action_authority.binding_mismatch",
+                primitive.action_id,
+            )
+
+    action_sources = tuple(
+        sorted(
+            (item.source_revision for item in selected_actions),
+            key=_source_sort_key,
+        )
+    )
+    method_sources = tuple(
+        sorted(
+            (item.primitive.source_ref for item in selected_methods),
+            key=_source_sort_key,
+        )
+    )
+
+    selected_by_candidate = {
+        item.candidate_id: item for item in selected_actions
+    }
+    proposal_step_by_id = {item.step_id: item for item in proposal.steps}
+    ordered_step_ids = _topological_step_ids(proposal)
+    plan_steps: list[CompositionPlanStepV1] = []
+    for step_id in ordered_step_ids:
+        proposed_step = proposal_step_by_id[step_id]
+        selected = selected_by_candidate.get(proposed_step.candidate_id)
+        if selected is None:
+            raise CapabilityCompositionError(
+                "compiler.step.candidate_not_selected", step_id
+            )
+        primitive = selected.primitive
+        plan_steps.append(
+            CompositionPlanStepV1(
+                step_id=step_id,
+                action_id=primitive.action_id,
+                action_version=primitive.action_version,
+                method_id=None,
+                depends_on=proposed_step.depends_on,
+                expected_effect_refs=tuple(sorted(set(primitive.produces))),
+                verification_intent_refs=tuple(
+                    sorted(set(primitive.verifier_refs))
+                ),
+            )
+        )
+
+    dependency_graph_sha256 = canonical_sha256(
+        {
+            "domain": "tiangong.capability-composition.dependency-graph.v1",
+            "control_flow": proposal.control_flow,
+            "steps": [
+                {
+                    "step_id": item.step_id,
+                    "depends_on": list(item.depends_on),
+                }
+                for item in plan_steps
+            ],
+            "edges": [list(item) for item in proposal.dependency_edges],
+        }
+    )
+    bindings_sha256 = canonical_sha256(
+        {
+            "domain": "tiangong.capability-composition.bindings.v1",
+            "proposal_sha256": proposal.proposal_sha256,
+            "candidate_snapshot_sha256": candidates.candidate_snapshot_sha256,
+            "compile_context_sha256": context.context_sha256,
+            "action_registry_sha256": registry.registry_sha256,
+            "selected_method_bindings": [
+                item.binding_sha256 for item in selected_methods
+            ],
+            "selected_action_bindings": [
+                item.binding_sha256 for item in selected_actions
+            ],
+            "step_candidate_bindings": [
+                [item.step_id, item.candidate_id] for item in proposal.steps
+            ],
+            "output_bindings": list(proposal.output_bindings),
+        }
+    )
+    source_manifest_sha256 = _source_manifest_sha256(
+        action_sources=action_sources,
+        method_sources=method_sources,
+    )
+
+    primitives = tuple(item.primitive for item in selected_actions)
+    risk_floor, composition_risk, flow_findings = analyze_composition_risk(
+        primitives
+    )
+    permission_requirements = tuple(
+        sorted({item.action_id for item in primitives})
+    )
+    expected_effects = tuple(
+        sorted(
+            {
+                effect
+                for primitive in primitives
+                for effect in primitive.produces
+            }
+        )
+    )
+    required_resources = tuple(
+        sorted(
+            {
+                resource
+                for primitive in primitives
+                for resource in primitive.resource_scope
+            }
+        )
+    )
+    verification_intents = tuple(
+        sorted(
+            {
+                intent
+                for method in selected_methods
+                for intent in method.primitive.verification_intent
+            }
+            | {
+                verifier
+                for primitive in primitives
+                for verifier in primitive.verifier_refs
+            }
+        )
+    )
+
+    plan_identity_sha256 = canonical_sha256(
+        {
+            "domain": "tiangong.capability-composition.plan-identity.v1",
+            "request_id": context.request_id,
+            "run_id": context.run_id,
+            "generation": context.generation,
+            "principal_scope_hash": context.principal_scope_hash,
+            "world_state_sha256": context.world_state_sha256,
+            "goal_fingerprint": context.goal_fingerprint,
+            "proposal_sha256": proposal.proposal_sha256,
+            "bindings_sha256": bindings_sha256,
+            "source_manifest_sha256": source_manifest_sha256,
+            "capability_manifest_sha256": context.capability_manifest_sha256,
+        }
+    )
+    plan = CapabilityCompositionPlanV1(
+        plan_id="plan_" + plan_identity_sha256,
+        request_id=context.request_id,
+        run_id=context.run_id,
+        generation=context.generation,
+        principal_scope_hash=context.principal_scope_hash,
+        world_state_ref=context.world_state_ref,
+        world_state_sha256=context.world_state_sha256,
+        goal_fingerprint=context.goal_fingerprint,
+        environment_class=context.environment_class,
+        context_fingerprint_sha256=context.context_fingerprint_sha256,
+        method_source_refs=method_sources,
+        action_source_refs=action_sources,
+        steps=tuple(plan_steps),
+        dependency_graph_sha256=dependency_graph_sha256,
+        bindings_sha256=bindings_sha256,
+        control_flow=proposal.control_flow,
+        expected_effects=expected_effects,
+        required_resource_classes=required_resources,
+        permission_requirements=permission_requirements,
+        risk_floor=risk_floor,
+        composition_risk=composition_risk,
+        information_flow_findings=flow_findings,
+        source_manifest_sha256=source_manifest_sha256,
+        capability_manifest_sha256=context.capability_manifest_sha256,
+        memory_experience_refs=(),
+        verification_intents=verification_intents,
+        created_at_ms=context.created_at_ms,
+        plan_sha256="0" * 64,
+    )
+    return plan.model_copy(
+        update={"plan_sha256": computed_plan_sha256(plan)}
+    )
+
+
+__all__ = [
+    "analyze_composition_risk",
+    "compile_capability_composition_plan",
+    "computed_plan_sha256",
+    "plan_has_valid_sha256",
+]

--- a/src/world_understanding/capability_composition/evaluation.py
+++ b/src/world_understanding/capability_composition/evaluation.py
@@ -77,7 +77,9 @@ class P4ModelMetricsV1:
     repair_attempt_count: int
     repair_success_count: int
     final_parse_failure_count: int
+    plan_success_count: int
     plan_compile_failure_count: int
+    semantic_validation_failure_count: int
     proved_valid_count: int
     proved_invalid_count: int
     unknown_count: int
@@ -90,7 +92,9 @@ class P4ModelMetricsV1:
             "repair_attempt_count": self.repair_attempt_count,
             "repair_success_count": self.repair_success_count,
             "final_parse_failure_count": self.final_parse_failure_count,
+            "plan_success_count": self.plan_success_count,
             "plan_compile_failure_count": self.plan_compile_failure_count,
+            "semantic_validation_failure_count": self.semantic_validation_failure_count,
             "proved_valid_count": self.proved_valid_count,
             "proved_invalid_count": self.proved_invalid_count,
             "unknown_count": self.unknown_count,
@@ -143,15 +147,18 @@ def _metrics(
         primary_parse_failure_count=sum(
             item.primary_error_code is not None for item in selected
         ),
-        repair_attempt_count=sum(
-            item.repair_attempted for item in selected
-        ),
+        repair_attempt_count=sum(item.repair_attempted for item in selected),
         repair_success_count=sum(item.repaired for item in selected),
         final_parse_failure_count=sum(
             not item.parse_succeeded for item in selected
         ),
+        plan_success_count=sum(item.plan_succeeded for item in selected),
         plan_compile_failure_count=sum(
             item.parse_succeeded and not item.plan_succeeded
+            for item in selected
+        ),
+        semantic_validation_failure_count=sum(
+            item.validation_result in {"PROVED_INVALID", "UNKNOWN"}
             for item in selected
         ),
         proved_valid_count=sum(

--- a/src/world_understanding/capability_composition/evaluation.py
+++ b/src/world_understanding/capability_composition/evaluation.py
@@ -40,6 +40,7 @@ class P4EvaluationCaseResultV1:
     evidence_mode: str
     parse_succeeded: bool
     repaired: bool
+    repair_attempted: bool
     primary_error_code: str | None
     plan_succeeded: bool
     validation_result: str | None
@@ -56,6 +57,7 @@ class P4EvaluationCaseResultV1:
             "evidence_mode": self.evidence_mode,
             "parse_succeeded": self.parse_succeeded,
             "repaired": self.repaired,
+            "repair_attempted": self.repair_attempted,
             "primary_error_code": self.primary_error_code,
             "plan_succeeded": self.plan_succeeded,
             "validation_result": self.validation_result,
@@ -142,7 +144,7 @@ def _metrics(
             item.primary_error_code is not None for item in selected
         ),
         repair_attempt_count=sum(
-            item.primary_error_code is not None for item in selected
+            item.repair_attempted for item in selected
         ),
         repair_success_count=sum(item.repaired for item in selected),
         final_parse_failure_count=sum(
@@ -210,6 +212,7 @@ def run_p4_early_evaluation(
                     evidence_mode=evidence_mode,
                     parse_succeeded=False,
                     repaired=False,
+                    repair_attempted=item.repair_text is not None,
                     primary_error_code=primary_error_code,
                     plan_succeeded=False,
                     validation_result=None,
@@ -235,6 +238,10 @@ def run_p4_early_evaluation(
                     evidence_mode=evidence_mode,
                     parse_succeeded=True,
                     repaired=parsed.repaired,
+                    repair_attempted=(
+                        parsed.primary_error_code is not None
+                        and item.repair_text is not None
+                    ),
                     primary_error_code=parsed.primary_error_code,
                     plan_succeeded=False,
                     validation_result=None,
@@ -263,6 +270,10 @@ def run_p4_early_evaluation(
                 evidence_mode=evidence_mode,
                 parse_succeeded=True,
                 repaired=parsed.repaired,
+                repair_attempted=(
+                    parsed.primary_error_code is not None
+                    and item.repair_text is not None
+                ),
                 primary_error_code=parsed.primary_error_code,
                 plan_succeeded=True,
                 validation_result=validation.result,

--- a/src/world_understanding/capability_composition/evaluation.py
+++ b/src/world_understanding/capability_composition/evaluation.py
@@ -1,0 +1,299 @@
+"""P4 early-evaluation harness for proposal/compiler/validator outputs.
+
+The harness accepts either recorded fixtures or outputs captured from live
+providers. It never performs network calls and never represents recorded
+protocol fixtures as live model performance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Mapping
+
+from contracts import ActionRegistrySnapshot, canonical_sha256
+
+from .compiler import compile_capability_composition_plan
+from .models import (
+    CapabilityCompositionError,
+    CompositionCandidateSnapshotV1,
+    CompositionCompileContextV1,
+)
+from .parser import (
+    CompositionProposalParseError,
+    parse_with_single_repair,
+)
+from .validator import validate_capability_composition_plan
+
+
+@dataclass(frozen=True, slots=True)
+class P4EvaluationInputV1:
+    task_id: str
+    model_id: str
+    primary_text: str
+    repair_text: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class P4EvaluationCaseResultV1:
+    task_id: str
+    model_id: str
+    evidence_mode: str
+    parse_succeeded: bool
+    repaired: bool
+    primary_error_code: str | None
+    plan_succeeded: bool
+    validation_result: str | None
+    validation_disposition: str | None
+    proposal_sha256: str | None
+    plan_sha256: str | None
+    validation_sha256: str | None
+    error_code: str | None
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "model_id": self.model_id,
+            "evidence_mode": self.evidence_mode,
+            "parse_succeeded": self.parse_succeeded,
+            "repaired": self.repaired,
+            "primary_error_code": self.primary_error_code,
+            "plan_succeeded": self.plan_succeeded,
+            "validation_result": self.validation_result,
+            "validation_disposition": self.validation_disposition,
+            "proposal_sha256": self.proposal_sha256,
+            "plan_sha256": self.plan_sha256,
+            "validation_sha256": self.validation_sha256,
+            "error_code": self.error_code,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class P4ModelMetricsV1:
+    model_id: str
+    case_count: int
+    primary_parse_failure_count: int
+    repair_attempt_count: int
+    repair_success_count: int
+    final_parse_failure_count: int
+    plan_compile_failure_count: int
+    proved_valid_count: int
+    proved_invalid_count: int
+    unknown_count: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "case_count": self.case_count,
+            "primary_parse_failure_count": self.primary_parse_failure_count,
+            "repair_attempt_count": self.repair_attempt_count,
+            "repair_success_count": self.repair_success_count,
+            "final_parse_failure_count": self.final_parse_failure_count,
+            "plan_compile_failure_count": self.plan_compile_failure_count,
+            "proved_valid_count": self.proved_valid_count,
+            "proved_invalid_count": self.proved_invalid_count,
+            "unknown_count": self.unknown_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class P4EarlyEvaluationReportV1:
+    schema: str
+    evidence_mode: str
+    cases: tuple[P4EvaluationCaseResultV1, ...]
+    model_metrics: tuple[P4ModelMetricsV1, ...]
+    report_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.schema != "tiangong.p4-early-evaluation.v1":
+            raise CapabilityCompositionError("evaluation.schema.invalid")
+        if self.evidence_mode not in {"RECORDED_FIXTURE", "LIVE_PROVIDER"}:
+            raise CapabilityCompositionError("evaluation.evidence_mode.invalid")
+        case_keys = tuple((item.model_id, item.task_id) for item in self.cases)
+        if not case_keys or case_keys != tuple(sorted(set(case_keys))):
+            raise CapabilityCompositionError("evaluation.cases.invalid")
+        model_ids = tuple(item.model_id for item in self.model_metrics)
+        if model_ids != tuple(sorted(set(model_ids))):
+            raise CapabilityCompositionError("evaluation.models.invalid")
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "evidence_mode": self.evidence_mode,
+            "cases": [item.payload() for item in self.cases],
+            "model_metrics": [item.payload() for item in self.model_metrics],
+        }
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.report_sha256 == self.computed_sha256()
+
+
+def _metrics(
+    model_id: str,
+    results: tuple[P4EvaluationCaseResultV1, ...],
+) -> P4ModelMetricsV1:
+    selected = tuple(item for item in results if item.model_id == model_id)
+    return P4ModelMetricsV1(
+        model_id=model_id,
+        case_count=len(selected),
+        primary_parse_failure_count=sum(
+            item.primary_error_code is not None for item in selected
+        ),
+        repair_attempt_count=sum(
+            item.primary_error_code is not None for item in selected
+        ),
+        repair_success_count=sum(item.repaired for item in selected),
+        final_parse_failure_count=sum(
+            not item.parse_succeeded for item in selected
+        ),
+        plan_compile_failure_count=sum(
+            item.parse_succeeded and not item.plan_succeeded
+            for item in selected
+        ),
+        proved_valid_count=sum(
+            item.validation_result == "PROVED_VALID" for item in selected
+        ),
+        proved_invalid_count=sum(
+            item.validation_result == "PROVED_INVALID" for item in selected
+        ),
+        unknown_count=sum(
+            item.validation_result == "UNKNOWN" for item in selected
+        ),
+    )
+
+
+def run_p4_early_evaluation(
+    inputs: tuple[P4EvaluationInputV1, ...],
+    *,
+    candidates_by_task: Mapping[str, CompositionCandidateSnapshotV1],
+    contexts_by_task: Mapping[str, CompositionCompileContextV1],
+    registry: ActionRegistrySnapshot,
+    available_verifiers: frozenset[str],
+    validated_at_ms: int,
+    evidence_mode: str,
+) -> P4EarlyEvaluationReportV1:
+    """Evaluate already-produced proposal texts without executing Actions."""
+
+    if evidence_mode not in {"RECORDED_FIXTURE", "LIVE_PROVIDER"}:
+        raise CapabilityCompositionError("evaluation.evidence_mode.invalid")
+    keys = tuple((item.model_id, item.task_id) for item in inputs)
+    if not keys or len(keys) != len(set(keys)):
+        raise CapabilityCompositionError("evaluation.input.identity_invalid")
+
+    results: list[P4EvaluationCaseResultV1] = []
+    for item in sorted(inputs, key=lambda value: (value.model_id, value.task_id)):
+        candidates = candidates_by_task.get(item.task_id)
+        context = contexts_by_task.get(item.task_id)
+        if candidates is None or context is None:
+            raise CapabilityCompositionError(
+                "evaluation.task_binding.missing", item.task_id
+            )
+        try:
+            parsed = parse_with_single_repair(
+                item.primary_text,
+                candidates,
+                repair_text=item.repair_text,
+            )
+        except CompositionProposalParseError as exc:
+            primary_error_code = exc.code
+            if exc.code == "proposal.repair.failed":
+                for part in exc.detail.split(";"):
+                    if part.startswith("primary="):
+                        primary_error_code = part.partition("=")[2] or exc.code
+                        break
+            results.append(
+                P4EvaluationCaseResultV1(
+                    task_id=item.task_id,
+                    model_id=item.model_id,
+                    evidence_mode=evidence_mode,
+                    parse_succeeded=False,
+                    repaired=False,
+                    primary_error_code=primary_error_code,
+                    plan_succeeded=False,
+                    validation_result=None,
+                    validation_disposition=None,
+                    proposal_sha256=None,
+                    plan_sha256=None,
+                    validation_sha256=None,
+                    error_code=exc.code,
+                )
+            )
+            continue
+
+        proposal = parsed.proposal
+        try:
+            plan = compile_capability_composition_plan(
+                proposal, candidates, context, registry
+            )
+        except CapabilityCompositionError as exc:
+            results.append(
+                P4EvaluationCaseResultV1(
+                    task_id=item.task_id,
+                    model_id=item.model_id,
+                    evidence_mode=evidence_mode,
+                    parse_succeeded=True,
+                    repaired=parsed.repaired,
+                    primary_error_code=parsed.primary_error_code,
+                    plan_succeeded=False,
+                    validation_result=None,
+                    validation_disposition=None,
+                    proposal_sha256=proposal.proposal_sha256,
+                    plan_sha256=None,
+                    validation_sha256=None,
+                    error_code=exc.code,
+                )
+            )
+            continue
+
+        validation = validate_capability_composition_plan(
+            plan,
+            proposal,
+            candidates,
+            context,
+            registry,
+            available_verifiers=available_verifiers,
+            validated_at_ms=validated_at_ms,
+        )
+        results.append(
+            P4EvaluationCaseResultV1(
+                task_id=item.task_id,
+                model_id=item.model_id,
+                evidence_mode=evidence_mode,
+                parse_succeeded=True,
+                repaired=parsed.repaired,
+                primary_error_code=parsed.primary_error_code,
+                plan_succeeded=True,
+                validation_result=validation.result,
+                validation_disposition=validation.unknown_disposition,
+                proposal_sha256=proposal.proposal_sha256,
+                plan_sha256=plan.plan_sha256,
+                validation_sha256=validation.validation_sha256,
+                error_code=None,
+            )
+        )
+
+    ordered_results = tuple(
+        sorted(results, key=lambda item: (item.model_id, item.task_id))
+    )
+    model_ids = tuple(sorted({item.model_id for item in ordered_results}))
+    report = P4EarlyEvaluationReportV1(
+        schema="tiangong.p4-early-evaluation.v1",
+        evidence_mode=evidence_mode,
+        cases=ordered_results,
+        model_metrics=tuple(
+            _metrics(model_id, ordered_results) for model_id in model_ids
+        ),
+        report_sha256="0" * 64,
+    )
+    return replace(report, report_sha256=report.computed_sha256())
+
+
+__all__ = [
+    "P4EarlyEvaluationReportV1",
+    "P4EvaluationCaseResultV1",
+    "P4EvaluationInputV1",
+    "P4ModelMetricsV1",
+    "run_p4_early_evaluation",
+]

--- a/src/world_understanding/capability_composition/models.py
+++ b/src/world_understanding/capability_composition/models.py
@@ -17,7 +17,10 @@ from contracts.capability_composition import (
     SourceRevisionRefV1,
     ToolSourcePrimitiveV1,
 )
-from world_understanding.skill_method_world import SkillMethodWorldSnapshotV1
+from world_understanding.skill_method_world import (
+    SkillMethodWorldSnapshotV1,
+    computed_skill_method_descriptor_sha256,
+)
 from world_understanding.tool_capability_world import ToolCapabilityWorldSnapshotV1
 
 
@@ -51,8 +54,76 @@ def _require_opaque(value: str, field: str) -> None:
         raise CapabilityCompositionError("composition.identity.invalid", field)
 
 
-def _primitive_payload(value: SkillSourcePrimitiveV1 | ToolSourcePrimitiveV1) -> dict[str, Any]:
+def _primitive_payload(
+    value: SkillSourcePrimitiveV1 | ToolSourcePrimitiveV1,
+) -> dict[str, Any]:
     return value.model_dump(mode="json")
+
+
+def _computed_tool_descriptor_sha256(
+    primitive: ToolSourcePrimitiveV1,
+) -> str:
+    return canonical_sha256(
+        primitive.model_dump(mode="json", exclude={"descriptor_sha256"})
+    )
+
+
+def _derived_action_source_revision(
+    primitive: ToolSourcePrimitiveV1,
+) -> SourceRevisionRefV1:
+    files = tuple(sorted({item.path for item in primitive.implementation_refs}))
+    if not files:
+        raise CapabilityCompositionError(
+            "candidate.action_source.empty", primitive.action_id
+        )
+    implementation_hashes = tuple(sorted(set(primitive.implementation_hashes)))
+    if not implementation_hashes:
+        raise CapabilityCompositionError(
+            "candidate.action_source.hash_empty", primitive.action_id
+        )
+    if any(_SHA256.fullmatch(value) is None for value in implementation_hashes):
+        raise CapabilityCompositionError(
+            "candidate.action_source.hash_invalid", primitive.action_id
+        )
+    if len(implementation_hashes) == 1:
+        source_sha256 = implementation_hashes[0]
+    else:
+        source_sha256 = canonical_sha256(
+            {
+                "domain": "tiangong.tool-source-revision-derived.v1",
+                "implementation_hashes": list(implementation_hashes),
+                "implementation_refs": [
+                    item.model_dump(mode="json")
+                    for item in sorted(
+                        primitive.implementation_refs,
+                        key=lambda item: (
+                            item.path,
+                            item.start_line or 0,
+                            item.end_line or 0,
+                        ),
+                    )
+                ],
+            }
+        )
+    return SourceRevisionRefV1(
+        source_kind="TOOL_ACTION",
+        semantic_id=primitive.action_id,
+        version=primitive.action_version,
+        source_files=files,
+        source_spans=tuple(
+            sorted(
+                primitive.implementation_refs,
+                key=lambda item: (
+                    item.path,
+                    item.start_line or 0,
+                    item.end_line or 0,
+                ),
+            )
+        ),
+        source_sha256=source_sha256,
+        descriptor_sha256=primitive.descriptor_sha256,
+        manifest_sha256=primitive.action_manifest_sha256,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,9 +146,12 @@ class MethodCandidateBindingV1:
             or self.primitive.source_ref.semantic_id != self.primitive.method_id
             or self.primitive.source_ref.version != self.primitive.version
             or self.primitive.source_ref.manifest_sha256 is not None
-            or self.primitive.source_sha256 != self.primitive.source_ref.source_sha256
+            or self.primitive.source_sha256
+            != self.primitive.source_ref.source_sha256
             or self.primitive.descriptor_sha256
             != self.primitive.source_ref.descriptor_sha256
+            or self.primitive.descriptor_sha256
+            != computed_skill_method_descriptor_sha256(self.primitive)
         ):
             raise CapabilityCompositionError(
                 "candidate.method_source.invalid", self.primitive.method_id
@@ -119,13 +193,9 @@ class ActionCandidateBindingV1:
         if self.may_authorize or self.may_execute:
             raise CapabilityCompositionError("candidate.action.authority_forbidden")
         if (
-            self.source_revision.source_kind != "TOOL_ACTION"
-            or self.source_revision.semantic_id != self.primitive.action_id
-            or self.source_revision.version != self.primitive.action_version
-            or self.source_revision.manifest_sha256
-            != self.primitive.action_manifest_sha256
-            or self.source_revision.descriptor_sha256
-            != self.primitive.descriptor_sha256
+            self.primitive.descriptor_sha256
+            != _computed_tool_descriptor_sha256(self.primitive)
+            or self.source_revision != _derived_action_source_revision(self.primitive)
         ):
             raise CapabilityCompositionError(
                 "candidate.action_source.invalid", self.primitive.action_id
@@ -173,14 +243,20 @@ class CompositionCandidateSnapshotV1:
 
         method_ids = tuple(item.candidate_id for item in self.method_candidates)
         action_ids = tuple(item.candidate_id for item in self.action_candidates)
+        expected_method_ids = tuple(
+            f"M{index:02d}" for index in range(1, len(method_ids) + 1)
+        )
+        expected_action_ids = tuple(
+            f"A{index:02d}" for index in range(1, len(action_ids) + 1)
+        )
         if (
-            method_ids != tuple(sorted(set(method_ids)))
+            method_ids != expected_method_ids
             or len(method_ids) > MAX_METHOD_CANDIDATES
         ):
             raise CapabilityCompositionError("candidate.method_set.invalid")
         if (
             not action_ids
-            or action_ids != tuple(sorted(set(action_ids)))
+            or action_ids != expected_action_ids
             or len(action_ids) > MAX_ACTION_CANDIDATES
         ):
             raise CapabilityCompositionError("candidate.action_set.invalid")
@@ -300,55 +376,7 @@ def derive_action_source_revision(
 ) -> SourceRevisionRefV1:
     """Derive a SourceRevisionRef from the already-validated P2 primitive."""
 
-    files = tuple(sorted({item.path for item in primitive.implementation_refs}))
-    if not files:
-        raise CapabilityCompositionError(
-            "candidate.action_source.empty", primitive.action_id
-        )
-    implementation_hashes = tuple(sorted(set(primitive.implementation_hashes)))
-    if not implementation_hashes:
-        raise CapabilityCompositionError(
-            "candidate.action_source.hash_empty", primitive.action_id
-        )
-    if len(implementation_hashes) == 1:
-        source_sha256 = implementation_hashes[0]
-    else:
-        source_sha256 = canonical_sha256(
-            {
-                "domain": "tiangong.tool-source-revision-derived.v1",
-                "implementation_hashes": list(implementation_hashes),
-                "implementation_refs": [
-                    item.model_dump(mode="json")
-                    for item in sorted(
-                        primitive.implementation_refs,
-                        key=lambda item: (
-                            item.path,
-                            item.start_line or 0,
-                            item.end_line or 0,
-                        ),
-                    )
-                ],
-            }
-        )
-    return SourceRevisionRefV1(
-        source_kind="TOOL_ACTION",
-        semantic_id=primitive.action_id,
-        version=primitive.action_version,
-        source_files=files,
-        source_spans=tuple(
-            sorted(
-                primitive.implementation_refs,
-                key=lambda item: (
-                    item.path,
-                    item.start_line or 0,
-                    item.end_line or 0,
-                ),
-            )
-        ),
-        source_sha256=source_sha256,
-        descriptor_sha256=primitive.descriptor_sha256,
-        manifest_sha256=primitive.action_manifest_sha256,
-    )
+    return _derived_action_source_revision(primitive)
 
 
 def _normalize_selection(
@@ -363,7 +391,9 @@ def _normalize_selection(
     else:
         raw = tuple(values)
         if len(raw) != len(set(raw)):
-            raise CapabilityCompositionError(f"candidate.{kind}.selection_duplicate")
+            raise CapabilityCompositionError(
+                f"candidate.{kind}.selection_duplicate"
+            )
         selected = tuple(sorted(raw))
     if len(selected) > limit:
         raise CapabilityCompositionError(f"candidate.{kind}.budget_exceeded")
@@ -375,6 +405,60 @@ def _normalize_selection(
     return selected
 
 
+def _validate_tool_world_integrity(
+    tool_world: ToolCapabilityWorldSnapshotV1,
+) -> None:
+    if not tool_world.has_valid_sha256():
+        raise CapabilityCompositionError("candidate.tool_world.hash_invalid")
+    if tool_world.may_authorize or tool_world.may_execute:
+        raise CapabilityCompositionError("candidate.tool_world.authority_forbidden")
+    if any(
+        primitive.action_manifest_sha256 != tool_world.source_manifest_sha256
+        or primitive.descriptor_sha256
+        != _computed_tool_descriptor_sha256(primitive)
+        for primitive in tool_world.primitives
+    ):
+        raise CapabilityCompositionError("candidate.tool_world.primitive_invalid")
+
+
+def _validate_method_world_integrity(
+    method_world: SkillMethodWorldSnapshotV1,
+) -> None:
+    if not method_world.has_valid_sha256():
+        raise CapabilityCompositionError("candidate.method_world.hash_invalid")
+    if method_world.may_authorize or method_world.may_execute:
+        raise CapabilityCompositionError(
+            "candidate.method_world.authority_forbidden"
+        )
+    if any(
+        not binding.has_valid_sha256()
+        for binding in method_world.migration_bindings
+    ):
+        raise CapabilityCompositionError(
+            "candidate.method_world.binding_invalid"
+        )
+    expected_sources_sha256 = canonical_sha256(
+        {
+            "domain": "tiangong.skill-method-sources.v1",
+            "primitives": [
+                item.model_dump(mode="json")
+                for item in method_world.primitives
+            ],
+        }
+    )
+    if (
+        method_world.method_sources_sha256 != expected_sources_sha256
+        or any(
+            primitive.descriptor_sha256
+            != computed_skill_method_descriptor_sha256(primitive)
+            for primitive in method_world.primitives
+        )
+    ):
+        raise CapabilityCompositionError(
+            "candidate.method_world.primitive_invalid"
+        )
+
+
 def build_candidate_snapshot(
     tool_world: ToolCapabilityWorldSnapshotV1,
     method_world: SkillMethodWorldSnapshotV1,
@@ -384,14 +468,8 @@ def build_candidate_snapshot(
 ) -> CompositionCandidateSnapshotV1:
     """Bind a bounded candidate set from P2/P3 read-only world projections."""
 
-    if not tool_world.has_valid_sha256():
-        raise CapabilityCompositionError("candidate.tool_world.hash_invalid")
-    if not method_world.has_valid_sha256():
-        raise CapabilityCompositionError("candidate.method_world.hash_invalid")
-    if tool_world.may_authorize or tool_world.may_execute:
-        raise CapabilityCompositionError("candidate.tool_world.authority_forbidden")
-    if method_world.may_authorize or method_world.may_execute:
-        raise CapabilityCompositionError("candidate.method_world.authority_forbidden")
+    _validate_tool_world_integrity(tool_world)
+    _validate_method_world_integrity(method_world)
 
     methods_by_id = {item.method_id: item for item in method_world.primitives}
     actions_by_id = {item.action_id: item for item in tool_world.primitives}
@@ -459,10 +537,12 @@ def validate_registry_binding(
             or permission.source_manifest_sha256
             != item.primitive.action_manifest_sha256
             or permission.effective_risk != item.primitive.risk_floor
-            or permission.effect != item.primitive.effect_class.removeprefix("effect:")
+            or permission.effect
+            != item.primitive.effect_class.removeprefix("effect:")
         ):
             raise CapabilityCompositionError(
-                "candidate.registry.binding_mismatch", item.primitive.action_id
+                "candidate.registry.binding_mismatch",
+                item.primitive.action_id,
             )
 
 

--- a/src/world_understanding/capability_composition/models.py
+++ b/src/world_understanding/capability_composition/models.py
@@ -1,0 +1,480 @@
+"""Immutable candidate and compile-context records for P4.
+
+These records are non-authorizing projections used by the proposal parser,
+composition compiler, and conservative validator. They do not route, execute,
+grant, ticket, persist, or mutate WorldState.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import re
+from typing import Any, Iterable
+
+from contracts import ActionRegistrySnapshot, canonical_sha256
+from contracts.capability_composition import (
+    SkillSourcePrimitiveV1,
+    SourceRevisionRefV1,
+    ToolSourcePrimitiveV1,
+)
+from world_understanding.skill_method_world import SkillMethodWorldSnapshotV1
+from world_understanding.tool_capability_world import ToolCapabilityWorldSnapshotV1
+
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,159}$")
+_REQUEST_ID = re.compile(r"^req_[0-9a-f]{64}$")
+_RUN_ID = re.compile(r"^run_[0-9a-f]{64}$")
+_METHOD_CANDIDATE_ID = re.compile(r"^M[0-9]{2}$")
+_ACTION_CANDIDATE_ID = re.compile(r"^A[0-9]{2}$")
+
+MAX_METHOD_CANDIDATES = 15
+MAX_ACTION_CANDIDATES = 30
+
+
+class CapabilityCompositionError(ValueError):
+    """Base error for deterministic P4 composition processing."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(code if not detail else f"{code}: {detail}")
+
+
+def _require_sha256(value: str, field: str) -> None:
+    if _SHA256.fullmatch(value) is None:
+        raise CapabilityCompositionError("composition.hash.invalid", field)
+
+
+def _require_opaque(value: str, field: str) -> None:
+    if _OPAQUE_ID.fullmatch(value) is None:
+        raise CapabilityCompositionError("composition.identity.invalid", field)
+
+
+def _primitive_payload(value: SkillSourcePrimitiveV1 | ToolSourcePrimitiveV1) -> dict[str, Any]:
+    return value.model_dump(mode="json")
+
+
+@dataclass(frozen=True, slots=True)
+class MethodCandidateBindingV1:
+    candidate_id: str
+    primitive: SkillSourcePrimitiveV1
+    binding_sha256: str
+    may_authorize: bool = False
+    may_execute: bool = False
+
+    def __post_init__(self) -> None:
+        if _METHOD_CANDIDATE_ID.fullmatch(self.candidate_id) is None:
+            raise CapabilityCompositionError(
+                "candidate.method_id.invalid", self.candidate_id
+            )
+        if self.may_authorize or self.may_execute:
+            raise CapabilityCompositionError("candidate.method.authority_forbidden")
+        if (
+            self.primitive.source_ref.source_kind != "SKILL_METHOD"
+            or self.primitive.source_ref.semantic_id != self.primitive.method_id
+            or self.primitive.source_ref.version != self.primitive.version
+            or self.primitive.source_ref.manifest_sha256 is not None
+            or self.primitive.source_sha256 != self.primitive.source_ref.source_sha256
+            or self.primitive.descriptor_sha256
+            != self.primitive.source_ref.descriptor_sha256
+        ):
+            raise CapabilityCompositionError(
+                "candidate.method_source.invalid", self.primitive.method_id
+            )
+        _require_sha256(self.binding_sha256, "method candidate binding")
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "primitive": _primitive_payload(self.primitive),
+            "may_authorize": self.may_authorize,
+            "may_execute": self.may_execute,
+        }
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.binding_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "MethodCandidateBindingV1":
+        return replace(self, binding_sha256=self.computed_sha256())
+
+
+@dataclass(frozen=True, slots=True)
+class ActionCandidateBindingV1:
+    candidate_id: str
+    primitive: ToolSourcePrimitiveV1
+    source_revision: SourceRevisionRefV1
+    binding_sha256: str
+    may_authorize: bool = False
+    may_execute: bool = False
+
+    def __post_init__(self) -> None:
+        if _ACTION_CANDIDATE_ID.fullmatch(self.candidate_id) is None:
+            raise CapabilityCompositionError(
+                "candidate.action_id.invalid", self.candidate_id
+            )
+        if self.may_authorize or self.may_execute:
+            raise CapabilityCompositionError("candidate.action.authority_forbidden")
+        if (
+            self.source_revision.source_kind != "TOOL_ACTION"
+            or self.source_revision.semantic_id != self.primitive.action_id
+            or self.source_revision.version != self.primitive.action_version
+            or self.source_revision.manifest_sha256
+            != self.primitive.action_manifest_sha256
+            or self.source_revision.descriptor_sha256
+            != self.primitive.descriptor_sha256
+        ):
+            raise CapabilityCompositionError(
+                "candidate.action_source.invalid", self.primitive.action_id
+            )
+        _require_sha256(self.binding_sha256, "action candidate binding")
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "primitive": _primitive_payload(self.primitive),
+            "source_revision": self.source_revision.model_dump(mode="json"),
+            "may_authorize": self.may_authorize,
+            "may_execute": self.may_execute,
+        }
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.binding_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "ActionCandidateBindingV1":
+        return replace(self, binding_sha256=self.computed_sha256())
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionCandidateSnapshotV1:
+    schema: str
+    tool_world_sha256: str
+    method_world_sha256: str
+    method_candidates: tuple[MethodCandidateBindingV1, ...]
+    action_candidates: tuple[ActionCandidateBindingV1, ...]
+    candidate_snapshot_sha256: str
+    may_authorize: bool = False
+    may_execute: bool = False
+
+    def __post_init__(self) -> None:
+        if self.schema != "tiangong.composition-candidates.v1":
+            raise CapabilityCompositionError("candidate.snapshot.schema.invalid")
+        if self.may_authorize or self.may_execute:
+            raise CapabilityCompositionError("candidate.snapshot.authority_forbidden")
+        _require_sha256(self.tool_world_sha256, "tool world")
+        _require_sha256(self.method_world_sha256, "method world")
+        _require_sha256(self.candidate_snapshot_sha256, "candidate snapshot")
+
+        method_ids = tuple(item.candidate_id for item in self.method_candidates)
+        action_ids = tuple(item.candidate_id for item in self.action_candidates)
+        if (
+            method_ids != tuple(sorted(set(method_ids)))
+            or len(method_ids) > MAX_METHOD_CANDIDATES
+        ):
+            raise CapabilityCompositionError("candidate.method_set.invalid")
+        if (
+            not action_ids
+            or action_ids != tuple(sorted(set(action_ids)))
+            or len(action_ids) > MAX_ACTION_CANDIDATES
+        ):
+            raise CapabilityCompositionError("candidate.action_set.invalid")
+        if any(not item.has_valid_sha256() for item in self.method_candidates):
+            raise CapabilityCompositionError("candidate.method_binding.hash_invalid")
+        if any(not item.has_valid_sha256() for item in self.action_candidates):
+            raise CapabilityCompositionError("candidate.action_binding.hash_invalid")
+        method_semantic_ids = tuple(
+            item.primitive.method_id for item in self.method_candidates
+        )
+        action_semantic_ids = tuple(
+            item.primitive.action_id for item in self.action_candidates
+        )
+        if len(method_semantic_ids) != len(set(method_semantic_ids)):
+            raise CapabilityCompositionError("candidate.method_semantic.duplicate")
+        if len(action_semantic_ids) != len(set(action_semantic_ids)):
+            raise CapabilityCompositionError("candidate.action_semantic.duplicate")
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "tool_world_sha256": self.tool_world_sha256,
+            "method_world_sha256": self.method_world_sha256,
+            "may_authorize": self.may_authorize,
+            "may_execute": self.may_execute,
+            "method_candidates": [
+                {**item.payload(), "binding_sha256": item.binding_sha256}
+                for item in self.method_candidates
+            ],
+            "action_candidates": [
+                {**item.payload(), "binding_sha256": item.binding_sha256}
+                for item in self.action_candidates
+            ],
+        }
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.candidate_snapshot_sha256 == self.computed_sha256()
+
+    def method_by_candidate(self) -> dict[str, MethodCandidateBindingV1]:
+        return {item.candidate_id: item for item in self.method_candidates}
+
+    def action_by_candidate(self) -> dict[str, ActionCandidateBindingV1]:
+        return {item.candidate_id: item for item in self.action_candidates}
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionCompileContextV1:
+    schema: str
+    request_id: str
+    run_id: str
+    generation: int
+    principal_scope_hash: str
+    world_state_ref: str
+    world_state_sha256: str
+    goal_ref: str
+    goal_fingerprint: str
+    environment_class: str
+    context_fingerprint_sha256: str
+    capability_manifest_sha256: str
+    created_at_ms: int
+    context_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.schema != "tiangong.composition-compile-context.v1":
+            raise CapabilityCompositionError("compile_context.schema.invalid")
+        if _REQUEST_ID.fullmatch(self.request_id) is None:
+            raise CapabilityCompositionError("compile_context.request_id.invalid")
+        if _RUN_ID.fullmatch(self.run_id) is None:
+            raise CapabilityCompositionError("compile_context.run_id.invalid")
+        if self.generation < 0 or self.created_at_ms < 0:
+            raise CapabilityCompositionError("compile_context.counter.invalid")
+        _require_opaque(self.world_state_ref, "world_state_ref")
+        _require_opaque(self.goal_ref, "goal_ref")
+        _require_opaque(self.environment_class, "environment_class")
+        for field, value in (
+            ("principal_scope_hash", self.principal_scope_hash),
+            ("world_state_sha256", self.world_state_sha256),
+            ("goal_fingerprint", self.goal_fingerprint),
+            ("context_fingerprint_sha256", self.context_fingerprint_sha256),
+            ("capability_manifest_sha256", self.capability_manifest_sha256),
+            ("context_sha256", self.context_sha256),
+        ):
+            _require_sha256(value, field)
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "request_id": self.request_id,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "principal_scope_hash": self.principal_scope_hash,
+            "world_state_ref": self.world_state_ref,
+            "world_state_sha256": self.world_state_sha256,
+            "goal_ref": self.goal_ref,
+            "goal_fingerprint": self.goal_fingerprint,
+            "environment_class": self.environment_class,
+            "context_fingerprint_sha256": self.context_fingerprint_sha256,
+            "capability_manifest_sha256": self.capability_manifest_sha256,
+            "created_at_ms": self.created_at_ms,
+        }
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.context_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "CompositionCompileContextV1":
+        return replace(self, context_sha256=self.computed_sha256())
+
+
+def derive_action_source_revision(
+    primitive: ToolSourcePrimitiveV1,
+) -> SourceRevisionRefV1:
+    """Derive a SourceRevisionRef from the already-validated P2 primitive."""
+
+    files = tuple(sorted({item.path for item in primitive.implementation_refs}))
+    if not files:
+        raise CapabilityCompositionError(
+            "candidate.action_source.empty", primitive.action_id
+        )
+    implementation_hashes = tuple(sorted(set(primitive.implementation_hashes)))
+    if not implementation_hashes:
+        raise CapabilityCompositionError(
+            "candidate.action_source.hash_empty", primitive.action_id
+        )
+    if len(implementation_hashes) == 1:
+        source_sha256 = implementation_hashes[0]
+    else:
+        source_sha256 = canonical_sha256(
+            {
+                "domain": "tiangong.tool-source-revision-derived.v1",
+                "implementation_hashes": list(implementation_hashes),
+                "implementation_refs": [
+                    item.model_dump(mode="json")
+                    for item in sorted(
+                        primitive.implementation_refs,
+                        key=lambda item: (
+                            item.path,
+                            item.start_line or 0,
+                            item.end_line or 0,
+                        ),
+                    )
+                ],
+            }
+        )
+    return SourceRevisionRefV1(
+        source_kind="TOOL_ACTION",
+        semantic_id=primitive.action_id,
+        version=primitive.action_version,
+        source_files=files,
+        source_spans=tuple(
+            sorted(
+                primitive.implementation_refs,
+                key=lambda item: (
+                    item.path,
+                    item.start_line or 0,
+                    item.end_line or 0,
+                ),
+            )
+        ),
+        source_sha256=source_sha256,
+        descriptor_sha256=primitive.descriptor_sha256,
+        manifest_sha256=primitive.action_manifest_sha256,
+    )
+
+
+def _normalize_selection(
+    values: Iterable[str] | None,
+    *,
+    available: set[str],
+    limit: int,
+    kind: str,
+) -> tuple[str, ...]:
+    if values is None:
+        selected = tuple(sorted(available))
+    else:
+        raw = tuple(values)
+        if len(raw) != len(set(raw)):
+            raise CapabilityCompositionError(f"candidate.{kind}.selection_duplicate")
+        selected = tuple(sorted(raw))
+    if len(selected) > limit:
+        raise CapabilityCompositionError(f"candidate.{kind}.budget_exceeded")
+    missing = tuple(value for value in selected if value not in available)
+    if missing:
+        raise CapabilityCompositionError(
+            f"candidate.{kind}.selection_missing", ",".join(missing)
+        )
+    return selected
+
+
+def build_candidate_snapshot(
+    tool_world: ToolCapabilityWorldSnapshotV1,
+    method_world: SkillMethodWorldSnapshotV1,
+    *,
+    method_ids: Iterable[str] | None = None,
+    action_ids: Iterable[str] | None = None,
+) -> CompositionCandidateSnapshotV1:
+    """Bind a bounded candidate set from P2/P3 read-only world projections."""
+
+    if not tool_world.has_valid_sha256():
+        raise CapabilityCompositionError("candidate.tool_world.hash_invalid")
+    if not method_world.has_valid_sha256():
+        raise CapabilityCompositionError("candidate.method_world.hash_invalid")
+    if tool_world.may_authorize or tool_world.may_execute:
+        raise CapabilityCompositionError("candidate.tool_world.authority_forbidden")
+    if method_world.may_authorize or method_world.may_execute:
+        raise CapabilityCompositionError("candidate.method_world.authority_forbidden")
+
+    methods_by_id = {item.method_id: item for item in method_world.primitives}
+    actions_by_id = {item.action_id: item for item in tool_world.primitives}
+    selected_methods = _normalize_selection(
+        method_ids,
+        available=set(methods_by_id),
+        limit=MAX_METHOD_CANDIDATES,
+        kind="method",
+    )
+    selected_actions = _normalize_selection(
+        action_ids,
+        available=set(actions_by_id),
+        limit=MAX_ACTION_CANDIDATES,
+        kind="action",
+    )
+    if not selected_actions:
+        raise CapabilityCompositionError("candidate.action.selection_empty")
+
+    method_bindings = tuple(
+        MethodCandidateBindingV1(
+            candidate_id=f"M{index:02d}",
+            primitive=methods_by_id[method_id],
+            binding_sha256="0" * 64,
+        ).with_computed_sha256()
+        for index, method_id in enumerate(selected_methods, start=1)
+    )
+    action_bindings = tuple(
+        ActionCandidateBindingV1(
+            candidate_id=f"A{index:02d}",
+            primitive=actions_by_id[action_id],
+            source_revision=derive_action_source_revision(actions_by_id[action_id]),
+            binding_sha256="0" * 64,
+        ).with_computed_sha256()
+        for index, action_id in enumerate(selected_actions, start=1)
+    )
+    snapshot = CompositionCandidateSnapshotV1(
+        schema="tiangong.composition-candidates.v1",
+        tool_world_sha256=tool_world.snapshot_sha256,
+        method_world_sha256=method_world.snapshot_sha256,
+        method_candidates=method_bindings,
+        action_candidates=action_bindings,
+        candidate_snapshot_sha256="0" * 64,
+    )
+    return replace(
+        snapshot, candidate_snapshot_sha256=snapshot.computed_sha256()
+    )
+
+
+def validate_registry_binding(
+    snapshot: CompositionCandidateSnapshotV1,
+    registry: ActionRegistrySnapshot,
+) -> None:
+    """Check candidate action identity against the existing Action Registry."""
+
+    if not snapshot.has_valid_sha256():
+        raise CapabilityCompositionError("candidate.snapshot.hash_invalid")
+    if not registry.has_valid_sha256():
+        raise CapabilityCompositionError("candidate.registry.hash_invalid")
+    permissions = {item.action_id: item for item in registry.permissions}
+    for item in snapshot.action_candidates:
+        permission = permissions.get(item.primitive.action_id)
+        if (
+            permission is None
+            or permission.action_version != item.primitive.action_version
+            or permission.source_manifest_sha256
+            != item.primitive.action_manifest_sha256
+            or permission.effective_risk != item.primitive.risk_floor
+            or permission.effect != item.primitive.effect_class.removeprefix("effect:")
+        ):
+            raise CapabilityCompositionError(
+                "candidate.registry.binding_mismatch", item.primitive.action_id
+            )
+
+
+__all__ = [
+    "ActionCandidateBindingV1",
+    "CapabilityCompositionError",
+    "CompositionCandidateSnapshotV1",
+    "CompositionCompileContextV1",
+    "MAX_ACTION_CANDIDATES",
+    "MAX_METHOD_CANDIDATES",
+    "MethodCandidateBindingV1",
+    "build_candidate_snapshot",
+    "derive_action_source_revision",
+    "validate_registry_binding",
+]

--- a/src/world_understanding/capability_composition/models.py
+++ b/src/world_understanding/capability_composition/models.py
@@ -1,9 +1,4 @@
-"""Immutable candidate and compile-context records for P4.
-
-These records are non-authorizing projections used by the proposal parser,
-composition compiler, and conservative validator. They do not route, execute,
-grant, ticket, persist, or mutate WorldState.
-"""
+"""Immutable, non-authorizing candidate and compile-context records for P4."""
 
 from __future__ import annotations
 
@@ -36,8 +31,6 @@ MAX_ACTION_CANDIDATES = 30
 
 
 class CapabilityCompositionError(ValueError):
-    """Base error for deterministic P4 composition processing."""
-
     def __init__(self, code: str, detail: str = "") -> None:
         self.code = code
         self.detail = detail
@@ -85,10 +78,10 @@ def _derived_action_source_revision(
         raise CapabilityCompositionError(
             "candidate.action_source.hash_invalid", primitive.action_id
         )
-    if len(implementation_hashes) == 1:
-        source_sha256 = implementation_hashes[0]
-    else:
-        source_sha256 = canonical_sha256(
+    source_sha256 = (
+        implementation_hashes[0]
+        if len(implementation_hashes) == 1
+        else canonical_sha256(
             {
                 "domain": "tiangong.tool-source-revision-derived.v1",
                 "implementation_hashes": list(implementation_hashes),
@@ -105,6 +98,7 @@ def _derived_action_source_revision(
                 ],
             }
         )
+    )
     return SourceRevisionRefV1(
         source_kind="TOOL_ACTION",
         semantic_id=primitive.action_id,
@@ -374,8 +368,6 @@ class CompositionCompileContextV1:
 def derive_action_source_revision(
     primitive: ToolSourcePrimitiveV1,
 ) -> SourceRevisionRefV1:
-    """Derive a SourceRevisionRef from the already-validated P2 primitive."""
-
     return _derived_action_source_revision(primitive)
 
 
@@ -437,22 +429,13 @@ def _validate_method_world_integrity(
         raise CapabilityCompositionError(
             "candidate.method_world.binding_invalid"
         )
-    expected_sources_sha256 = canonical_sha256(
-        {
-            "domain": "tiangong.skill-method-sources.v1",
-            "primitives": [
-                item.model_dump(mode="json")
-                for item in method_world.primitives
-            ],
-        }
-    )
-    if (
-        method_world.method_sources_sha256 != expected_sources_sha256
-        or any(
-            primitive.descriptor_sha256
-            != computed_skill_method_descriptor_sha256(primitive)
-            for primitive in method_world.primitives
-        )
+    # P3 owns the aggregate method_sources_sha256 derivation. P4 revalidates
+    # each selected descriptor and migration binding without becoming a second
+    # P3 compiler authority.
+    if any(
+        primitive.descriptor_sha256
+        != computed_skill_method_descriptor_sha256(primitive)
+        for primitive in method_world.primitives
     ):
         raise CapabilityCompositionError(
             "candidate.method_world.primitive_invalid"
@@ -522,8 +505,6 @@ def validate_registry_binding(
     snapshot: CompositionCandidateSnapshotV1,
     registry: ActionRegistrySnapshot,
 ) -> None:
-    """Check candidate action identity against the existing Action Registry."""
-
     if not snapshot.has_valid_sha256():
         raise CapabilityCompositionError("candidate.snapshot.hash_invalid")
     if not registry.has_valid_sha256():

--- a/src/world_understanding/capability_composition/parser.py
+++ b/src/world_understanding/capability_composition/parser.py
@@ -1,0 +1,443 @@
+"""Strict JSON/DSL parser for the small model-authored CompositionProposal ABI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping
+
+from pydantic import ValidationError
+
+from contracts import canonical_sha256
+from contracts.capability_composition import (
+    CompositionProposalV1,
+    ProposalStepV1,
+)
+
+from .models import (
+    CapabilityCompositionError,
+    CompositionCandidateSnapshotV1,
+)
+
+
+_RAW_SCHEMA = "tiangong.composition-proposal.v1"
+_RAW_ROOT_FIELDS = {
+    "proposal_schema",
+    "goal_ref",
+    "selected_method_candidate_ids",
+    "selected_action_candidate_ids",
+    "steps",
+    "dependency_edges",
+    "output_bindings",
+    "control_flow",
+    "rationale_tags",
+}
+_RAW_STEP_FIELDS = {
+    "step_id",
+    "candidate_id",
+    "depends_on",
+    "output_bindings",
+}
+
+
+class CompositionProposalParseError(CapabilityCompositionError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ProposalParseOutcomeV1:
+    proposal: CompositionProposalV1
+    repaired: bool
+    primary_error_code: str | None
+
+
+def computed_proposal_sha256(proposal: CompositionProposalV1) -> str:
+    return canonical_sha256(
+        proposal.model_dump(mode="json", exclude={"proposal_sha256"})
+    )
+
+
+def proposal_has_valid_sha256(proposal: CompositionProposalV1) -> bool:
+    return proposal.proposal_sha256 == computed_proposal_sha256(proposal)
+
+
+def _strict_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CompositionProposalParseError(
+                "proposal.json.duplicate_key", key
+            )
+        result[key] = value
+    return result
+
+
+def _reject_number(value: str) -> None:
+    raise CompositionProposalParseError("proposal.json.number_forbidden", value)
+
+
+def _parse_json(text: str) -> Mapping[str, Any]:
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_strict_pairs,
+            parse_float=_reject_number,
+            parse_int=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except CompositionProposalParseError:
+        raise
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise CompositionProposalParseError(
+            "proposal.json.invalid", str(exc)
+        ) from exc
+    if not isinstance(value, Mapping):
+        raise CompositionProposalParseError("proposal.json.root_not_object")
+    return value
+
+
+def _csv(value: str) -> list[str]:
+    stripped = value.strip()
+    if stripped in {"", "-"}:
+        return []
+    parts = [item.strip() for item in stripped.split(",")]
+    if any(not item for item in parts):
+        raise CompositionProposalParseError("proposal.dsl.empty_list_item")
+    return parts
+
+
+def _parse_dsl(text: str) -> Mapping[str, Any]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines or lines[-1] != "END":
+        raise CompositionProposalParseError("proposal.dsl.missing_end")
+    if len(lines) > 256:
+        raise CompositionProposalParseError("proposal.dsl.too_many_lines")
+
+    singleton: dict[str, str] = {}
+    steps: list[dict[str, Any]] = []
+    edges: list[list[str]] = []
+    for line in lines[:-1]:
+        key, separator, remainder = line.partition(" ")
+        if not separator:
+            raise CompositionProposalParseError(
+                "proposal.dsl.line_invalid", line[:120]
+            )
+        key = key.upper()
+        value = remainder.strip()
+        if key == "STEP":
+            parts = [item.strip() for item in value.split("|")]
+            if len(parts) != 4 or not parts[0] or not parts[1]:
+                raise CompositionProposalParseError(
+                    "proposal.dsl.step_invalid", value[:120]
+                )
+            steps.append(
+                {
+                    "step_id": parts[0],
+                    "candidate_id": parts[1],
+                    "depends_on": _csv(parts[2]),
+                    "output_bindings": _csv(parts[3]),
+                }
+            )
+        elif key == "EDGE":
+            left, marker, right = value.partition(">")
+            left = left.strip()
+            right = right.strip()
+            if marker != ">" or not left or not right:
+                raise CompositionProposalParseError(
+                    "proposal.dsl.edge_invalid", value[:120]
+                )
+            edges.append([left, right])
+        elif key in {
+            "PROPOSAL",
+            "GOAL",
+            "METHODS",
+            "ACTIONS",
+            "OUTPUTS",
+            "FLOW",
+            "TAGS",
+        }:
+            if key in singleton:
+                raise CompositionProposalParseError(
+                    "proposal.dsl.duplicate_field", key
+                )
+            singleton[key] = value
+        else:
+            raise CompositionProposalParseError(
+                "proposal.dsl.unknown_line", key
+            )
+
+    required = {"PROPOSAL", "GOAL", "METHODS", "ACTIONS", "OUTPUTS", "FLOW", "TAGS"}
+    if set(singleton) != required:
+        missing = ",".join(sorted(required - set(singleton)))
+        extra = ",".join(sorted(set(singleton) - required))
+        raise CompositionProposalParseError(
+            "proposal.dsl.fields_incomplete", f"missing={missing};extra={extra}"
+        )
+    return {
+        "proposal_schema": singleton["PROPOSAL"],
+        "goal_ref": singleton["GOAL"],
+        "selected_method_candidate_ids": _csv(singleton["METHODS"]),
+        "selected_action_candidate_ids": _csv(singleton["ACTIONS"]),
+        "steps": steps,
+        "dependency_edges": edges,
+        "output_bindings": _csv(singleton["OUTPUTS"]),
+        "control_flow": singleton["FLOW"],
+        "rationale_tags": _csv(singleton["TAGS"]),
+    }
+
+
+def _string_list(value: object, *, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise CompositionProposalParseError(
+            "proposal.field.string_list_invalid", field
+        )
+    if len(value) != len(set(value)):
+        raise CompositionProposalParseError(
+            "proposal.field.duplicate_value", field
+        )
+    return tuple(sorted(value))
+
+
+def _steps(value: object) -> tuple[ProposalStepV1, ...]:
+    if not isinstance(value, list) or not value or len(value) > 128:
+        raise CompositionProposalParseError("proposal.steps.invalid")
+    result: list[ProposalStepV1] = []
+    seen: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, Mapping) or set(raw) != _RAW_STEP_FIELDS:
+            raise CompositionProposalParseError(
+                "proposal.step.fields_invalid"
+            )
+        step_id = raw.get("step_id")
+        candidate_id = raw.get("candidate_id")
+        if (
+            not isinstance(step_id, str)
+            or not step_id
+            or not isinstance(candidate_id, str)
+            or not candidate_id
+            or step_id in seen
+        ):
+            raise CompositionProposalParseError(
+                "proposal.step.identity_invalid"
+            )
+        seen.add(step_id)
+        result.append(
+            ProposalStepV1(
+                step_id=step_id,
+                candidate_id=candidate_id,
+                depends_on=_string_list(
+                    raw.get("depends_on"), field=f"{step_id}.depends_on"
+                ),
+                output_bindings=_string_list(
+                    raw.get("output_bindings"),
+                    field=f"{step_id}.output_bindings",
+                ),
+            )
+        )
+    return tuple(result)
+
+
+def _edges(value: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, list) or len(value) > 512:
+        raise CompositionProposalParseError("proposal.edges.invalid")
+    result: list[tuple[str, str]] = []
+    for item in value:
+        if (
+            not isinstance(item, list)
+            or len(item) != 2
+            or any(not isinstance(part, str) or not part for part in item)
+        ):
+            raise CompositionProposalParseError(
+                "proposal.edge.invalid"
+            )
+        result.append((item[0], item[1]))
+    if len(result) != len(set(result)):
+        raise CompositionProposalParseError(
+            "proposal.edge.duplicate"
+        )
+    return tuple(sorted(result))
+
+
+def _validate_candidate_and_graph_bindings(
+    *,
+    proposal: CompositionProposalV1,
+    candidates: CompositionCandidateSnapshotV1,
+) -> None:
+    if not candidates.has_valid_sha256():
+        raise CompositionProposalParseError(
+            "proposal.candidate_snapshot.hash_invalid"
+        )
+    methods = candidates.method_by_candidate()
+    actions = candidates.action_by_candidate()
+    selected_methods = set(proposal.selected_method_candidate_ids)
+    selected_actions = set(proposal.selected_action_candidate_ids)
+    if not selected_methods.issubset(methods):
+        unknown = sorted(selected_methods - set(methods))
+        raise CompositionProposalParseError(
+            "proposal.method_candidate.unknown", ",".join(unknown)
+        )
+    if not selected_actions or not selected_actions.issubset(actions):
+        unknown = sorted(selected_actions - set(actions))
+        raise CompositionProposalParseError(
+            "proposal.action_candidate.unknown",
+            ",".join(unknown) if unknown else "empty",
+        )
+
+    step_ids = {step.step_id for step in proposal.steps}
+    used_actions = {step.candidate_id for step in proposal.steps}
+    if used_actions != selected_actions:
+        raise CompositionProposalParseError(
+            "proposal.action_selection.step_mismatch"
+        )
+    if not used_actions.issubset(actions):
+        raise CompositionProposalParseError(
+            "proposal.step.candidate_not_action"
+        )
+    for step in proposal.steps:
+        dependencies = set(step.depends_on)
+        if step.step_id in dependencies or not dependencies.issubset(step_ids):
+            raise CompositionProposalParseError(
+                "proposal.step.dependency_invalid", step.step_id
+            )
+
+    derived_edges = tuple(
+        sorted(
+            (dependency, step.step_id)
+            for step in proposal.steps
+            for dependency in step.depends_on
+        )
+    )
+    if proposal.control_flow == "SEQUENTIAL":
+        expected_edges: list[tuple[str, str]] = []
+        for index, step in enumerate(proposal.steps):
+            expected = () if index == 0 else (proposal.steps[index - 1].step_id,)
+            if step.depends_on != expected:
+                raise CompositionProposalParseError(
+                    "proposal.sequential.dependency_invalid", step.step_id
+                )
+            if index:
+                expected_edges.append((proposal.steps[index - 1].step_id, step.step_id))
+        if proposal.dependency_edges != tuple(sorted(expected_edges)):
+            raise CompositionProposalParseError(
+                "proposal.sequential.edges_invalid"
+            )
+    elif proposal.control_flow == "DAG":
+        if proposal.dependency_edges != derived_edges:
+            raise CompositionProposalParseError(
+                "proposal.dag.edges_mismatch"
+            )
+    else:
+        raise CompositionProposalParseError(
+            "proposal.control_flow.invalid"
+        )
+
+
+def _build_proposal(
+    raw: Mapping[str, Any],
+    candidates: CompositionCandidateSnapshotV1,
+) -> CompositionProposalV1:
+    if set(raw) != _RAW_ROOT_FIELDS:
+        missing = ",".join(sorted(_RAW_ROOT_FIELDS - set(raw)))
+        extra = ",".join(sorted(set(raw) - _RAW_ROOT_FIELDS))
+        raise CompositionProposalParseError(
+            "proposal.fields.invalid", f"missing={missing};extra={extra}"
+        )
+    if raw.get("proposal_schema") != _RAW_SCHEMA:
+        raise CompositionProposalParseError("proposal.schema.invalid")
+    goal_ref = raw.get("goal_ref")
+    control_flow = raw.get("control_flow")
+    if not isinstance(goal_ref, str) or not goal_ref:
+        raise CompositionProposalParseError("proposal.goal_ref.invalid")
+    if control_flow not in {"SEQUENTIAL", "DAG"}:
+        raise CompositionProposalParseError("proposal.control_flow.invalid")
+
+    try:
+        proposal = CompositionProposalV1(
+            goal_ref=goal_ref,
+            selected_method_candidate_ids=_string_list(
+                raw.get("selected_method_candidate_ids"),
+                field="selected_method_candidate_ids",
+            ),
+            selected_action_candidate_ids=_string_list(
+                raw.get("selected_action_candidate_ids"),
+                field="selected_action_candidate_ids",
+            ),
+            steps=_steps(raw.get("steps")),
+            dependency_edges=_edges(raw.get("dependency_edges")),
+            output_bindings=_string_list(
+                raw.get("output_bindings"), field="output_bindings"
+            ),
+            control_flow=control_flow,
+            rationale_tags=_string_list(
+                raw.get("rationale_tags"), field="rationale_tags"
+            ),
+            proposal_sha256="0" * 64,
+        )
+    except ValidationError as exc:
+        raise CompositionProposalParseError(
+            "proposal.contract.invalid", str(exc)
+        ) from exc
+    proposal = proposal.model_copy(
+        update={"proposal_sha256": computed_proposal_sha256(proposal)}
+    )
+    _validate_candidate_and_graph_bindings(
+        proposal=proposal, candidates=candidates
+    )
+    return proposal
+
+
+def parse_composition_proposal(
+    text: str,
+    candidates: CompositionCandidateSnapshotV1,
+) -> CompositionProposalV1:
+    """Parse one strict model proposal without any implicit retry."""
+
+    if not isinstance(text, str) or not text.strip() or len(text.encode("utf-8")) > 65_536:
+        raise CompositionProposalParseError("proposal.text.invalid")
+    stripped = text.strip()
+    raw = _parse_json(stripped) if stripped.startswith("{") else _parse_dsl(stripped)
+    return _build_proposal(raw, candidates)
+
+
+def parse_with_single_repair(
+    primary_text: str,
+    candidates: CompositionCandidateSnapshotV1,
+    *,
+    repair_text: str | None = None,
+) -> ProposalParseOutcomeV1:
+    """Allow at most one externally-produced repair proposal."""
+
+    try:
+        proposal = parse_composition_proposal(primary_text, candidates)
+        return ProposalParseOutcomeV1(
+            proposal=proposal,
+            repaired=False,
+            primary_error_code=None,
+        )
+    except CompositionProposalParseError as primary_error:
+        if repair_text is None:
+            raise
+        try:
+            proposal = parse_composition_proposal(repair_text, candidates)
+        except CompositionProposalParseError as repair_error:
+            raise CompositionProposalParseError(
+                "proposal.repair.failed",
+                f"primary={primary_error.code};repair={repair_error.code}",
+            ) from repair_error
+        return ProposalParseOutcomeV1(
+            proposal=proposal,
+            repaired=True,
+            primary_error_code=primary_error.code,
+        )
+
+
+__all__ = [
+    "CompositionProposalParseError",
+    "ProposalParseOutcomeV1",
+    "computed_proposal_sha256",
+    "parse_composition_proposal",
+    "parse_with_single_repair",
+    "proposal_has_valid_sha256",
+]

--- a/src/world_understanding/capability_composition/validator.py
+++ b/src/world_understanding/capability_composition/validator.py
@@ -160,7 +160,8 @@ def _validate_dependency_compatibility(
                 else ()
             )
         }
-        if not predecessor_outputs.intersection(consumer.consumes):
+        missing_inputs = set(consumer.consumes) - predecessor_outputs
+        if missing_inputs:
             findings.append(
                 _finding(
                     "validator.dependency.type_incompatible",
@@ -169,6 +170,7 @@ def _validate_dependency_compatibility(
                     {
                         "consumes": list(consumer.consumes),
                         "predecessor_outputs": sorted(predecessor_outputs),
+                        "missing_inputs": sorted(missing_inputs),
                     },
                 )
             )
@@ -232,12 +234,13 @@ def _unknown_findings(
                     primitive.availability,
                 )
             )
-        if primitive.idempotency == "UNKNOWN":
+        if primitive.idempotency in {"UNKNOWN", "CONDITIONAL"}:
             findings.append(
                 _finding(
                     "validator.action.idempotency_unknown",
                     "UNKNOWN",
                     action_id,
+                    primitive.idempotency,
                 )
             )
         if primitive.determinism_class != "DETERMINISTIC":
@@ -327,6 +330,18 @@ def validate_capability_composition_plan(
         raise ValueError("validated_at_ms must be non-negative")
 
     invalid: list[CompositionValidationFindingV1] = []
+    if validated_at_ms < plan.created_at_ms:
+        invalid.append(
+            _finding(
+                "validator.time.before_plan",
+                "PROVED_INVALID",
+                plan.plan_id,
+                {
+                    "created_at_ms": plan.created_at_ms,
+                    "validated_at_ms": validated_at_ms,
+                },
+            )
+        )
     if not plan_has_valid_sha256(plan):
         invalid.append(
             _finding(

--- a/src/world_understanding/capability_composition/validator.py
+++ b/src/world_understanding/capability_composition/validator.py
@@ -250,22 +250,31 @@ def _unknown_findings(
                 )
             )
 
-    missing_verifiers = tuple(
-        sorted(
-            intent
-            for intent in plan.verification_intents
-            if intent not in available_verifiers
-        )
-    )
-    if missing_verifiers:
+    if not plan.verification_intents:
         findings.append(
             _finding(
-                "validator.verifier.unavailable",
+                "validator.verifier.binding_missing",
                 "UNKNOWN",
                 plan.plan_id,
-                list(missing_verifiers),
             )
         )
+    else:
+        missing_verifiers = tuple(
+            sorted(
+                intent
+                for intent in plan.verification_intents
+                if intent not in available_verifiers
+            )
+        )
+        if missing_verifiers:
+            findings.append(
+                _finding(
+                    "validator.verifier.unavailable",
+                    "UNKNOWN",
+                    plan.plan_id,
+                    list(missing_verifiers),
+                )
+            )
     return findings
 
 
@@ -406,12 +415,8 @@ def validate_capability_composition_plan(
         )
 
     primitives = _primitive_by_action(candidates)
-    invalid.extend(
-        _validate_dependency_compatibility(plan, primitives)
-    )
-    invalid.extend(
-        _validate_parallel_write_conflicts(plan, primitives)
-    )
+    invalid.extend(_validate_dependency_compatibility(plan, primitives))
+    invalid.extend(_validate_parallel_write_conflicts(plan, primitives))
     for action_id in plan.permission_requirements:
         primitive = primitives.get(action_id)
         if primitive is None:

--- a/src/world_understanding/capability_composition/validator.py
+++ b/src/world_understanding/capability_composition/validator.py
@@ -1,0 +1,484 @@
+"""Conservative tri-state validation for system-compiled composition plans."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Iterable, Mapping
+
+from contracts import ActionRegistrySnapshot, canonical_sha256
+from contracts.capability_composition import (
+    CapabilityCompositionPlanV1,
+    CompositionProposalV1,
+    CompositionValidationFindingV1,
+    CompositionValidationResultV1,
+    ToolSourcePrimitiveV1,
+)
+
+from .compiler import (
+    compile_capability_composition_plan,
+    plan_has_valid_sha256,
+)
+from .models import (
+    CapabilityCompositionError,
+    CompositionCandidateSnapshotV1,
+    CompositionCompileContextV1,
+)
+from .parser import proposal_has_valid_sha256
+
+
+_RISK_ORDER = {"A0": 0, "A1": 1, "A2": 2, "A3": 3, "A4": 4, "A5": 5}
+_WRITE_EFFECTS = {"create", "write", "update", "execute"}
+_DANGEROUS_SIDE_EFFECTS = {
+    "credential_read",
+    "destructive",
+    "external_send",
+    "external_write",
+    "irreversible",
+}
+_DANGEROUS_RESOURCES = {
+    "credential",
+    "credentials",
+    "python",
+    "secret",
+    "secrets",
+    "shell",
+    "user_private",
+    "private_data",
+}
+
+
+def computed_validation_sha256(
+    result: CompositionValidationResultV1,
+) -> str:
+    return canonical_sha256(
+        result.model_dump(mode="json", exclude={"validation_sha256"})
+    )
+
+
+def validation_has_valid_sha256(
+    result: CompositionValidationResultV1,
+) -> bool:
+    return result.validation_sha256 == computed_validation_sha256(result)
+
+
+def _finding(
+    code: str,
+    state: str,
+    subject_ref: str,
+    detail: object | None = None,
+) -> CompositionValidationFindingV1:
+    return CompositionValidationFindingV1(
+        code=code,
+        state=state,  # type: ignore[arg-type]
+        subject_ref=subject_ref,
+        detail_hash=canonical_sha256(detail) if detail is not None else None,
+    )
+
+
+def _result(
+    *,
+    plan: CapabilityCompositionPlanV1,
+    result: str,
+    findings: Iterable[CompositionValidationFindingV1],
+    validated_at_ms: int,
+    unknown_disposition: str = "NOT_APPLICABLE",
+    mandatory_verification: bool = False,
+) -> CompositionValidationResultV1:
+    ordered = tuple(
+        sorted(
+            findings,
+            key=lambda item: (
+                item.state,
+                item.code,
+                item.subject_ref,
+                item.detail_hash or "",
+            ),
+        )
+    )
+    value = CompositionValidationResultV1(
+        plan_id=plan.plan_id,
+        plan_sha256=plan.plan_sha256,
+        result=result,  # type: ignore[arg-type]
+        unknown_disposition=unknown_disposition,  # type: ignore[arg-type]
+        findings=ordered,
+        mandatory_verification=mandatory_verification,
+        validated_at_ms=validated_at_ms,
+        validation_sha256="0" * 64,
+    )
+    return value.model_copy(
+        update={"validation_sha256": computed_validation_sha256(value)}
+    )
+
+
+def _primitive_by_action(
+    candidates: CompositionCandidateSnapshotV1,
+) -> dict[str, ToolSourcePrimitiveV1]:
+    return {
+        item.primitive.action_id: item.primitive
+        for item in candidates.action_candidates
+    }
+
+
+def _reachability(
+    plan: CapabilityCompositionPlanV1,
+) -> Mapping[str, set[str]]:
+    outgoing: dict[str, set[str]] = defaultdict(set)
+    for step in plan.steps:
+        for dependency in step.depends_on:
+            outgoing[dependency].add(step.step_id)
+    reachable: dict[str, set[str]] = {}
+    for step in plan.steps:
+        seen: set[str] = set()
+        queue = deque(sorted(outgoing.get(step.step_id, ())))
+        while queue:
+            target = queue.popleft()
+            if target in seen:
+                continue
+            seen.add(target)
+            queue.extend(sorted(outgoing.get(target, ())))
+        reachable[step.step_id] = seen
+    return reachable
+
+
+def _validate_dependency_compatibility(
+    plan: CapabilityCompositionPlanV1,
+    primitives: Mapping[str, ToolSourcePrimitiveV1],
+) -> list[CompositionValidationFindingV1]:
+    findings: list[CompositionValidationFindingV1] = []
+    steps = {item.step_id: item for item in plan.steps}
+    for step in plan.steps:
+        consumer = primitives.get(step.action_id)
+        if consumer is None or not consumer.consumes:
+            continue
+        predecessor_outputs = {
+            output
+            for dependency in step.depends_on
+            for output in (
+                primitives.get(steps[dependency].action_id).produces
+                if dependency in steps
+                and primitives.get(steps[dependency].action_id) is not None
+                else ()
+            )
+        }
+        if not predecessor_outputs.intersection(consumer.consumes):
+            findings.append(
+                _finding(
+                    "validator.dependency.type_incompatible",
+                    "PROVED_INVALID",
+                    step.step_id,
+                    {
+                        "consumes": list(consumer.consumes),
+                        "predecessor_outputs": sorted(predecessor_outputs),
+                    },
+                )
+            )
+    return findings
+
+
+def _validate_parallel_write_conflicts(
+    plan: CapabilityCompositionPlanV1,
+    primitives: Mapping[str, ToolSourcePrimitiveV1],
+) -> list[CompositionValidationFindingV1]:
+    findings: list[CompositionValidationFindingV1] = []
+    reachable = _reachability(plan)
+    writes: list[tuple[str, set[str]]] = []
+    for step in plan.steps:
+        primitive = primitives.get(step.action_id)
+        if primitive is None:
+            continue
+        write_set = set(primitive.write_set_descriptor)
+        effect = primitive.effect_class.removeprefix("effect:").casefold()
+        if write_set or effect in _WRITE_EFFECTS:
+            writes.append((step.step_id, write_set or {"resource:write"}))
+    for index, (left_id, left_set) in enumerate(writes):
+        for right_id, right_set in writes[index + 1 :]:
+            ordered = (
+                right_id in reachable.get(left_id, set())
+                or left_id in reachable.get(right_id, set())
+            )
+            overlap = left_set.intersection(right_set)
+            if not ordered and overlap:
+                findings.append(
+                    _finding(
+                        "validator.write_set.parallel_conflict",
+                        "PROVED_INVALID",
+                        left_id,
+                        {
+                            "other_step": right_id,
+                            "overlap": sorted(overlap),
+                        },
+                    )
+                )
+    return findings
+
+
+def _unknown_findings(
+    plan: CapabilityCompositionPlanV1,
+    primitives: Mapping[str, ToolSourcePrimitiveV1],
+    *,
+    available_verifiers: frozenset[str],
+) -> list[CompositionValidationFindingV1]:
+    findings: list[CompositionValidationFindingV1] = []
+    for action_id in plan.permission_requirements:
+        primitive = primitives.get(action_id)
+        if primitive is None:
+            continue
+        if primitive.availability in {"DEGRADED", "UNKNOWN"}:
+            findings.append(
+                _finding(
+                    "validator.action.availability_unknown",
+                    "UNKNOWN",
+                    action_id,
+                    primitive.availability,
+                )
+            )
+        if primitive.idempotency == "UNKNOWN":
+            findings.append(
+                _finding(
+                    "validator.action.idempotency_unknown",
+                    "UNKNOWN",
+                    action_id,
+                )
+            )
+        if primitive.determinism_class != "DETERMINISTIC":
+            findings.append(
+                _finding(
+                    "validator.action.determinism_unknown",
+                    "UNKNOWN",
+                    action_id,
+                    primitive.determinism_class,
+                )
+            )
+
+    missing_verifiers = tuple(
+        sorted(
+            intent
+            for intent in plan.verification_intents
+            if intent not in available_verifiers
+        )
+    )
+    if missing_verifiers:
+        findings.append(
+            _finding(
+                "validator.verifier.unavailable",
+                "UNKNOWN",
+                plan.plan_id,
+                list(missing_verifiers),
+            )
+        )
+    return findings
+
+
+def _safe_provisional_unknown(
+    plan: CapabilityCompositionPlanV1,
+    primitives: Mapping[str, ToolSourcePrimitiveV1],
+    *,
+    available_verifiers: frozenset[str],
+) -> bool:
+    if _RISK_ORDER[plan.composition_risk] > _RISK_ORDER["A1"]:
+        return False
+    if not plan.verification_intents or not set(plan.verification_intents).issubset(
+        available_verifiers
+    ):
+        return False
+    for action_id in plan.permission_requirements:
+        primitive = primitives.get(action_id)
+        if primitive is None:
+            return False
+        effect = primitive.effect_class.removeprefix("effect:").casefold()
+        side_effects = {item.casefold() for item in primitive.side_effects}
+        resources = {item.casefold() for item in primitive.resource_scope}
+        if (
+            effect not in {"read", "verify"}
+            or side_effects.intersection(_DANGEROUS_SIDE_EFFECTS)
+            or resources.intersection(_DANGEROUS_RESOURCES)
+        ):
+            return False
+    return True
+
+
+def validate_capability_composition_plan(
+    plan: CapabilityCompositionPlanV1,
+    proposal: CompositionProposalV1,
+    candidates: CompositionCandidateSnapshotV1,
+    context: CompositionCompileContextV1,
+    registry: ActionRegistrySnapshot,
+    *,
+    available_verifiers: frozenset[str] = frozenset(),
+    validated_at_ms: int,
+) -> CompositionValidationResultV1:
+    """Validate only mechanically decidable P4 properties.
+
+    ``PROVED_VALID`` means the bounded mechanical contract is proven. It does
+    not claim a natural-language theorem that the plan must satisfy the user's
+    goal.
+    """
+
+    if validated_at_ms < 0:
+        raise ValueError("validated_at_ms must be non-negative")
+
+    invalid: list[CompositionValidationFindingV1] = []
+    if not plan_has_valid_sha256(plan):
+        invalid.append(
+            _finding(
+                "validator.plan.hash_invalid",
+                "PROVED_INVALID",
+                plan.plan_id,
+            )
+        )
+    if not proposal_has_valid_sha256(proposal):
+        invalid.append(
+            _finding(
+                "validator.proposal.hash_invalid",
+                "PROVED_INVALID",
+                plan.plan_id,
+            )
+        )
+    if not candidates.has_valid_sha256():
+        invalid.append(
+            _finding(
+                "validator.candidates.hash_invalid",
+                "PROVED_INVALID",
+                plan.plan_id,
+            )
+        )
+    if not context.has_valid_sha256():
+        invalid.append(
+            _finding(
+                "validator.context.hash_invalid",
+                "PROVED_INVALID",
+                plan.plan_id,
+            )
+        )
+    if not registry.has_valid_sha256():
+        invalid.append(
+            _finding(
+                "validator.registry.hash_invalid",
+                "PROVED_INVALID",
+                plan.plan_id,
+            )
+        )
+    if invalid:
+        return _result(
+            plan=plan,
+            result="PROVED_INVALID",
+            findings=invalid,
+            validated_at_ms=validated_at_ms,
+        )
+
+    try:
+        expected = compile_capability_composition_plan(
+            proposal, candidates, context, registry
+        )
+    except (CapabilityCompositionError, ValueError) as exc:
+        code = getattr(exc, "code", "validator.compiler.unexpected_error")
+        detail = getattr(exc, "detail", str(exc))
+        return _result(
+            plan=plan,
+            result="PROVED_INVALID",
+            findings=(
+                _finding(
+                    "validator.compiler.reconstruction_failed",
+                    "PROVED_INVALID",
+                    plan.plan_id,
+                    {"code": code, "detail": detail},
+                ),
+            ),
+            validated_at_ms=validated_at_ms,
+        )
+
+    if plan.model_dump(mode="json") != expected.model_dump(mode="json"):
+        return _result(
+            plan=plan,
+            result="PROVED_INVALID",
+            findings=(
+                _finding(
+                    "validator.plan.compiler_mismatch",
+                    "PROVED_INVALID",
+                    plan.plan_id,
+                    {
+                        "actual": plan.plan_sha256,
+                        "expected": expected.plan_sha256,
+                    },
+                ),
+            ),
+            validated_at_ms=validated_at_ms,
+        )
+
+    primitives = _primitive_by_action(candidates)
+    invalid.extend(
+        _validate_dependency_compatibility(plan, primitives)
+    )
+    invalid.extend(
+        _validate_parallel_write_conflicts(plan, primitives)
+    )
+    for action_id in plan.permission_requirements:
+        primitive = primitives.get(action_id)
+        if primitive is None:
+            invalid.append(
+                _finding(
+                    "validator.action.primitive_missing",
+                    "PROVED_INVALID",
+                    action_id,
+                )
+            )
+        elif primitive.availability == "UNAVAILABLE":
+            invalid.append(
+                _finding(
+                    "validator.action.unavailable",
+                    "PROVED_INVALID",
+                    action_id,
+                )
+            )
+    if plan.composition_risk == "A5":
+        invalid.append(
+            _finding(
+                "validator.composition.a5_forbidden",
+                "PROVED_INVALID",
+                plan.plan_id,
+                list(plan.information_flow_findings),
+            )
+        )
+    if invalid:
+        return _result(
+            plan=plan,
+            result="PROVED_INVALID",
+            findings=invalid,
+            validated_at_ms=validated_at_ms,
+        )
+
+    unknown = _unknown_findings(
+        plan,
+        primitives,
+        available_verifiers=available_verifiers,
+    )
+    if unknown:
+        provisional = _safe_provisional_unknown(
+            plan,
+            primitives,
+            available_verifiers=available_verifiers,
+        )
+        return _result(
+            plan=plan,
+            result="UNKNOWN",
+            findings=unknown,
+            validated_at_ms=validated_at_ms,
+            unknown_disposition=(
+                "PROVISIONAL_ALLOW" if provisional else "REJECT"
+            ),
+            mandatory_verification=provisional,
+        )
+
+    return _result(
+        plan=plan,
+        result="PROVED_VALID",
+        findings=(),
+        validated_at_ms=validated_at_ms,
+    )
+
+
+__all__ = [
+    "computed_validation_sha256",
+    "validate_capability_composition_plan",
+    "validation_has_valid_sha256",
+]

--- a/tests/test_capability_composition_p4.py
+++ b/tests/test_capability_composition_p4.py
@@ -1,0 +1,912 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+
+import pytest
+
+from contracts import (
+    ActionPermission,
+    ActionRegistrySnapshot,
+    canonical_sha256,
+)
+from contracts.capability_composition import (
+    SkillSourcePrimitiveV1,
+    SourceRevisionRefV1,
+    SourceSpanRefV1,
+    ToolSourcePrimitiveV1,
+)
+from world_understanding.capability_composition import (
+    CapabilityCompositionError,
+    CompositionCompileContextV1,
+    CompositionProposalParseError,
+    P4EvaluationInputV1,
+    build_candidate_snapshot,
+    compile_capability_composition_plan,
+    computed_plan_sha256,
+    parse_composition_proposal,
+    parse_with_single_repair,
+    plan_has_valid_sha256,
+    run_p4_early_evaluation,
+    validate_capability_composition_plan,
+    validation_has_valid_sha256,
+)
+from world_understanding.skill_method_world import (
+    MethodMigrationBindingV1,
+    SkillMethodWorldSnapshotV1,
+    computed_skill_method_descriptor_sha256,
+)
+from world_understanding.tool_capability_world import (
+    ToolCapabilityWorldSnapshotV1,
+)
+
+
+H = "a" * 64
+H2 = "b" * 64
+REQ = "req_" + "c" * 64
+RUN = "run_" + "d" * 64
+
+
+def _permission(
+    action_id: str,
+    *,
+    manifest_sha256: str,
+    risk: str,
+    effect: str,
+    side_effects: tuple[str, ...],
+    allow_shell: bool = False,
+    allow_python: bool = False,
+) -> ActionPermission:
+    return ActionPermission(
+        action_id=action_id,
+        action_version="omni-registry-v1",
+        registry_risk=risk,
+        effective_risk=risk,
+        effect=effect,
+        handler="_action_" + action_id.replace(".", "_"),
+        allowed_side_effects=tuple(sorted(set(side_effects))),
+        path_policy="object_grant_only",
+        allow_absolute_paths=True,
+        allow_shell=allow_shell,
+        allow_python=allow_python,
+        requires_confirmation=False,
+        source_manifest_sha256=manifest_sha256,
+        permission_sha256="0" * 64,
+    ).with_computed_sha256()
+
+
+def _registry(
+    specs: tuple[dict, ...],
+    *,
+    manifest_sha256: str = H,
+) -> ActionRegistrySnapshot:
+    permissions = tuple(
+        sorted(
+            (
+                _permission(
+                    spec["action_id"],
+                    manifest_sha256=manifest_sha256,
+                    risk=spec["risk"],
+                    effect=spec["effect"],
+                    side_effects=spec["side_effects"],
+                    allow_shell=spec.get("allow_shell", False),
+                    allow_python=spec.get("allow_python", False),
+                )
+                for spec in specs
+            ),
+            key=lambda item: item.action_id,
+        )
+    )
+    return ActionRegistrySnapshot(
+        registry_id="omni-action-registry",
+        revision=1,
+        generated_at_ms=1,
+        source_manifest_sha256=manifest_sha256,
+        executable_count=len(permissions),
+        permissions=permissions,
+        registry_sha256="0" * 64,
+    ).with_computed_sha256()
+
+
+def _tool_primitive(
+    action_id: str,
+    *,
+    manifest_sha256: str,
+    risk: str,
+    effect: str,
+    side_effects: tuple[str, ...],
+    resource_scope: tuple[str, ...] = ("object_grant_only",),
+    consumes: tuple[str, ...] = (),
+    produces: tuple[str, ...] = ("type:artifact",),
+    read_set: tuple[str, ...] = (),
+    write_set: tuple[str, ...] = (),
+    verifier_refs: tuple[str, ...] = ("verifier:artifact",),
+    idempotency: str = "IDEMPOTENT",
+    determinism: str = "DETERMINISTIC",
+    availability: str = "AVAILABLE",
+) -> ToolSourcePrimitiveV1:
+    primitive = ToolSourcePrimitiveV1(
+        source_primitive_id=f"tool-source:{action_id}",
+        action_id=action_id,
+        action_version="omni-registry-v1",
+        provider_component_id="omni-body",
+        implementation_refs=(
+            SourceSpanRefV1(
+                path="src/omni_body_skill/tools/omni_body_tool.py"
+            ),
+        ),
+        implementation_hashes=(H2,),
+        action_manifest_sha256=manifest_sha256,
+        argument_schema_sha256=H,
+        result_schema_sha256=H,
+        consumes=consumes,
+        produces=produces,
+        effect_class=f"effect:{effect}",
+        side_effects=tuple(sorted(set(side_effects))),
+        risk_floor=risk,
+        idempotency=idempotency,
+        determinism_class=determinism,
+        resource_scope=tuple(sorted(set(resource_scope))),
+        read_set_descriptor=tuple(sorted(set(read_set))),
+        write_set_descriptor=tuple(sorted(set(write_set))),
+        evidence_contract=("evidence:typed-result",),
+        verifier_refs=tuple(sorted(set(verifier_refs))),
+        failure_taxonomy=("failure:runtime",),
+        availability=availability,
+        descriptor_sha256="0" * 64,
+    )
+    return primitive.model_copy(
+        update={
+            "descriptor_sha256": canonical_sha256(
+                primitive.model_dump(
+                    mode="json", exclude={"descriptor_sha256"}
+                )
+            )
+        }
+    )
+
+
+def _method_primitive() -> tuple[SkillSourcePrimitiveV1, MethodMigrationBindingV1]:
+    binding = MethodMigrationBindingV1(
+        method_id="generate_then_verify",
+        legacy_skill_ids=(
+            "skill_code_project_delivery_worldclass_v1",
+            "skill_word_business_proposal_worldclass_v1",
+        ),
+        required_phases=("PRODUCTION", "VERIFICATION"),
+        binding_sha256="0" * 64,
+    ).with_computed_sha256()
+    source_ref = SourceRevisionRefV1(
+        source_kind="SKILL_METHOD",
+        semantic_id="generate_then_verify",
+        version="v1",
+        source_files=(
+            "src/omni_body_skill/deliverable_skills/29_skill_word_business_proposal_worldclass.md",
+            "src/omni_body_skill/deliverable_skills/31_skill_code_project_delivery_worldclass.md",
+        ),
+        source_sha256=H2,
+        descriptor_sha256="0" * 64,
+        manifest_sha256=None,
+    )
+    primitive = SkillSourcePrimitiveV1(
+        method_id="generate_then_verify",
+        version="v1",
+        source_ref=source_ref,
+        source_sha256=H2,
+        title="Generate then verify",
+        semantic_summary="Produce an outcome and verify it before completion.",
+        goal_classes=("goal-class:artifact-production",),
+        preconditions=("condition:goal-defined",),
+        expected_postconditions=("condition:outcome-verified",),
+        required_capability_classes=(
+            "capability-class:artifact-production",
+        ),
+        method_steps=(
+            "method-step:01-produce",
+            "method-step:02-verify",
+        ),
+        control_flow_hints=("control-flow:verify-before-complete",),
+        failure_modes=("failure-mode:verification-failed",),
+        fallback_patterns=("fallback-pattern:diagnose-and-retry",),
+        verification_intent=("verifier:artifact",),
+        composition_tags=("composition-tag:production-method",),
+        descriptor_sha256="0" * 64,
+    )
+    descriptor = computed_skill_method_descriptor_sha256(primitive)
+    return (
+        primitive.model_copy(
+            update={
+                "source_ref": source_ref.model_copy(
+                    update={"descriptor_sha256": descriptor}
+                ),
+                "descriptor_sha256": descriptor,
+            }
+        ),
+        binding,
+    )
+
+
+def _worlds(
+    specs: tuple[dict, ...],
+    *,
+    manifest_sha256: str = H,
+) -> tuple[
+    ActionRegistrySnapshot,
+    ToolCapabilityWorldSnapshotV1,
+    SkillMethodWorldSnapshotV1,
+]:
+    registry = _registry(specs, manifest_sha256=manifest_sha256)
+    primitives = tuple(
+        sorted(
+            (
+                _tool_primitive(
+                    spec["action_id"],
+                    manifest_sha256=manifest_sha256,
+                    risk=spec["risk"],
+                    effect=spec["effect"],
+                    side_effects=spec["side_effects"],
+                    resource_scope=spec.get(
+                        "resource_scope", ("object_grant_only",)
+                    ),
+                    consumes=spec.get("consumes", ()),
+                    produces=spec.get("produces", ("type:artifact",)),
+                    read_set=spec.get("read_set", ()),
+                    write_set=spec.get("write_set", ()),
+                    verifier_refs=spec.get(
+                        "verifier_refs", ("verifier:artifact",)
+                    ),
+                    idempotency=spec.get("idempotency", "IDEMPOTENT"),
+                    determinism=spec.get(
+                        "determinism", "DETERMINISTIC"
+                    ),
+                    availability=spec.get("availability", "AVAILABLE"),
+                )
+                for spec in specs
+            ),
+            key=lambda item: item.action_id,
+        )
+    )
+    tool_world = ToolCapabilityWorldSnapshotV1(
+        schema="tiangong.tool-capability-world.v1",
+        source_manifest_sha256=manifest_sha256,
+        action_registry_sha256=registry.registry_sha256,
+        primitives=primitives,
+        relations=(),
+        snapshot_sha256="0" * 64,
+    )
+    tool_world = replace(
+        tool_world,
+        snapshot_sha256=canonical_sha256(tool_world.payload()),
+    )
+
+    method, binding = _method_primitive()
+    method_world = SkillMethodWorldSnapshotV1(
+        schema="tiangong.skill-method-world.v1",
+        legacy_corpus_sha256=H,
+        method_sources_sha256=H2,
+        primitives=(method,),
+        migration_bindings=(binding,),
+        relations=(),
+        snapshot_sha256="0" * 64,
+    )
+    method_world = replace(
+        method_world,
+        snapshot_sha256=canonical_sha256(method_world.payload()),
+    )
+    return registry, tool_world, method_world
+
+
+def _context(
+    *,
+    goal_ref: str,
+    manifest_sha256: str = H,
+    generation: int = 0,
+) -> CompositionCompileContextV1:
+    return CompositionCompileContextV1(
+        schema="tiangong.composition-compile-context.v1",
+        request_id=REQ,
+        run_id=RUN,
+        generation=generation,
+        principal_scope_hash=H,
+        world_state_ref="world.current",
+        world_state_sha256=H2,
+        goal_ref=goal_ref,
+        goal_fingerprint=canonical_sha256({"goal_ref": goal_ref}),
+        environment_class="environment.test",
+        context_fingerprint_sha256=H,
+        capability_manifest_sha256=manifest_sha256,
+        created_at_ms=10,
+        context_sha256="0" * 64,
+    ).with_computed_sha256()
+
+
+def _proposal_document(
+    *,
+    goal_ref: str,
+    methods: tuple[str, ...],
+    actions: tuple[str, ...],
+    steps: tuple[tuple[str, str, tuple[str, ...]], ...],
+    control_flow: str = "DAG",
+    extra: dict | None = None,
+) -> str:
+    document = {
+        "proposal_schema": "tiangong.composition-proposal.v1",
+        "goal_ref": goal_ref,
+        "selected_method_candidate_ids": list(methods),
+        "selected_action_candidate_ids": list(actions),
+        "steps": [
+            {
+                "step_id": step_id,
+                "candidate_id": candidate_id,
+                "depends_on": list(depends_on),
+                "output_bindings": [f"out.{step_id}"],
+            }
+            for step_id, candidate_id, depends_on in steps
+        ],
+        "dependency_edges": [
+            [dependency, step_id]
+            for step_id, _candidate_id, dependencies in steps
+            for dependency in dependencies
+        ],
+        "output_bindings": ["out.final"],
+        "control_flow": control_flow,
+        "rationale_tags": ["rationale.bounded-candidates"],
+    }
+    if extra:
+        document.update(extra)
+    return json.dumps(document, ensure_ascii=False, sort_keys=True)
+
+
+def _single_read_fixture(
+    *,
+    idempotency: str = "IDEMPOTENT",
+    determinism: str = "DETERMINISTIC",
+    risk: str = "A0",
+    effect: str = "read",
+) -> tuple[
+    ActionRegistrySnapshot,
+    object,
+    CompositionCompileContextV1,
+    str,
+]:
+    specs = (
+        {
+            "action_id": "artifact.read",
+            "risk": risk,
+            "effect": effect,
+            "side_effects": ("read",)
+            if effect == "read"
+            else ("local_write", "read"),
+            "read_set": ("resource:artifact",)
+            if effect == "read"
+            else (),
+            "write_set": ("resource:artifact",)
+            if effect != "read"
+            else (),
+            "idempotency": idempotency,
+            "determinism": determinism,
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.read",),
+    )
+    goal_ref = "goal.single-read"
+    document = _proposal_document(
+        goal_ref=goal_ref,
+        methods=("M01",),
+        actions=("A01",),
+        steps=(("step.01", "A01", ()),),
+    )
+    return registry, candidates, _context(goal_ref=goal_ref), document
+
+
+def test_json_and_dsl_proposals_compile_to_the_same_identity() -> None:
+    registry, candidates, context, document = _single_read_fixture()
+    json_proposal = parse_composition_proposal(document, candidates)
+    dsl = """\
+PROPOSAL tiangong.composition-proposal.v1
+GOAL goal.single-read
+METHODS M01
+ACTIONS A01
+STEP step.01|A01|-|out.step.01
+OUTPUTS out.final
+FLOW DAG
+TAGS rationale.bounded-candidates
+END
+"""
+    dsl_proposal = parse_composition_proposal(dsl, candidates)
+    assert json_proposal.proposal_sha256 == dsl_proposal.proposal_sha256
+
+    first = compile_capability_composition_plan(
+        json_proposal, candidates, context, registry
+    )
+    second = compile_capability_composition_plan(
+        dsl_proposal, candidates, context, registry
+    )
+    assert first.plan_sha256 == second.plan_sha256
+    assert plan_has_valid_sha256(first)
+    assert first.permission_requirements == ("artifact.read",)
+    assert first.capability_manifest_sha256 == registry.source_manifest_sha256
+    assert first.memory_experience_refs == ()
+
+
+def test_model_cannot_submit_authority_or_invent_candidate() -> None:
+    _registry_value, candidates, _context_value, document = _single_read_fixture()
+    with pytest.raises(
+        CompositionProposalParseError, match="proposal.fields.invalid"
+    ):
+        parse_composition_proposal(
+            _proposal_document(
+                goal_ref="goal.single-read",
+                methods=("M01",),
+                actions=("A01",),
+                steps=(("step.01", "A01", ()),),
+                extra={"permission_requirements": ["artifact.read"]},
+            ),
+            candidates,
+        )
+
+    invented = json.loads(document)
+    invented["selected_action_candidate_ids"] = ["A99"]
+    invented["steps"][0]["candidate_id"] = "A99"
+    with pytest.raises(
+        CompositionProposalParseError, match="action_candidate.unknown"
+    ):
+        parse_composition_proposal(
+            json.dumps(invented, ensure_ascii=False), candidates
+        )
+
+
+def test_parser_allows_exactly_one_repair() -> None:
+    _registry_value, candidates, _context_value, valid = _single_read_fixture()
+    outcome = parse_with_single_repair(
+        '{"bad": true}',
+        candidates,
+        repair_text=valid,
+    )
+    assert outcome.repaired is True
+    assert outcome.primary_error_code == "proposal.fields.invalid"
+
+    with pytest.raises(
+        CompositionProposalParseError, match="proposal.repair.failed"
+    ):
+        parse_with_single_repair(
+            '{"bad": true}',
+            candidates,
+            repair_text='{"still_bad": true}',
+        )
+
+
+def test_cycle_is_rejected_by_system_compiler() -> None:
+    specs = (
+        {
+            "action_id": "artifact.read",
+            "risk": "A0",
+            "effect": "read",
+            "side_effects": ("read",),
+        },
+        {
+            "action_id": "artifact.verify",
+            "risk": "A0",
+            "effect": "verify",
+            "side_effects": ("read",),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.read", "artifact.verify"),
+    )
+    text = _proposal_document(
+        goal_ref="goal.cycle",
+        methods=("M01",),
+        actions=("A01", "A02"),
+        steps=(
+            ("step.01", "A01", ("step.02",)),
+            ("step.02", "A02", ("step.01",)),
+        ),
+    )
+    proposal = parse_composition_proposal(text, candidates)
+    with pytest.raises(CapabilityCompositionError, match="dependency.cycle"):
+        compile_capability_composition_plan(
+            proposal, candidates, _context(goal_ref="goal.cycle"), registry
+        )
+
+
+def test_composition_risk_escalates_sensitive_external_flow_to_a5() -> None:
+    specs = (
+        {
+            "action_id": "credential.read",
+            "risk": "A1",
+            "effect": "read",
+            "side_effects": ("read",),
+            "resource_scope": ("credential",),
+            "produces": ("type:credential",),
+            "read_set": ("resource:credential",),
+        },
+        {
+            "action_id": "http.send",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("external_write", "read"),
+            "resource_scope": ("network",),
+            "consumes": ("type:credential",),
+            "produces": ("type:delivery-result",),
+            "write_set": ("resource:external-endpoint",),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("credential.read", "http.send"),
+    )
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.sensitive-flow",
+            methods=("M01",),
+            actions=("A01", "A02"),
+            steps=(
+                ("step.01", "A01", ()),
+                ("step.02", "A02", ("step.01",)),
+            ),
+        ),
+        candidates,
+    )
+    context = _context(goal_ref="goal.sensitive-flow")
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    assert plan.risk_floor == "A2"
+    assert plan.composition_risk == "A5"
+    assert "flow:sensitive-source-to-external-sink" in (
+        plan.information_flow_findings
+    )
+
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "PROVED_INVALID"
+    assert validation_has_valid_sha256(result)
+
+
+def test_validator_rejects_permission_expansion_even_with_recomputed_plan_hash() -> None:
+    registry, candidates, context, document = _single_read_fixture()
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    tampered = plan.model_copy(
+        update={
+            "permission_requirements": (
+                "artifact.read",
+                "invented.write",
+            )
+        }
+    )
+    tampered = tampered.model_copy(
+        update={"plan_sha256": computed_plan_sha256(tampered)}
+    )
+    assert plan_has_valid_sha256(tampered)
+
+    result = validate_capability_composition_plan(
+        tampered,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "PROVED_INVALID"
+    assert any(
+        finding.code == "validator.plan.compiler_mismatch"
+        for finding in result.findings
+    )
+
+
+def test_validator_unknown_policy_is_risk_sensitive() -> None:
+    registry, candidates, context, document = _single_read_fixture(
+        idempotency="UNKNOWN",
+        determinism="NONDETERMINISTIC",
+    )
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    read_result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert read_result.result == "UNKNOWN"
+    assert read_result.unknown_disposition == "PROVISIONAL_ALLOW"
+    assert read_result.mandatory_verification is True
+
+    write_specs = (
+        {
+            "action_id": "artifact.write",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("local_write", "read"),
+            "write_set": ("resource:artifact",),
+            "idempotency": "UNKNOWN",
+            "determinism": "NONDETERMINISTIC",
+        },
+    )
+    write_registry, tool_world, method_world = _worlds(write_specs)
+    write_candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.write",),
+    )
+    write_text = _proposal_document(
+        goal_ref="goal.write",
+        methods=("M01",),
+        actions=("A01",),
+        steps=(("step.01", "A01", ()),),
+    )
+    write_proposal = parse_composition_proposal(
+        write_text, write_candidates
+    )
+    write_context = _context(goal_ref="goal.write")
+    write_plan = compile_capability_composition_plan(
+        write_proposal, write_candidates, write_context, write_registry
+    )
+    write_result = validate_capability_composition_plan(
+        write_plan,
+        write_proposal,
+        write_candidates,
+        write_context,
+        write_registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert write_result.result == "UNKNOWN"
+    assert write_result.unknown_disposition == "REJECT"
+    assert write_result.mandatory_verification is False
+
+
+def test_validator_proves_mechanical_validity_for_deterministic_plan() -> None:
+    registry, candidates, context, document = _single_read_fixture()
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "PROVED_VALID"
+    assert result.unknown_disposition == "NOT_APPLICABLE"
+    assert result.mandatory_verification is False
+    assert validation_has_valid_sha256(result)
+
+
+def test_dependency_type_mismatch_is_proved_invalid() -> None:
+    specs = (
+        {
+            "action_id": "artifact.read",
+            "risk": "A0",
+            "effect": "read",
+            "side_effects": ("read",),
+            "produces": ("type:text",),
+        },
+        {
+            "action_id": "artifact.write",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("local_write", "read"),
+            "consumes": ("type:image",),
+            "produces": ("type:artifact",),
+            "write_set": ("resource:artifact",),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.read", "artifact.write"),
+    )
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.type-mismatch",
+            methods=("M01",),
+            actions=("A01", "A02"),
+            steps=(
+                ("step.01", "A01", ()),
+                ("step.02", "A02", ("step.01",)),
+            ),
+        ),
+        candidates,
+    )
+    context = _context(goal_ref="goal.type-mismatch")
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "PROVED_INVALID"
+    assert any(
+        finding.code == "validator.dependency.type_incompatible"
+        for finding in result.findings
+    )
+
+
+def test_parallel_write_conflict_is_proved_invalid() -> None:
+    specs = (
+        {
+            "action_id": "artifact.write-a",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("local_write", "read"),
+            "write_set": ("resource:artifact",),
+        },
+        {
+            "action_id": "artifact.write-b",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("local_write", "read"),
+            "write_set": ("resource:artifact",),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.write-a", "artifact.write-b"),
+    )
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.parallel-write",
+            methods=("M01",),
+            actions=("A01", "A02"),
+            steps=(
+                ("step.01", "A01", ()),
+                ("step.02", "A02", ()),
+            ),
+        ),
+        candidates,
+    )
+    context = _context(goal_ref="goal.parallel-write")
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "PROVED_INVALID"
+    assert any(
+        finding.code == "validator.write_set.parallel_conflict"
+        for finding in result.findings
+    )
+
+
+def _dsl_for_task(task_id: str) -> str:
+    return f"""\
+PROPOSAL tiangong.composition-proposal.v1
+GOAL goal.{task_id}
+METHODS M01
+ACTIONS A01
+STEP step.01|A01|-|out.step.01
+OUTPUTS out.final
+FLOW DAG
+TAGS rationale.bounded-candidates
+END
+"""
+
+
+def test_p4_recorded_protocol_preflight_runs_24_by_3_without_execution() -> None:
+    registry, tool_world, method_world = _worlds(
+        (
+            {
+                "action_id": "artifact.read",
+                "risk": "A0",
+                "effect": "read",
+                "side_effects": ("read",),
+            },
+        )
+    )
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.read",),
+    )
+    inputs: list[P4EvaluationInputV1] = []
+    contexts = {}
+    candidate_bindings = {}
+    for ordinal in range(1, 25):
+        task_id = f"task-{ordinal:02d}"
+        goal_ref = f"goal.{task_id}"
+        valid_json = _proposal_document(
+            goal_ref=goal_ref,
+            methods=("M01",),
+            actions=("A01",),
+            steps=(("step.01", "A01", ()),),
+        )
+        inputs.extend(
+            (
+                P4EvaluationInputV1(
+                    task_id=task_id,
+                    model_id="abi.json-structured",
+                    primary_text=valid_json,
+                ),
+                P4EvaluationInputV1(
+                    task_id=task_id,
+                    model_id="abi.json-one-repair",
+                    primary_text='{"bad": true}',
+                    repair_text=valid_json,
+                ),
+                P4EvaluationInputV1(
+                    task_id=task_id,
+                    model_id="abi.strict-dsl",
+                    primary_text=_dsl_for_task(task_id),
+                ),
+            )
+        )
+        contexts[task_id] = _context(goal_ref=goal_ref)
+        candidate_bindings[task_id] = candidates
+
+    report = run_p4_early_evaluation(
+        tuple(inputs),
+        candidates_by_task=candidate_bindings,
+        contexts_by_task=contexts,
+        registry=registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=12,
+        evidence_mode="RECORDED_FIXTURE",
+    )
+    assert report.has_valid_sha256()
+    assert report.evidence_mode == "RECORDED_FIXTURE"
+    assert len(report.cases) == 72
+    assert len(report.model_metrics) == 3
+    assert all(item.case_count == 24 for item in report.model_metrics)
+    assert all(item.proved_valid_count == 24 for item in report.model_metrics)
+    assert all(item.final_parse_failure_count == 0 for item in report.model_metrics)
+    repaired = next(
+        item
+        for item in report.model_metrics
+        if item.model_id == "abi.json-one-repair"
+    )
+    assert repaired.primary_parse_failure_count == 24
+    assert repaired.repair_attempt_count == 24
+    assert repaired.repair_success_count == 24

--- a/tests/test_capability_composition_p4_cross_phase.py
+++ b/tests/test_capability_composition_p4_cross_phase.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from contracts import canonical_sha256
+from total_gateway.action_registry import compile_action_registry
+from world_understanding.capability_composition import (
+    build_candidate_snapshot,
+    compile_capability_composition_plan,
+    parse_composition_proposal,
+    validate_capability_composition_plan,
+)
+from world_understanding.skill_method_world import (
+    compile_production_skill_method_world,
+)
+from world_understanding.tool_capability_world import (
+    compile_tool_capability_world,
+)
+
+from tests.test_capability_composition_p4 import (
+    H,
+    _context,
+    _proposal_document,
+)
+from tests.test_skill_method_world_p3_production import _production_inputs
+from tests.test_tool_capability_world_p2 import manifest, source_ref
+
+
+def test_p2_p3_outputs_form_a_p4_plan_without_new_authority() -> None:
+    capability_manifest = manifest()
+    registry = compile_action_registry(capability_manifest, generated_at_ms=1)
+    manifest_sha256 = canonical_sha256(capability_manifest)
+    action_ids = tuple(sorted(capability_manifest["capabilities"]))
+    tool_world = compile_tool_capability_world(
+        capability_manifest,
+        registry,
+        source_revisions={
+            action_id: source_ref(action_id, manifest_sha256)
+            for action_id in action_ids
+        },
+        argument_schema_hashes={action_id: H for action_id in action_ids},
+        result_schema_hashes={action_id: H for action_id in action_ids},
+    )
+
+    index, index_sha256, source_hashes = _production_inputs()
+    method_world = compile_production_skill_method_world(
+        index,
+        index_source_sha256=index_sha256,
+        skill_source_hashes=source_hashes,
+    )
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("file.read",),
+    )
+    assert candidates.may_authorize is False
+    assert candidates.may_execute is False
+    assert candidates.method_candidates[0].primitive.method_id == (
+        "generate_then_verify"
+    )
+    assert candidates.action_candidates[0].primitive.action_id == "file.read"
+
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.cross-phase-read",
+            methods=("M01",),
+            actions=("A01",),
+            steps=(("step.01", "A01", ()),),
+        ),
+        candidates,
+    )
+    context = _context(
+        goal_ref="goal.cross-phase-read",
+        manifest_sha256=registry.source_manifest_sha256,
+    )
+    plan = compile_capability_composition_plan(
+        proposal,
+        candidates,
+        context,
+        registry,
+    )
+    assert plan.permission_requirements == ("file.read",)
+    assert len(plan.method_source_refs) == 1
+    assert len(plan.action_source_refs) == 1
+    assert plan.capability_manifest_sha256 == registry.source_manifest_sha256
+    assert plan.memory_experience_refs == ()
+
+    # The current P2 source is intentionally conservative about idempotency
+    # and determinism. P4 therefore returns UNKNOWN, but the A0 read can be
+    # provisionally considered only with mandatory verification.
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset(plan.verification_intents),
+        validated_at_ms=11,
+    )
+    assert result.result == "UNKNOWN"
+    assert result.unknown_disposition == "PROVISIONAL_ALLOW"
+    assert result.mandatory_verification is True

--- a/tests/test_capability_composition_p4_hardening.py
+++ b/tests/test_capability_composition_p4_hardening.py
@@ -61,9 +61,7 @@ def test_candidate_builder_recomputes_tool_descriptor_integrity() -> None:
         )
     )
     original = tool_world.primitives[0]
-    tampered = original.model_copy(
-        update={"produces": ("type:tampered",)}
-    )
+    tampered = original.model_copy(update={"produces": ("type:tampered",)})
     forged_world = replace(
         tool_world,
         primitives=(tampered,),
@@ -173,6 +171,119 @@ def test_missing_verification_binding_is_unknown_and_rejected() -> None:
     assert any(
         item.code == "validator.verifier.binding_missing"
         for item in result.findings
+    )
+
+
+def test_dependency_requires_every_declared_input_type() -> None:
+    specs = (
+        {
+            "action_id": "artifact.read",
+            "risk": "A0",
+            "effect": "read",
+            "side_effects": ("read",),
+            "produces": ("type:text",),
+        },
+        {
+            "action_id": "artifact.combine",
+            "risk": "A0",
+            "effect": "verify",
+            "side_effects": ("read",),
+            "consumes": ("type:image", "type:text"),
+            "produces": ("type:artifact",),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.combine", "artifact.read"),
+    )
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.partial-inputs",
+            methods=("M01",),
+            actions=("A01", "A02"),
+            steps=(
+                ("step.01", "A02", ()),
+                ("step.02", "A01", ("step.01",)),
+            ),
+        ),
+        candidates,
+    )
+    context = _context(goal_ref="goal.partial-inputs")
+    plan = compile_capability_composition_plan(
+        proposal,
+        candidates,
+        context,
+        registry,
+    )
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "PROVED_INVALID"
+    assert any(
+        item.code == "validator.dependency.type_incompatible"
+        for item in result.findings
+    )
+
+
+def test_conditional_idempotency_remains_unknown() -> None:
+    registry, candidates, context, document = _single_read_fixture(
+        idempotency="CONDITIONAL",
+        determinism="DETERMINISTIC",
+    )
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal,
+        candidates,
+        context,
+        registry,
+    )
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert result.result == "UNKNOWN"
+    assert result.unknown_disposition == "PROVISIONAL_ALLOW"
+    assert any(
+        item.code == "validator.action.idempotency_unknown"
+        for item in result.findings
+    )
+
+
+def test_validation_timestamp_cannot_predate_plan() -> None:
+    registry, candidates, context, document = _single_read_fixture()
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal,
+        candidates,
+        context,
+        registry,
+    )
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=plan.created_at_ms - 1,
+    )
+    assert result.result == "PROVED_INVALID"
+    assert any(
+        item.code == "validator.time.before_plan" for item in result.findings
     )
 
 

--- a/tests/test_capability_composition_p4_hardening.py
+++ b/tests/test_capability_composition_p4_hardening.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from world_understanding.capability_composition import (
+    CapabilityCompositionError,
+    CompositionCandidateSnapshotV1,
+    P4EvaluationInputV1,
+    build_candidate_snapshot,
+    compile_capability_composition_plan,
+    parse_composition_proposal,
+    run_p4_early_evaluation,
+    validate_capability_composition_plan,
+)
+
+from tests.test_capability_composition_p4 import (
+    H,
+    _context,
+    _proposal_document,
+    _single_read_fixture,
+    _worlds,
+)
+
+
+def test_candidate_snapshot_rejects_noncanonical_numbering_gaps() -> None:
+    _registry, candidates, _context_value, _document = _single_read_fixture()
+    original = candidates.action_candidates[0]
+    gapped = replace(
+        original,
+        candidate_id="A02",
+        binding_sha256="0" * 64,
+    )
+    gapped = replace(gapped, binding_sha256=gapped.computed_sha256())
+
+    with pytest.raises(
+        CapabilityCompositionError,
+        match="candidate.action_set.invalid",
+    ):
+        CompositionCandidateSnapshotV1(
+            schema="tiangong.composition-candidates.v1",
+            tool_world_sha256=candidates.tool_world_sha256,
+            method_world_sha256=candidates.method_world_sha256,
+            method_candidates=candidates.method_candidates,
+            action_candidates=(gapped,),
+            candidate_snapshot_sha256=H,
+        )
+
+
+def test_candidate_builder_recomputes_tool_descriptor_integrity() -> None:
+    _registry, tool_world, method_world = _worlds(
+        (
+            {
+                "action_id": "artifact.read",
+                "risk": "A0",
+                "effect": "read",
+                "side_effects": ("read",),
+            },
+        )
+    )
+    original = tool_world.primitives[0]
+    tampered = original.model_copy(
+        update={"produces": ("type:tampered",)}
+    )
+    forged_world = replace(
+        tool_world,
+        primitives=(tampered,),
+        snapshot_sha256="0" * 64,
+    )
+    forged_world = replace(
+        forged_world,
+        snapshot_sha256=forged_world.payload()
+        and __import__("contracts").canonical_sha256(forged_world.payload()),
+    )
+
+    with pytest.raises(
+        CapabilityCompositionError,
+        match="candidate.tool_world.primitive_invalid",
+    ):
+        build_candidate_snapshot(
+            forged_world,
+            method_world,
+            method_ids=("generate_then_verify",),
+            action_ids=("artifact.read",),
+        )
+
+
+def test_candidate_builder_recomputes_method_descriptor_integrity() -> None:
+    _registry, tool_world, method_world = _worlds(
+        (
+            {
+                "action_id": "artifact.read",
+                "risk": "A0",
+                "effect": "read",
+                "side_effects": ("read",),
+            },
+        )
+    )
+    original = method_world.primitives[0]
+    tampered = original.model_copy(
+        update={"semantic_summary": "tampered method semantics"}
+    )
+    forged_world = replace(
+        method_world,
+        primitives=(tampered,),
+        snapshot_sha256="0" * 64,
+    )
+    forged_world = replace(
+        forged_world,
+        snapshot_sha256=__import__("contracts").canonical_sha256(
+            forged_world.payload()
+        ),
+    )
+
+    with pytest.raises(
+        CapabilityCompositionError,
+        match="candidate.method_world.primitive_invalid",
+    ):
+        build_candidate_snapshot(
+            tool_world,
+            forged_world,
+            method_ids=("generate_then_verify",),
+            action_ids=("artifact.read",),
+        )
+
+
+def test_missing_verification_binding_is_unknown_and_rejected() -> None:
+    specs = (
+        {
+            "action_id": "artifact.read",
+            "risk": "A0",
+            "effect": "read",
+            "side_effects": ("read",),
+            "verifier_refs": (),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=(),
+        action_ids=("artifact.read",),
+    )
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.no-verifier",
+            methods=(),
+            actions=("A01",),
+            steps=(("step.01", "A01", ()),),
+        ),
+        candidates,
+    )
+    context = _context(goal_ref="goal.no-verifier")
+    plan = compile_capability_composition_plan(
+        proposal,
+        candidates,
+        context,
+        registry,
+    )
+    assert plan.verification_intents == ()
+
+    result = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset(),
+        validated_at_ms=11,
+    )
+    assert result.result == "UNKNOWN"
+    assert result.unknown_disposition == "REJECT"
+    assert result.mandatory_verification is False
+    assert any(
+        item.code == "validator.verifier.binding_missing"
+        for item in result.findings
+    )
+
+
+def test_early_evaluation_reports_plan_and_semantic_metrics_explicitly() -> None:
+    registry, candidates, context, document = _single_read_fixture()
+    report = run_p4_early_evaluation(
+        (
+            P4EvaluationInputV1(
+                task_id="task-01",
+                model_id="abi.test",
+                primary_text=document,
+            ),
+        ),
+        candidates_by_task={"task-01": candidates},
+        contexts_by_task={"task-01": context},
+        registry=registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=12,
+        evidence_mode="RECORDED_FIXTURE",
+    )
+    metrics = report.model_metrics[0]
+    assert metrics.plan_success_count == 1
+    assert metrics.plan_compile_failure_count == 0
+    assert metrics.semantic_validation_failure_count == 0
+    assert metrics.proved_valid_count == 1

--- a/tests/test_capability_composition_p4_hardening.py
+++ b/tests/test_capability_composition_p4_hardening.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 
 import pytest
 
+from contracts import canonical_sha256
 from world_understanding.capability_composition import (
     CapabilityCompositionError,
     CompositionCandidateSnapshotV1,
@@ -70,8 +71,7 @@ def test_candidate_builder_recomputes_tool_descriptor_integrity() -> None:
     )
     forged_world = replace(
         forged_world,
-        snapshot_sha256=forged_world.payload()
-        and __import__("contracts").canonical_sha256(forged_world.payload()),
+        snapshot_sha256=canonical_sha256(forged_world.payload()),
     )
 
     with pytest.raises(
@@ -108,9 +108,7 @@ def test_candidate_builder_recomputes_method_descriptor_integrity() -> None:
     )
     forged_world = replace(
         forged_world,
-        snapshot_sha256=__import__("contracts").canonical_sha256(
-            forged_world.payload()
-        ),
+        snapshot_sha256=canonical_sha256(forged_world.payload()),
     )
 
     with pytest.raises(


### PR DESCRIPTION
Implements P4 of the world-understanding-driven capability composition plan on top of `main @ 3ce15faf8d463a8c5b5b3bfaa855b10ec94a1b2e`.

Scope:
- adds a bounded, content-addressed candidate snapshot over the P2 Tool Capability World and P3 Skill Method World;
- assigns contiguous system-owned Method IDs `M01-M15` and Action IDs `A01-A30`; numbering gaps are rejected;
- recomputes P2 Tool and P3 Method descriptor hashes before exposing candidates;
- adds a strict small model ABI with JSON and bounded DSL provider tiers;
- rejects unknown fields, caller-supplied authority fields, hallucinated candidates, Method-as-Action use, malformed graph bindings and duplicate keys;
- permits exactly one externally-produced proposal repair, then fails closed;
- compiles `CompositionProposalV1` into a system-derived `CapabilityCompositionPlanV1` with exact source/version/WorldState/context/Registry bindings, leaf permission union, risk, information-flow findings and immutable hashes;
- performs composition-risk escalation instead of using only maximum leaf risk;
- adds a conservative `PROVED_VALID / PROVED_INVALID / UNKNOWN` Validator;
- reconstructs the expected Plan from original authorities, so recomputing a tampered Plan hash cannot expand permissions;
- requires all declared input types, rejects unordered overlapping writes, validates monotonic plan/validation time, and keeps conditional idempotency in UNKNOWN;
- treats a missing Verification Intent binding as UNKNOWN/REJECT rather than PROVED_VALID;
- allows UNKNOWN provisional handling only for A0/A1 read/verify compositions with complete verification; A2+ UNKNOWN is rejected;
- reports explicit parse failure, repair success, plan success, compile failure and semantic validation failure metrics;
- runs a 24-task x 3-protocol-profile recorded preflight without executing Actions;
- includes a real P2 compiler → production P3 Method World → P4 Proposal/Plan/Validator cross-phase test.

Evidence boundary:
- the 24x3 CI matrix is explicitly `RECORDED_FIXTURE`; it validates protocol behavior and is not represented as live performance of named models;
- the same harness accepts separately captured `LIVE_PROVIDER` outputs for the later exact-model evidence run.

Non-goals:
- no execution, activation, Grant, Ticket, Effect, Fact, P19 or Completion decision;
- no Memory write or P5 experience policy;
- no P6 WorldState/context integration;
- no second Runtime, Gateway, Action Registry, WorldState store or Memory store;
- no Static Skill decommission.

Gate: focused P4 tests, recorded 24x3 preflight, source-authority/full-regression on Ubuntu/Windows, P14 repository perception, and P19-R2 Golden Gate must all pass before P5 begins.