### PR TITLE
P7A: shadow-only composition activation and P19 verification adapter

### DIFF
--- a/docs/capability-composition/P7A_SHADOW_ACTIVATION.md
+++ b/docs/capability-composition/P7A_SHADOW_ACTIVATION.md
@@ -1,0 +1,175 @@
+# P7A — Shadow Activation Adapter
+
+Base: `main @ ae601a9fd28b936f3f2d5e2b711669152697b271`.
+
+## Purpose
+
+P7A connects a validated `CapabilityCompositionPlanV1` to the existing Action
+Registry and P19 verifier RegistrySnapshot in **shadow only**.
+
+It emits:
+
+- a proposed `CompositionActivationContractV1`;
+- a proposed current-version P19 `VerificationPlan`;
+- exact allowed Action IDs and versions;
+- a deterministic differential trace against the legacy allowed Action set;
+- a first-batch limited-production eligibility assessment.
+
+It does not persist or activate any of them.
+
+## Input authority
+
+P7A accepts only:
+
+- a valid system-compiled Composition Plan;
+- a valid `PROVED_VALID` validation result, or `UNKNOWN + PROVISIONAL_ALLOW + mandatory_verification`;
+- the existing valid `ActionRegistrySnapshot`;
+- the existing valid P19 `RegistrySnapshot`;
+- system-resolved verification bindings;
+- bounded issue/expiry times;
+- an optional legacy Action set used only for differential reporting.
+
+A `PROVED_INVALID`, rejected UNKNOWN, mismatched Plan, stale validation, malformed
+hash, source drift, unregistered Action, version mismatch, incomplete verifier
+binding, or Registry mismatch fails closed.
+
+## System-resolved Verification binding
+
+The model never names the verifier.
+
+`build_system_verification_binding(...)` receives an already-authoritative
+`AcceptancePredicate`, subject identity and evaluation phase. It searches the
+current P19 RegistrySnapshot and requires exactly one verifier that:
+
+- has a valid descriptor hash;
+- is `L0_DETERMINISTIC`;
+- is deterministic;
+- supports the predicate type;
+- supports the subject kind.
+
+The selected verifier ID/version and RegistrySnapshot hash are then frozen into
+`SystemVerificationBindingV1`.
+
+Every `plan.verification_intents` item must have exactly one binding. The adapter
+constructs complete `VerificationPlanEntryV2` records and one current-version
+`VerificationPlan`. It never creates a `VerificationRecord`, never invokes a
+verifier, and cannot output PASS.
+
+## Action and source checks
+
+The proposed allowed set must equal all three of:
+
+- the sorted unique Action IDs used by Plan steps;
+- `plan.permission_requirements`;
+- the exact set of Action source revisions carried by the Plan.
+
+For every Action, P7A requires:
+
+- presence in the existing Action Registry;
+- exact Action version equality across Plan step, source revision and Registry;
+- exact capability-manifest equality;
+- `source_kind = TOOL_ACTION`;
+- exact recomputation of the Plan source-manifest hash.
+
+The model cannot expand permissions by changing the proposed Action list.
+
+## Proposed activation
+
+The embedded `CompositionActivationContractV1` binds:
+
+- Plan ID/hash;
+- request/run/generation;
+- principal scope;
+- WorldState hash;
+- source manifest;
+- capability manifest;
+- allowed Action IDs and versions;
+- proposed VerificationPlan ID;
+- issue/expiry time;
+- deterministic activation hash.
+
+The outer shadow proposal also binds:
+
+- validation hash;
+- Action Registry hash;
+- P19 RegistrySnapshot hash;
+- VerificationPlan hash;
+- differential trace hash.
+
+The complete output is fixed as:
+
+- `proposed_only = true`
+- `persistence_allowed = false`
+- `authorizes = false`
+- `confirms = false`
+- `changes_risk = false`
+- `may_execute = false`
+
+## Differential trace
+
+The trace records:
+
+- planned Action set;
+- proposed Action set;
+- legacy comparison set;
+- additions and removals;
+- exact set/Registry/source/version/verifier checks;
+- limited-production eligibility and rejection reasons;
+- `persisted = false`;
+- `authorizes = false`;
+- `may_execute = false`.
+
+It is evidence for P7B/P7C cutover analysis, not an execution credential.
+
+## Limited-production eligibility
+
+P7A computes, but does not enact, the initial limited-production eligibility
+specified by the execution master:
+
+- composition risk A0/A1;
+- every Action risk A0/A1;
+- read/verify effect only;
+- no Shell;
+- no Python;
+- no credential read;
+- no destructive or irreversible effect;
+- no external write/send;
+- every VerificationPlan entry required and identity-valid.
+
+A2+ and write/execute compositions may still be observed in shadow, but are
+marked ineligible for the first limited-production batch.
+
+## Preserved authorities
+
+P7A does not import or call:
+
+- `GatewayStateStore`;
+- `put_verification_plan`;
+- `ExecutionTicket` construction;
+- `OmniCapabilityGrant` construction;
+- `VerificationPlanExecutor`;
+- `VerificationRecorder`;
+- Omni Body or BodyRuntime;
+- P19 readiness/failure/repair execution;
+- CompletionGate.
+
+No P19 frozen contract or implementation file is modified. The current Static
+Skill path remains the production path.
+
+## P7A gate
+
+Before P7B begins, P7A must prove:
+
+- proposed Action set is an exact Registry subset;
+- no permission expansion;
+- Action versions and source revisions are exact;
+- capability/source/Action Registry/P19 Registry hashes are exact;
+- every Verification Intent has one complete deterministic P19 entry;
+- missing/ambiguous verifier resolution fails closed;
+- validation must be valid or explicitly provisional UNKNOWN;
+- proposed output has no authorization, persistence or execution power;
+- the adapter cannot emit PASS or write any P19 record;
+- A0/A1 limited eligibility is reported independently from shadow proposal
+  generation;
+- source-authority/full-regression and P19 Golden Gate remain green on Ubuntu
+  and Windows.

--- a/src/total_gateway/composition_activation_shadow.py
+++ b/src/total_gateway/composition_activation_shadow.py
@@ -1,33 +1,34 @@
 """P7A shadow-only composition activation adapter.
 
 The adapter validates a system-compiled composition plan against the current
-Action Registry and P19 verifier RegistrySnapshot, then emits a proposed
-activation contract, a proposed VerificationPlan, and a deterministic
-differential trace.  It never writes GatewayStateStore, issues a real Grant or
-Ticket, invokes Runtime, runs a verifier, records PASS, or changes Completion.
+principal, WorldState, Action Registry, and P19 verifier RegistrySnapshot. It
+emits proposed-only activation/verification records and a differential trace.
+It never writes GatewayStateStore, issues a real Grant or Ticket, invokes
+Runtime, runs a verifier, records PASS, or changes Completion.
 """
 
 from __future__ import annotations
 
-from typing import Any, Literal, Self
+import re
+from typing import Literal, Self
 
 from pydantic import Field, field_validator, model_validator
 
-from contracts import (
-    AcceptancePredicate,
-    ActionRegistrySnapshot,
+from contracts.canonical import canonical_sha256
+from contracts.capability_composition import (
+    CapabilityCompositionPlanV1,
     CompositionActivationContractV1,
     CompositionValidationResultV1,
+    SourceRevisionRefV1,
+)
+from contracts.models import ContractModel, OpaqueId, RequestId, RunId, Sha256
+from contracts.policy import ActionRegistrySnapshot
+from contracts.verification import (
+    AcceptancePredicate,
     RegistrySnapshot,
     VerificationPlan,
     VerificationPlanEntryV2,
-    canonical_sha256,
 )
-from contracts.capability_composition import (
-    CapabilityCompositionPlanV1,
-    SourceRevisionRefV1,
-)
-from contracts.models import ContractModel, OpaqueId, Sha256
 from world_understanding.capability_composition import (
     plan_has_valid_sha256,
     validation_has_valid_sha256,
@@ -47,6 +48,7 @@ EvaluationPhase = Literal[
 ]
 AcceptedValidationMode = Literal["PROVED_VALID", "PROVISIONAL_UNKNOWN"]
 
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _HIGH_RISK_SIDE_EFFECTS = frozenset(
     {
         "credential_read",
@@ -67,8 +69,17 @@ class CompositionShadowActivationError(ValueError):
 
 def _sorted_unique(values: tuple[str, ...]) -> tuple[str, ...]:
     if values != tuple(sorted(set(values))):
-        raise ValueError("set-like shadow activation fields must be sorted and unique")
+        raise ValueError(
+            "set-like shadow activation fields must be sorted and unique"
+        )
     return values
+
+
+def _require_sha256(value: str, field: str) -> None:
+    if _SHA256.fullmatch(value) is None:
+        raise CompositionShadowActivationError(
+            "shadow.identity.sha256_invalid", field
+        )
 
 
 def _source_sort_key(
@@ -95,14 +106,20 @@ def computed_activation_sha256(
 def activation_has_valid_sha256(
     activation: CompositionActivationContractV1,
 ) -> bool:
-    return activation.activation_sha256 == computed_activation_sha256(activation)
+    return activation.activation_sha256 == computed_activation_sha256(
+        activation
+    )
 
 
 def computed_composition_source_manifest_sha256(
     plan: CapabilityCompositionPlanV1,
 ) -> str:
-    action_sources = tuple(sorted(plan.action_source_refs, key=_source_sort_key))
-    method_sources = tuple(sorted(plan.method_source_refs, key=_source_sort_key))
+    action_sources = tuple(
+        sorted(plan.action_source_refs, key=_source_sort_key)
+    )
+    method_sources = tuple(
+        sorted(plan.method_source_refs, key=_source_sort_key)
+    )
     return canonical_sha256(
         {
             "domain": "tiangong.capability-composition.source-manifest.v1",
@@ -130,14 +147,18 @@ class SystemVerificationBindingV1(ContractModel):
     evaluation_phase: EvaluationPhase
     required: Literal[True] = True
     registry_snapshot_sha256: Sha256
-    producer_component_id: Literal["tiangong-gateway"] = "tiangong-gateway"
+    producer_component_id: Literal["tiangong-gateway"] = (
+        "tiangong-gateway"
+    )
     model_generated: Literal[False] = False
     binding_sha256: Sha256
 
     @model_validator(mode="after")
     def validate_binding(self) -> Self:
         if not self.predicate.has_valid_identity():
-            raise ValueError("verification binding predicate identity is invalid")
+            raise ValueError(
+                "verification binding predicate identity is invalid"
+            )
         return self
 
     def computed_sha256(self) -> str:
@@ -149,15 +170,17 @@ class SystemVerificationBindingV1(ContractModel):
         return self.binding_sha256 == self.computed_sha256()
 
     def with_computed_sha256(self) -> "SystemVerificationBindingV1":
-        return self.model_copy(update={"binding_sha256": self.computed_sha256()})
+        return self.model_copy(
+            update={"binding_sha256": self.computed_sha256()}
+        )
 
 
 class ShadowActivationDifferentialTraceV1(ContractModel):
     schema_version: Literal[
         "tiangong.composition-shadow-activation-trace.v1"
     ] = "tiangong.composition-shadow-activation-trace.v1"
-    request_id: OpaqueId
-    run_id: OpaqueId
+    request_id: RequestId
+    run_id: RunId
     generation: int = Field(ge=0)
     composition_plan_id: OpaqueId
     composition_plan_sha256: Sha256
@@ -170,11 +193,11 @@ class ShadowActivationDifferentialTraceV1(ContractModel):
     legacy_allowed_action_ids: tuple[OpaqueId, ...] = ()
     added_vs_legacy: tuple[OpaqueId, ...] = ()
     removed_vs_legacy: tuple[OpaqueId, ...] = ()
-    exact_action_set: bool
-    registry_subset: bool
-    source_manifest_exact: bool
-    action_versions_exact: bool
-    verification_bindings_complete: bool
+    exact_action_set: Literal[True] = True
+    registry_subset: Literal[True] = True
+    source_manifest_exact: Literal[True] = True
+    action_versions_exact: Literal[True] = True
+    verification_bindings_complete: Literal[True] = True
     limited_production_eligible: bool
     limited_rejection_codes: tuple[OpaqueId, ...] = ()
     proposed_only: Literal[True] = True
@@ -192,6 +215,23 @@ class ShadowActivationDifferentialTraceV1(ContractModel):
         "limited_rejection_codes",
     )(_sorted_unique)
 
+    @model_validator(mode="after")
+    def validate_differential(self) -> Self:
+        planned = set(self.planned_action_ids)
+        proposed = set(self.proposed_allowed_action_ids)
+        legacy = set(self.legacy_allowed_action_ids)
+        if planned != proposed:
+            raise ValueError("shadow proposed action set differs from plan")
+        if set(self.added_vs_legacy) != proposed - legacy:
+            raise ValueError("shadow added Action differential is invalid")
+        if set(self.removed_vs_legacy) != legacy - proposed:
+            raise ValueError("shadow removed Action differential is invalid")
+        if self.limited_production_eligible != (
+            not self.limited_rejection_codes
+        ):
+            raise ValueError("limited eligibility disagrees with reasons")
+        return self
+
     def computed_sha256(self) -> str:
         return canonical_sha256(
             self.model_dump(mode="json", exclude={"trace_sha256"})
@@ -200,14 +240,20 @@ class ShadowActivationDifferentialTraceV1(ContractModel):
     def has_valid_sha256(self) -> bool:
         return self.trace_sha256 == self.computed_sha256()
 
-    def with_computed_sha256(self) -> "ShadowActivationDifferentialTraceV1":
-        return self.model_copy(update={"trace_sha256": self.computed_sha256()})
+    def with_computed_sha256(
+        self,
+    ) -> "ShadowActivationDifferentialTraceV1":
+        return self.model_copy(
+            update={"trace_sha256": self.computed_sha256()}
+        )
 
 
 class ShadowCompositionActivationProposalV1(ContractModel):
-    """Proposed-only P7A output. It is deliberately not a real gateway grant."""
+    """Proposed-only P7A output. It is deliberately not a gateway grant."""
 
-    schema_version: Literal[SHADOW_ACTIVATION_SCHEMA] = SHADOW_ACTIVATION_SCHEMA
+    schema_version: Literal[SHADOW_ACTIVATION_SCHEMA] = (
+        SHADOW_ACTIVATION_SCHEMA
+    )
     activation_contract: CompositionActivationContractV1
     verification_plan: VerificationPlan
     validation_mode: AcceptedValidationMode
@@ -235,8 +281,20 @@ class ShadowCompositionActivationProposalV1(ContractModel):
         if not trace.has_valid_sha256():
             raise ValueError("shadow differential trace hash is invalid")
         if (
-            activation.verification_plan_ref != verification.verification_plan_id
+            activation.request_id != verification.request_id
+            or activation.run_id != verification.run_id
+            or activation.generation != verification.generation
+            or activation.request_id != trace.request_id
+            or activation.run_id != trace.run_id
+            or activation.generation != trace.generation
+            or activation.composition_plan_id != trace.composition_plan_id
+            or activation.composition_plan_sha256
+            != trace.composition_plan_sha256
+            or activation.verification_plan_ref
+            != verification.verification_plan_id
             or verification.plan_sha256 != trace.verification_plan_sha256
+            or verification.registry_snapshot_sha256
+            != self.verification_registry_sha256
             or self.validation_sha256 != trace.validation_sha256
             or self.action_registry_sha256 != trace.action_registry_sha256
             or self.verification_registry_sha256
@@ -244,7 +302,9 @@ class ShadowCompositionActivationProposalV1(ContractModel):
             or activation.allowed_action_ids
             != trace.proposed_allowed_action_ids
         ):
-            raise ValueError("shadow activation output bindings are inconsistent")
+            raise ValueError(
+                "shadow activation output bindings are inconsistent"
+            )
         return self
 
     def computed_sha256(self) -> str:
@@ -255,8 +315,12 @@ class ShadowCompositionActivationProposalV1(ContractModel):
     def has_valid_sha256(self) -> bool:
         return self.proposal_sha256 == self.computed_sha256()
 
-    def with_computed_sha256(self) -> "ShadowCompositionActivationProposalV1":
-        return self.model_copy(update={"proposal_sha256": self.computed_sha256()})
+    def with_computed_sha256(
+        self,
+    ) -> "ShadowCompositionActivationProposalV1":
+        return self.model_copy(
+            update={"proposal_sha256": self.computed_sha256()}
+        )
 
 
 def build_system_verification_binding(
@@ -281,7 +345,8 @@ def build_system_verification_binding(
         if descriptor.has_valid_descriptor_sha256()
         and descriptor.layer == "L0_DETERMINISTIC"
         and descriptor.deterministic
-        and predicate.predicate_type in descriptor.supported_predicate_types
+        and predicate.predicate_type
+        in descriptor.supported_predicate_types
         and predicate.subject_kind in descriptor.supported_subject_kinds
     )
     if len(eligible) != 1:
@@ -327,7 +392,9 @@ def _validate_plan_and_registry(
             "shadow.source_manifest.hash_invalid"
         )
 
-    planned_actions = tuple(sorted(set(step.action_id for step in plan.steps)))
+    planned_actions = tuple(
+        sorted(set(step.action_id for step in plan.steps))
+    )
     if (
         plan.permission_requirements
         != tuple(sorted(set(plan.permission_requirements)))
@@ -473,8 +540,12 @@ def _compile_verification_plan(
             entry_sha256="0" * 64,
         ).with_computed_sha256()
         entries.append(entry)
-    entries_tuple = tuple(sorted(entries, key=lambda item: item.plan_entry_id))
-    if len({entry.plan_entry_id for entry in entries_tuple}) != len(entries_tuple):
+    entries_tuple = tuple(
+        sorted(entries, key=lambda item: item.plan_entry_id)
+    )
+    if len({entry.plan_entry_id for entry in entries_tuple}) != len(
+        entries_tuple
+    ):
         raise CompositionShadowActivationError(
             "shadow.verification_entries.duplicate"
         )
@@ -534,15 +605,36 @@ def propose_shadow_composition_activation(
     verification_registry: RegistrySnapshot,
     verification_bindings: tuple[SystemVerificationBindingV1, ...],
     *,
+    current_world_state_sha256: str,
+    expected_principal_scope_hash: str,
     issued_at_ms: int,
     expires_at_ms: int,
     legacy_allowed_action_ids: tuple[str, ...] = (),
 ) -> ShadowCompositionActivationProposalV1:
     """Create a fully checked proposal without persistence or authority."""
 
+    _require_sha256(current_world_state_sha256, "current WorldState")
+    _require_sha256(expected_principal_scope_hash, "principal scope")
+    if plan.world_state_sha256 != current_world_state_sha256:
+        raise CompositionShadowActivationError(
+            "shadow.world_state.mismatch"
+        )
+    if plan.principal_scope_hash != expected_principal_scope_hash:
+        raise CompositionShadowActivationError(
+            "shadow.principal_scope.mismatch"
+        )
     if not 0 <= issued_at_ms < expires_at_ms <= issued_at_ms + 60_000:
         raise CompositionShadowActivationError(
             "shadow.activation.lifetime_invalid"
+        )
+    validation_mode = _validate_validation(plan, validation)
+    if issued_at_ms < max(
+        plan.created_at_ms,
+        validation.validated_at_ms,
+        verification_registry.captured_at_ms,
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.activation.time_inverted"
         )
     if legacy_allowed_action_ids != tuple(
         sorted(set(legacy_allowed_action_ids))
@@ -550,7 +642,6 @@ def propose_shadow_composition_activation(
         raise CompositionShadowActivationError(
             "shadow.legacy_action_set.invalid"
         )
-    validation_mode = _validate_validation(plan, validation)
     planned_actions, versions = _validate_plan_and_registry(
         plan, action_registry
     )
@@ -573,6 +664,8 @@ def propose_shadow_composition_activation(
                 verification_registry.snapshot_sha256
             ),
             "verification_plan_sha256": verification_plan.plan_sha256,
+            "current_world_state_sha256": current_world_state_sha256,
+            "expected_principal_scope_hash": expected_principal_scope_hash,
             "issued_at_ms": issued_at_ms,
             "expires_at_ms": expires_at_ms,
         }
@@ -596,7 +689,9 @@ def propose_shadow_composition_activation(
         activation_sha256="0" * 64,
     )
     activation = activation.model_copy(
-        update={"activation_sha256": computed_activation_sha256(activation)}
+        update={
+            "activation_sha256": computed_activation_sha256(activation)
+        }
     )
 
     legacy = set(legacy_allowed_action_ids)
@@ -609,18 +704,15 @@ def propose_shadow_composition_activation(
         composition_plan_sha256=plan.plan_sha256,
         validation_sha256=validation.validation_sha256,
         action_registry_sha256=action_registry.registry_sha256,
-        verification_registry_sha256=verification_registry.snapshot_sha256,
+        verification_registry_sha256=(
+            verification_registry.snapshot_sha256
+        ),
         verification_plan_sha256=verification_plan.plan_sha256,
         planned_action_ids=planned_actions,
         proposed_allowed_action_ids=planned_actions,
         legacy_allowed_action_ids=legacy_allowed_action_ids,
         added_vs_legacy=tuple(sorted(proposed - legacy)),
         removed_vs_legacy=tuple(sorted(legacy - proposed)),
-        exact_action_set=True,
-        registry_subset=True,
-        source_manifest_exact=True,
-        action_versions_exact=True,
-        verification_bindings_complete=True,
         limited_production_eligible=limited_eligible,
         limited_rejection_codes=limited_reasons,
         trace_sha256="0" * 64,
@@ -631,7 +723,9 @@ def propose_shadow_composition_activation(
         validation_mode=validation_mode,
         validation_sha256=validation.validation_sha256,
         action_registry_sha256=action_registry.registry_sha256,
-        verification_registry_sha256=verification_registry.snapshot_sha256,
+        verification_registry_sha256=(
+            verification_registry.snapshot_sha256
+        ),
         differential_trace=trace,
         proposal_sha256="0" * 64,
     )

--- a/src/total_gateway/composition_activation_shadow.py
+++ b/src/total_gateway/composition_activation_shadow.py
@@ -1,0 +1,652 @@
+"""P7A shadow-only composition activation adapter.
+
+The adapter validates a system-compiled composition plan against the current
+Action Registry and P19 verifier RegistrySnapshot, then emits a proposed
+activation contract, a proposed VerificationPlan, and a deterministic
+differential trace.  It never writes GatewayStateStore, issues a real Grant or
+Ticket, invokes Runtime, runs a verifier, records PASS, or changes Completion.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Self
+
+from pydantic import Field, field_validator, model_validator
+
+from contracts import (
+    AcceptancePredicate,
+    ActionRegistrySnapshot,
+    CompositionActivationContractV1,
+    CompositionValidationResultV1,
+    RegistrySnapshot,
+    VerificationPlan,
+    VerificationPlanEntryV2,
+    canonical_sha256,
+)
+from contracts.capability_composition import (
+    CapabilityCompositionPlanV1,
+    SourceRevisionRefV1,
+)
+from contracts.models import ContractModel, OpaqueId, Sha256
+from world_understanding.capability_composition import (
+    plan_has_valid_sha256,
+    validation_has_valid_sha256,
+)
+
+
+SHADOW_ACTIVATION_SCHEMA = "tiangong.composition-shadow-activation.v1"
+SYSTEM_VERIFICATION_BINDING_SCHEMA = (
+    "tiangong.composition-system-verification-binding.v1"
+)
+
+EvaluationPhase = Literal[
+    "POST_EXECUTION",
+    "PRE_DELIVERY",
+    "DELIVERY_FINALIZATION",
+    "ASYNC_OBSERVATION",
+]
+AcceptedValidationMode = Literal["PROVED_VALID", "PROVISIONAL_UNKNOWN"]
+
+_HIGH_RISK_SIDE_EFFECTS = frozenset(
+    {
+        "credential_read",
+        "destructive",
+        "external_send",
+        "external_write",
+        "irreversible",
+    }
+)
+
+
+class CompositionShadowActivationError(ValueError):
+    def __init__(self, code: str, detail: str = "") -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(code if not detail else f"{code}: {detail}")
+
+
+def _sorted_unique(values: tuple[str, ...]) -> tuple[str, ...]:
+    if values != tuple(sorted(set(values))):
+        raise ValueError("set-like shadow activation fields must be sorted and unique")
+    return values
+
+
+def _source_sort_key(
+    source: SourceRevisionRefV1,
+) -> tuple[str, str, str, str, str, str]:
+    return (
+        source.source_kind,
+        source.semantic_id,
+        source.version,
+        source.source_sha256,
+        source.descriptor_sha256,
+        source.manifest_sha256 or "",
+    )
+
+
+def computed_activation_sha256(
+    activation: CompositionActivationContractV1,
+) -> str:
+    return canonical_sha256(
+        activation.model_dump(mode="json", exclude={"activation_sha256"})
+    )
+
+
+def activation_has_valid_sha256(
+    activation: CompositionActivationContractV1,
+) -> bool:
+    return activation.activation_sha256 == computed_activation_sha256(activation)
+
+
+def computed_composition_source_manifest_sha256(
+    plan: CapabilityCompositionPlanV1,
+) -> str:
+    action_sources = tuple(sorted(plan.action_source_refs, key=_source_sort_key))
+    method_sources = tuple(sorted(plan.method_source_refs, key=_source_sort_key))
+    return canonical_sha256(
+        {
+            "domain": "tiangong.capability-composition.source-manifest.v1",
+            "action_sources": [
+                item.model_dump(mode="json") for item in action_sources
+            ],
+            "method_sources": [
+                item.model_dump(mode="json") for item in method_sources
+            ],
+        }
+    )
+
+
+class SystemVerificationBindingV1(ContractModel):
+    """One system-resolved intent-to-P19 binding; never supplied by a model."""
+
+    schema_version: Literal[SYSTEM_VERIFICATION_BINDING_SCHEMA] = (
+        SYSTEM_VERIFICATION_BINDING_SCHEMA
+    )
+    intent_ref: OpaqueId
+    predicate: AcceptancePredicate
+    verifier_id: OpaqueId
+    verifier_version: str = Field(min_length=1, max_length=64)
+    subject_identity: str = Field(min_length=1, max_length=400)
+    evaluation_phase: EvaluationPhase
+    required: Literal[True] = True
+    registry_snapshot_sha256: Sha256
+    producer_component_id: Literal["tiangong-gateway"] = "tiangong-gateway"
+    model_generated: Literal[False] = False
+    binding_sha256: Sha256
+
+    @model_validator(mode="after")
+    def validate_binding(self) -> Self:
+        if not self.predicate.has_valid_identity():
+            raise ValueError("verification binding predicate identity is invalid")
+        return self
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(
+            self.model_dump(mode="json", exclude={"binding_sha256"})
+        )
+
+    def has_valid_sha256(self) -> bool:
+        return self.binding_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "SystemVerificationBindingV1":
+        return self.model_copy(update={"binding_sha256": self.computed_sha256()})
+
+
+class ShadowActivationDifferentialTraceV1(ContractModel):
+    schema_version: Literal[
+        "tiangong.composition-shadow-activation-trace.v1"
+    ] = "tiangong.composition-shadow-activation-trace.v1"
+    request_id: OpaqueId
+    run_id: OpaqueId
+    generation: int = Field(ge=0)
+    composition_plan_id: OpaqueId
+    composition_plan_sha256: Sha256
+    validation_sha256: Sha256
+    action_registry_sha256: Sha256
+    verification_registry_sha256: Sha256
+    verification_plan_sha256: Sha256
+    planned_action_ids: tuple[OpaqueId, ...] = Field(min_length=1)
+    proposed_allowed_action_ids: tuple[OpaqueId, ...] = Field(min_length=1)
+    legacy_allowed_action_ids: tuple[OpaqueId, ...] = ()
+    added_vs_legacy: tuple[OpaqueId, ...] = ()
+    removed_vs_legacy: tuple[OpaqueId, ...] = ()
+    exact_action_set: bool
+    registry_subset: bool
+    source_manifest_exact: bool
+    action_versions_exact: bool
+    verification_bindings_complete: bool
+    limited_production_eligible: bool
+    limited_rejection_codes: tuple[OpaqueId, ...] = ()
+    proposed_only: Literal[True] = True
+    persisted: Literal[False] = False
+    authorizes: Literal[False] = False
+    may_execute: Literal[False] = False
+    trace_sha256: Sha256
+
+    _sets = field_validator(
+        "planned_action_ids",
+        "proposed_allowed_action_ids",
+        "legacy_allowed_action_ids",
+        "added_vs_legacy",
+        "removed_vs_legacy",
+        "limited_rejection_codes",
+    )(_sorted_unique)
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(
+            self.model_dump(mode="json", exclude={"trace_sha256"})
+        )
+
+    def has_valid_sha256(self) -> bool:
+        return self.trace_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "ShadowActivationDifferentialTraceV1":
+        return self.model_copy(update={"trace_sha256": self.computed_sha256()})
+
+
+class ShadowCompositionActivationProposalV1(ContractModel):
+    """Proposed-only P7A output. It is deliberately not a real gateway grant."""
+
+    schema_version: Literal[SHADOW_ACTIVATION_SCHEMA] = SHADOW_ACTIVATION_SCHEMA
+    activation_contract: CompositionActivationContractV1
+    verification_plan: VerificationPlan
+    validation_mode: AcceptedValidationMode
+    validation_sha256: Sha256
+    action_registry_sha256: Sha256
+    verification_registry_sha256: Sha256
+    differential_trace: ShadowActivationDifferentialTraceV1
+    proposed_only: Literal[True] = True
+    persistence_allowed: Literal[False] = False
+    authorizes: Literal[False] = False
+    confirms: Literal[False] = False
+    changes_risk: Literal[False] = False
+    may_execute: Literal[False] = False
+    proposal_sha256: Sha256
+
+    @model_validator(mode="after")
+    def validate_proposal(self) -> Self:
+        activation = self.activation_contract
+        verification = self.verification_plan
+        trace = self.differential_trace
+        if not activation_has_valid_sha256(activation):
+            raise ValueError("shadow activation contract hash is invalid")
+        if not verification.has_valid_identity():
+            raise ValueError("shadow VerificationPlan identity is invalid")
+        if not trace.has_valid_sha256():
+            raise ValueError("shadow differential trace hash is invalid")
+        if (
+            activation.verification_plan_ref != verification.verification_plan_id
+            or verification.plan_sha256 != trace.verification_plan_sha256
+            or self.validation_sha256 != trace.validation_sha256
+            or self.action_registry_sha256 != trace.action_registry_sha256
+            or self.verification_registry_sha256
+            != trace.verification_registry_sha256
+            or activation.allowed_action_ids
+            != trace.proposed_allowed_action_ids
+        ):
+            raise ValueError("shadow activation output bindings are inconsistent")
+        return self
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(
+            self.model_dump(mode="json", exclude={"proposal_sha256"})
+        )
+
+    def has_valid_sha256(self) -> bool:
+        return self.proposal_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "ShadowCompositionActivationProposalV1":
+        return self.model_copy(update={"proposal_sha256": self.computed_sha256()})
+
+
+def build_system_verification_binding(
+    *,
+    intent_ref: str,
+    predicate: AcceptancePredicate,
+    subject_identity: str,
+    evaluation_phase: EvaluationPhase,
+    registry_snapshot: RegistrySnapshot,
+) -> SystemVerificationBindingV1:
+    """Resolve a verifier mechanically; callers cannot name the verifier."""
+
+    if not registry_snapshot.has_valid_identity():
+        raise CompositionShadowActivationError(
+            "shadow.verification_registry.invalid"
+        )
+    if not predicate.has_valid_identity():
+        raise CompositionShadowActivationError("shadow.predicate.invalid")
+    eligible = tuple(
+        descriptor
+        for descriptor in registry_snapshot.verifiers
+        if descriptor.has_valid_descriptor_sha256()
+        and descriptor.layer == "L0_DETERMINISTIC"
+        and descriptor.deterministic
+        and predicate.predicate_type in descriptor.supported_predicate_types
+        and predicate.subject_kind in descriptor.supported_subject_kinds
+    )
+    if len(eligible) != 1:
+        raise CompositionShadowActivationError(
+            "shadow.verifier_resolution.not_unique",
+            f"intent={intent_ref};eligible={len(eligible)}",
+        )
+    descriptor = eligible[0]
+    value = SystemVerificationBindingV1(
+        intent_ref=intent_ref,
+        predicate=predicate,
+        verifier_id=descriptor.verifier_id,
+        verifier_version=descriptor.verifier_version,
+        subject_identity=subject_identity,
+        evaluation_phase=evaluation_phase,
+        registry_snapshot_sha256=registry_snapshot.snapshot_sha256,
+        binding_sha256="0" * 64,
+    )
+    return value.with_computed_sha256()
+
+
+def _validate_plan_and_registry(
+    plan: CapabilityCompositionPlanV1,
+    action_registry: ActionRegistrySnapshot,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if not plan_has_valid_sha256(plan):
+        raise CompositionShadowActivationError("shadow.plan.hash_invalid")
+    if not action_registry.has_valid_sha256():
+        raise CompositionShadowActivationError(
+            "shadow.action_registry.hash_invalid"
+        )
+    if (
+        plan.capability_manifest_sha256
+        != action_registry.source_manifest_sha256
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.capability_manifest.mismatch"
+        )
+    if plan.source_manifest_sha256 != (
+        computed_composition_source_manifest_sha256(plan)
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.source_manifest.hash_invalid"
+        )
+
+    planned_actions = tuple(sorted(set(step.action_id for step in plan.steps)))
+    if (
+        plan.permission_requirements
+        != tuple(sorted(set(plan.permission_requirements)))
+        or planned_actions != plan.permission_requirements
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.plan.action_set_inconsistent"
+        )
+    source_by_action = {
+        source.semantic_id: source for source in plan.action_source_refs
+    }
+    if (
+        len(source_by_action) != len(plan.action_source_refs)
+        or tuple(sorted(source_by_action)) != planned_actions
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.plan.action_sources_incomplete"
+        )
+    permission_by_action = {
+        permission.action_id: permission
+        for permission in action_registry.permissions
+    }
+    versions: list[str] = []
+    for action_id in planned_actions:
+        permission = permission_by_action.get(action_id)
+        source = source_by_action[action_id]
+        step_versions = {
+            step.action_version
+            for step in plan.steps
+            if step.action_id == action_id
+        }
+        if permission is None:
+            raise CompositionShadowActivationError(
+                "shadow.action.not_registered", action_id
+            )
+        if (
+            step_versions != {permission.action_version}
+            or source.source_kind != "TOOL_ACTION"
+            or source.semantic_id != action_id
+            or source.version != permission.action_version
+            or source.manifest_sha256
+            != action_registry.source_manifest_sha256
+        ):
+            raise CompositionShadowActivationError(
+                "shadow.action.version_or_source_mismatch", action_id
+            )
+        versions.append(permission.action_version)
+    return planned_actions, tuple(versions)
+
+
+def _validate_validation(
+    plan: CapabilityCompositionPlanV1,
+    validation: CompositionValidationResultV1,
+) -> AcceptedValidationMode:
+    if not validation_has_valid_sha256(validation):
+        raise CompositionShadowActivationError(
+            "shadow.validation.hash_invalid"
+        )
+    if (
+        validation.plan_id != plan.plan_id
+        or validation.plan_sha256 != plan.plan_sha256
+        or validation.validated_at_ms < plan.created_at_ms
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.validation.plan_binding_mismatch"
+        )
+    if validation.result == "PROVED_VALID":
+        if validation.mandatory_verification:
+            raise CompositionShadowActivationError(
+                "shadow.validation.valid_flag_inconsistent"
+            )
+        return "PROVED_VALID"
+    if (
+        validation.result == "UNKNOWN"
+        and validation.unknown_disposition == "PROVISIONAL_ALLOW"
+        and validation.mandatory_verification
+    ):
+        return "PROVISIONAL_UNKNOWN"
+    raise CompositionShadowActivationError(
+        "shadow.validation.not_activatable", validation.result
+    )
+
+
+def _compile_verification_plan(
+    plan: CapabilityCompositionPlanV1,
+    registry_snapshot: RegistrySnapshot,
+    bindings: tuple[SystemVerificationBindingV1, ...],
+) -> VerificationPlan:
+    if not registry_snapshot.has_valid_identity():
+        raise CompositionShadowActivationError(
+            "shadow.verification_registry.invalid"
+        )
+    intents = tuple(plan.verification_intents)
+    if not intents or intents != tuple(sorted(set(intents))):
+        raise CompositionShadowActivationError(
+            "shadow.verification_intents.invalid"
+        )
+    binding_intents = tuple(binding.intent_ref for binding in bindings)
+    if binding_intents != tuple(sorted(set(binding_intents))):
+        raise CompositionShadowActivationError(
+            "shadow.verification_bindings.order_or_duplicate"
+        )
+    if binding_intents != intents:
+        raise CompositionShadowActivationError(
+            "shadow.verification_bindings.incomplete"
+        )
+
+    entries: list[VerificationPlanEntryV2] = []
+    for binding in bindings:
+        if (
+            not binding.has_valid_sha256()
+            or binding.registry_snapshot_sha256
+            != registry_snapshot.snapshot_sha256
+            or binding.model_generated
+        ):
+            raise CompositionShadowActivationError(
+                "shadow.verification_binding.invalid", binding.intent_ref
+            )
+        descriptor = registry_snapshot.find(binding.verifier_id)
+        if (
+            descriptor is None
+            or not descriptor.has_valid_descriptor_sha256()
+            or descriptor.verifier_version != binding.verifier_version
+            or descriptor.layer != "L0_DETERMINISTIC"
+            or not descriptor.deterministic
+            or binding.predicate.predicate_type
+            not in descriptor.supported_predicate_types
+            or binding.predicate.subject_kind
+            not in descriptor.supported_subject_kinds
+        ):
+            raise CompositionShadowActivationError(
+                "shadow.verification_binding.registry_mismatch",
+                binding.intent_ref,
+            )
+        entry = VerificationPlanEntryV2(
+            plan_entry_id="vpe_" + "0" * 64,
+            verifier_id=binding.verifier_id,
+            verifier_version=binding.verifier_version,
+            predicate=binding.predicate,
+            subject_identity=binding.subject_identity,
+            evaluation_phase=binding.evaluation_phase,
+            required=True,
+            entry_sha256="0" * 64,
+        ).with_computed_sha256()
+        entries.append(entry)
+    entries_tuple = tuple(sorted(entries, key=lambda item: item.plan_entry_id))
+    if len({entry.plan_entry_id for entry in entries_tuple}) != len(entries_tuple):
+        raise CompositionShadowActivationError(
+            "shadow.verification_entries.duplicate"
+        )
+    verification_plan = VerificationPlan(
+        verification_plan_id="vpl_" + "0" * 64,
+        request_id=plan.request_id,
+        run_id=plan.run_id,
+        generation=plan.generation,
+        registry_snapshot_sha256=registry_snapshot.snapshot_sha256,
+        entries=entries_tuple,
+        plan_sha256="0" * 64,
+    ).with_computed_sha256()
+    if not verification_plan.has_valid_identity():
+        raise CompositionShadowActivationError(
+            "shadow.verification_plan.identity_invalid"
+        )
+    return verification_plan
+
+
+def _limited_eligibility(
+    *,
+    plan: CapabilityCompositionPlanV1,
+    action_registry: ActionRegistrySnapshot,
+    verification_plan: VerificationPlan,
+) -> tuple[bool, tuple[str, ...]]:
+    permission_by_action = {
+        permission.action_id: permission
+        for permission in action_registry.permissions
+    }
+    reasons: set[str] = set()
+    if plan.composition_risk not in {"A0", "A1"}:
+        reasons.add("limited.composition_risk_not_a0_a1")
+    for action_id in plan.permission_requirements:
+        permission = permission_by_action[action_id]
+        if permission.effective_risk not in {"A0", "A1"}:
+            reasons.add("limited.action_risk_not_a0_a1")
+        if permission.effect not in {"read", "verify"}:
+            reasons.add("limited.effect_not_read_verify")
+        if permission.allow_shell:
+            reasons.add("limited.shell_forbidden")
+        if permission.allow_python:
+            reasons.add("limited.python_forbidden")
+        if set(permission.allowed_side_effects) & _HIGH_RISK_SIDE_EFFECTS:
+            reasons.add("limited.high_risk_side_effect")
+    if not verification_plan.entries or any(
+        not entry.required or not entry.has_valid_identity()
+        for entry in verification_plan.entries
+    ):
+        reasons.add("limited.verification_incomplete")
+    return not reasons, tuple(sorted(reasons))
+
+
+def propose_shadow_composition_activation(
+    plan: CapabilityCompositionPlanV1,
+    validation: CompositionValidationResultV1,
+    action_registry: ActionRegistrySnapshot,
+    verification_registry: RegistrySnapshot,
+    verification_bindings: tuple[SystemVerificationBindingV1, ...],
+    *,
+    issued_at_ms: int,
+    expires_at_ms: int,
+    legacy_allowed_action_ids: tuple[str, ...] = (),
+) -> ShadowCompositionActivationProposalV1:
+    """Create a fully checked proposal without persistence or authority."""
+
+    if not 0 <= issued_at_ms < expires_at_ms <= issued_at_ms + 60_000:
+        raise CompositionShadowActivationError(
+            "shadow.activation.lifetime_invalid"
+        )
+    if legacy_allowed_action_ids != tuple(
+        sorted(set(legacy_allowed_action_ids))
+    ):
+        raise CompositionShadowActivationError(
+            "shadow.legacy_action_set.invalid"
+        )
+    validation_mode = _validate_validation(plan, validation)
+    planned_actions, versions = _validate_plan_and_registry(
+        plan, action_registry
+    )
+    verification_plan = _compile_verification_plan(
+        plan, verification_registry, verification_bindings
+    )
+    limited_eligible, limited_reasons = _limited_eligibility(
+        plan=plan,
+        action_registry=action_registry,
+        verification_plan=verification_plan,
+    )
+
+    activation_identity = canonical_sha256(
+        {
+            "domain": SHADOW_ACTIVATION_SCHEMA,
+            "composition_plan_sha256": plan.plan_sha256,
+            "validation_sha256": validation.validation_sha256,
+            "action_registry_sha256": action_registry.registry_sha256,
+            "verification_registry_sha256": (
+                verification_registry.snapshot_sha256
+            ),
+            "verification_plan_sha256": verification_plan.plan_sha256,
+            "issued_at_ms": issued_at_ms,
+            "expires_at_ms": expires_at_ms,
+        }
+    )
+    activation = CompositionActivationContractV1(
+        composition_activation_id="activation_" + activation_identity,
+        composition_plan_id=plan.plan_id,
+        composition_plan_sha256=plan.plan_sha256,
+        request_id=plan.request_id,
+        run_id=plan.run_id,
+        generation=plan.generation,
+        principal_scope_hash=plan.principal_scope_hash,
+        world_state_sha256=plan.world_state_sha256,
+        source_manifest_sha256=plan.source_manifest_sha256,
+        capability_manifest_sha256=plan.capability_manifest_sha256,
+        allowed_action_ids=planned_actions,
+        allowed_action_versions=versions,
+        verification_plan_ref=verification_plan.verification_plan_id,
+        issued_at_ms=issued_at_ms,
+        expires_at_ms=expires_at_ms,
+        activation_sha256="0" * 64,
+    )
+    activation = activation.model_copy(
+        update={"activation_sha256": computed_activation_sha256(activation)}
+    )
+
+    legacy = set(legacy_allowed_action_ids)
+    proposed = set(planned_actions)
+    trace = ShadowActivationDifferentialTraceV1(
+        request_id=plan.request_id,
+        run_id=plan.run_id,
+        generation=plan.generation,
+        composition_plan_id=plan.plan_id,
+        composition_plan_sha256=plan.plan_sha256,
+        validation_sha256=validation.validation_sha256,
+        action_registry_sha256=action_registry.registry_sha256,
+        verification_registry_sha256=verification_registry.snapshot_sha256,
+        verification_plan_sha256=verification_plan.plan_sha256,
+        planned_action_ids=planned_actions,
+        proposed_allowed_action_ids=planned_actions,
+        legacy_allowed_action_ids=legacy_allowed_action_ids,
+        added_vs_legacy=tuple(sorted(proposed - legacy)),
+        removed_vs_legacy=tuple(sorted(legacy - proposed)),
+        exact_action_set=True,
+        registry_subset=True,
+        source_manifest_exact=True,
+        action_versions_exact=True,
+        verification_bindings_complete=True,
+        limited_production_eligible=limited_eligible,
+        limited_rejection_codes=limited_reasons,
+        trace_sha256="0" * 64,
+    ).with_computed_sha256()
+    proposal = ShadowCompositionActivationProposalV1(
+        activation_contract=activation,
+        verification_plan=verification_plan,
+        validation_mode=validation_mode,
+        validation_sha256=validation.validation_sha256,
+        action_registry_sha256=action_registry.registry_sha256,
+        verification_registry_sha256=verification_registry.snapshot_sha256,
+        differential_trace=trace,
+        proposal_sha256="0" * 64,
+    )
+    return proposal.with_computed_sha256()
+
+
+__all__ = [
+    "CompositionShadowActivationError",
+    "SHADOW_ACTIVATION_SCHEMA",
+    "ShadowActivationDifferentialTraceV1",
+    "ShadowCompositionActivationProposalV1",
+    "SystemVerificationBindingV1",
+    "activation_has_valid_sha256",
+    "build_system_verification_binding",
+    "computed_activation_sha256",
+    "computed_composition_source_manifest_sha256",
+    "propose_shadow_composition_activation",
+]

--- a/tests/test_composition_activation_shadow_p7a.py
+++ b/tests/test_composition_activation_shadow_p7a.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from contracts import (
+    AcceptancePredicate,
+    CompositionValidationResultV1,
+)
+from total_gateway.composition_activation_shadow import (
+    CompositionShadowActivationError,
+    activation_has_valid_sha256,
+    build_system_verification_binding,
+    propose_shadow_composition_activation,
+)
+from total_gateway.verification_registry import VerifierRegistry
+from world_understanding.capability_composition import (
+    build_candidate_snapshot,
+    compile_capability_composition_plan,
+    computed_plan_sha256,
+    computed_validation_sha256,
+    parse_composition_proposal,
+    validate_capability_composition_plan,
+)
+
+from tests.test_capability_composition_p4 import (
+    _context,
+    _proposal_document,
+    _single_read_fixture,
+    _worlds,
+)
+
+
+def _validated_read_plan():
+    action_registry, candidates, context, document = _single_read_fixture()
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, action_registry
+    )
+    validation = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        action_registry,
+        available_verifiers=frozenset(plan.verification_intents),
+        validated_at_ms=11,
+    )
+    assert validation.result == "PROVED_VALID"
+    verification_registry = VerifierRegistry.with_defaults().snapshot(
+        captured_at_ms=12
+    )
+    predicate = AcceptancePredicate.create(
+        predicate_type="artifact.nonempty",
+        subject_kind="artifact",
+        params={},
+    )
+    binding = build_system_verification_binding(
+        intent_ref=plan.verification_intents[0],
+        predicate=predicate,
+        subject_identity="object:artifact-read-output",
+        evaluation_phase="POST_EXECUTION",
+        registry_snapshot=verification_registry,
+    )
+    return action_registry, plan, validation, verification_registry, (binding,)
+
+
+def _validation_for(plan, *, result="PROVED_VALID"):
+    value = CompositionValidationResultV1(
+        plan_id=plan.plan_id,
+        plan_sha256=plan.plan_sha256,
+        result=result,
+        unknown_disposition=(
+            "PROVISIONAL_ALLOW" if result == "UNKNOWN" else "NOT_APPLICABLE"
+        ),
+        findings=(),
+        mandatory_verification=result == "UNKNOWN",
+        validated_at_ms=max(11, plan.created_at_ms),
+        validation_sha256="0" * 64,
+    )
+    return value.model_copy(
+        update={"validation_sha256": computed_validation_sha256(value)}
+    )
+
+
+def test_shadow_adapter_proposes_exact_activation_and_p19_plan() -> None:
+    action_registry, plan, validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    result = propose_shadow_composition_activation(
+        plan,
+        validation,
+        action_registry,
+        verifier_registry,
+        bindings,
+        issued_at_ms=20,
+        expires_at_ms=60,
+        legacy_allowed_action_ids=(),
+    )
+    activation = result.activation_contract
+    verification_plan = result.verification_plan
+    assert result.has_valid_sha256()
+    assert activation_has_valid_sha256(activation)
+    assert verification_plan.has_valid_identity()
+    assert activation.composition_plan_id == plan.plan_id
+    assert activation.composition_plan_sha256 == plan.plan_sha256
+    assert activation.request_id == plan.request_id
+    assert activation.run_id == plan.run_id
+    assert activation.generation == plan.generation
+    assert activation.principal_scope_hash == plan.principal_scope_hash
+    assert activation.world_state_sha256 == plan.world_state_sha256
+    assert activation.source_manifest_sha256 == plan.source_manifest_sha256
+    assert (
+        activation.capability_manifest_sha256
+        == action_registry.source_manifest_sha256
+    )
+    assert activation.allowed_action_ids == plan.permission_requirements
+    assert activation.allowed_action_versions == ("omni-registry-v1",)
+    assert activation.verification_plan_ref == (
+        verification_plan.verification_plan_id
+    )
+    assert verification_plan.registry_snapshot_sha256 == (
+        verifier_registry.snapshot_sha256
+    )
+    assert verification_plan.entries[0].predicate.predicate_type == (
+        "artifact.nonempty"
+    )
+    assert result.proposed_only is True
+    assert result.persistence_allowed is False
+    assert result.authorizes is False
+    assert result.confirms is False
+    assert result.changes_risk is False
+    assert result.may_execute is False
+    assert result.differential_trace.persisted is False
+    assert result.differential_trace.authorizes is False
+    assert result.differential_trace.may_execute is False
+    assert result.differential_trace.registry_subset is True
+    assert result.differential_trace.exact_action_set is True
+    assert result.differential_trace.verification_bindings_complete is True
+    assert result.differential_trace.limited_production_eligible is True
+
+
+def test_shadow_adapter_is_deterministic_and_records_legacy_difference() -> None:
+    action_registry, plan, validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    kwargs = dict(
+        issued_at_ms=20,
+        expires_at_ms=60,
+        legacy_allowed_action_ids=("legacy.only",),
+    )
+    first = propose_shadow_composition_activation(
+        plan,
+        validation,
+        action_registry,
+        verifier_registry,
+        bindings,
+        **kwargs,
+    )
+    second = propose_shadow_composition_activation(
+        plan,
+        validation,
+        action_registry,
+        verifier_registry,
+        bindings,
+        **kwargs,
+    )
+    assert first == second
+    assert first.proposal_sha256 == second.proposal_sha256
+    trace = first.differential_trace
+    assert trace.added_vs_legacy == plan.permission_requirements
+    assert trace.removed_vs_legacy == ("legacy.only",)
+
+
+def test_model_cannot_name_verifier_and_resolution_requires_one_exact_match() -> None:
+    _action_registry, plan, _validation, registry, _bindings = (
+        _validated_read_plan()
+    )
+    predicate = AcceptancePredicate.create(
+        predicate_type="artifact.nonempty",
+        subject_kind="artifact",
+        params={},
+    )
+    without_artifact = VerifierRegistry(
+        tuple(
+            descriptor
+            for descriptor in registry.verifiers
+            if descriptor.verifier_id != "verifier.artifact_content"
+        )
+    ).snapshot(captured_at_ms=13)
+    with pytest.raises(
+        CompositionShadowActivationError,
+        match="verifier_resolution.not_unique",
+    ):
+        build_system_verification_binding(
+            intent_ref=plan.verification_intents[0],
+            predicate=predicate,
+            subject_identity="object:artifact-read-output",
+            evaluation_phase="POST_EXECUTION",
+            registry_snapshot=without_artifact,
+        )
+
+
+def test_missing_or_drifted_verification_binding_fails_closed() -> None:
+    action_registry, plan, validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    with pytest.raises(
+        CompositionShadowActivationError,
+        match="verification_bindings.incomplete",
+    ):
+        propose_shadow_composition_activation(
+            plan,
+            validation,
+            action_registry,
+            verifier_registry,
+            (),
+            issued_at_ms=20,
+            expires_at_ms=60,
+        )
+
+    drifted = bindings[0].model_copy(
+        update={"registry_snapshot_sha256": "a" * 64}
+    )
+    with pytest.raises(
+        CompositionShadowActivationError,
+        match="verification_binding.invalid",
+    ):
+        propose_shadow_composition_activation(
+            plan,
+            validation,
+            action_registry,
+            verifier_registry,
+            (drifted,),
+            issued_at_ms=20,
+            expires_at_ms=60,
+        )
+
+
+def test_permission_expansion_and_source_drift_fail_closed() -> None:
+    action_registry, plan, _validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    expanded = plan.model_copy(
+        update={
+            "permission_requirements": (
+                *plan.permission_requirements,
+                "invented.action",
+            ),
+            "plan_sha256": "0" * 64,
+        }
+    )
+    expanded = expanded.model_copy(
+        update={"plan_sha256": computed_plan_sha256(expanded)}
+    )
+    with pytest.raises(
+        CompositionShadowActivationError,
+        match="plan.action_set_inconsistent",
+    ):
+        propose_shadow_composition_activation(
+            expanded,
+            _validation_for(expanded),
+            action_registry,
+            verifier_registry,
+            bindings,
+            issued_at_ms=20,
+            expires_at_ms=60,
+        )
+
+    source = plan.action_source_refs[0].model_copy(
+        update={"manifest_sha256": "b" * 64}
+    )
+    drifted = plan.model_copy(
+        update={
+            "action_source_refs": (source,),
+            "plan_sha256": "0" * 64,
+        }
+    )
+    drifted = drifted.model_copy(
+        update={"plan_sha256": computed_plan_sha256(drifted)}
+    )
+    with pytest.raises(
+        CompositionShadowActivationError,
+        match="source_manifest.hash_invalid|version_or_source_mismatch",
+    ):
+        propose_shadow_composition_activation(
+            drifted,
+            _validation_for(drifted),
+            action_registry,
+            verifier_registry,
+            bindings,
+            issued_at_ms=20,
+            expires_at_ms=60,
+        )
+
+
+def test_only_valid_or_provisional_unknown_validation_is_shadow_activatable() -> None:
+    action_registry, plan, _validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    unknown = _validation_for(plan, result="UNKNOWN")
+    proposed = propose_shadow_composition_activation(
+        plan,
+        unknown,
+        action_registry,
+        verifier_registry,
+        bindings,
+        issued_at_ms=20,
+        expires_at_ms=60,
+    )
+    assert proposed.validation_mode == "PROVISIONAL_UNKNOWN"
+    assert proposed.verification_plan.entries[0].required is True
+
+    invalid = _validation_for(plan, result="PROVED_INVALID")
+    with pytest.raises(
+        CompositionShadowActivationError,
+        match="validation.not_activatable",
+    ):
+        propose_shadow_composition_activation(
+            plan,
+            invalid,
+            action_registry,
+            verifier_registry,
+            bindings,
+            issued_at_ms=20,
+            expires_at_ms=60,
+        )
+
+
+def test_a2_write_can_be_compared_in_shadow_but_is_not_limited_eligible() -> None:
+    specs = (
+        {
+            "action_id": "artifact.write",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("local_write", "read"),
+            "write_set": ("resource:artifact",),
+        },
+    )
+    action_registry, tool_world, method_world = _worlds(specs)
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("artifact.write",),
+    )
+    document = _proposal_document(
+        goal_ref="goal.shadow-write",
+        methods=("M01",),
+        actions=("A01",),
+        steps=(("step.01", "A01", ()),),
+    )
+    proposal = parse_composition_proposal(document, candidates)
+    context = _context(goal_ref="goal.shadow-write")
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, action_registry
+    )
+    validation = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        action_registry,
+        available_verifiers=frozenset(plan.verification_intents),
+        validated_at_ms=11,
+    )
+    assert validation.result == "PROVED_VALID"
+    verifier_registry = VerifierRegistry.with_defaults().snapshot(
+        captured_at_ms=12
+    )
+    binding = build_system_verification_binding(
+        intent_ref=plan.verification_intents[0],
+        predicate=AcceptancePredicate.create(
+            predicate_type="artifact.nonempty",
+            subject_kind="artifact",
+            params={},
+        ),
+        subject_identity="object:written-artifact",
+        evaluation_phase="POST_EXECUTION",
+        registry_snapshot=verifier_registry,
+    )
+    result = propose_shadow_composition_activation(
+        plan,
+        validation,
+        action_registry,
+        verifier_registry,
+        (binding,),
+        issued_at_ms=20,
+        expires_at_ms=60,
+    )
+    assert result.proposed_only is True
+    assert result.differential_trace.limited_production_eligible is False
+    assert "limited.composition_risk_not_a0_a1" in (
+        result.differential_trace.limited_rejection_codes
+    )
+    assert "limited.effect_not_read_verify" in (
+        result.differential_trace.limited_rejection_codes
+    )
+
+
+def test_p7a_module_has_no_store_runtime_ticket_or_verifier_execution_path() -> None:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "total_gateway"
+        / "composition_activation_shadow.py"
+    )
+    source = path.read_text(encoding="utf-8")
+    forbidden = (
+        "GatewayStateStore",
+        "put_verification_plan",
+        "ExecutionTicket(",
+        "OmniCapabilityGrant(",
+        "BodyRuntime",
+        "VerificationPlanExecutor",
+        "VerificationRecorder",
+        ".execute(",
+        ".dispatch(",
+        "status=\"PASS\"",
+        "status='PASS'",
+    )
+    for token in forbidden:
+        assert token not in source, token

--- a/tests/test_composition_activation_shadow_p7a.py
+++ b/tests/test_composition_activation_shadow_p7a.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
 
-from contracts import (
-    AcceptancePredicate,
-    CompositionValidationResultV1,
-)
+from contracts.capability_composition import CompositionValidationResultV1
+from contracts.verification import AcceptancePredicate
 from total_gateway.composition_activation_shadow import (
     CompositionShadowActivationError,
     activation_has_valid_sha256,
@@ -72,7 +71,9 @@ def _validation_for(plan, *, result="PROVED_VALID"):
         plan_sha256=plan.plan_sha256,
         result=result,
         unknown_disposition=(
-            "PROVISIONAL_ALLOW" if result == "UNKNOWN" else "NOT_APPLICABLE"
+            "PROVISIONAL_ALLOW"
+            if result == "UNKNOWN"
+            else "NOT_APPLICABLE"
         ),
         findings=(),
         mandatory_verification=result == "UNKNOWN",
@@ -84,19 +85,51 @@ def _validation_for(plan, *, result="PROVED_VALID"):
     )
 
 
-def test_shadow_adapter_proposes_exact_activation_and_p19_plan() -> None:
-    action_registry, plan, validation, verifier_registry, bindings = (
-        _validated_read_plan()
-    )
-    result = propose_shadow_composition_activation(
+def _propose(
+    action_registry,
+    plan,
+    validation,
+    verifier_registry,
+    bindings,
+    *,
+    current_world_state_sha256=None,
+    expected_principal_scope_hash=None,
+    issued_at_ms=20,
+    expires_at_ms=60,
+    legacy_allowed_action_ids=(),
+):
+    return propose_shadow_composition_activation(
         plan,
         validation,
         action_registry,
         verifier_registry,
         bindings,
-        issued_at_ms=20,
-        expires_at_ms=60,
-        legacy_allowed_action_ids=(),
+        current_world_state_sha256=(
+            plan.world_state_sha256
+            if current_world_state_sha256 is None
+            else current_world_state_sha256
+        ),
+        expected_principal_scope_hash=(
+            plan.principal_scope_hash
+            if expected_principal_scope_hash is None
+            else expected_principal_scope_hash
+        ),
+        issued_at_ms=issued_at_ms,
+        expires_at_ms=expires_at_ms,
+        legacy_allowed_action_ids=legacy_allowed_action_ids,
+    )
+
+
+def test_shadow_adapter_proposes_exact_activation_and_p19_plan() -> None:
+    action_registry, plan, validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    result = _propose(
+        action_registry,
+        plan,
+        validation,
+        verifier_registry,
+        bindings,
     )
     activation = result.activation_contract
     verification_plan = result.verification_plan
@@ -117,14 +150,17 @@ def test_shadow_adapter_proposes_exact_activation_and_p19_plan() -> None:
     )
     assert activation.allowed_action_ids == plan.permission_requirements
     assert activation.allowed_action_versions == ("omni-registry-v1",)
-    assert activation.verification_plan_ref == (
-        verification_plan.verification_plan_id
+    assert (
+        activation.verification_plan_ref
+        == verification_plan.verification_plan_id
     )
-    assert verification_plan.registry_snapshot_sha256 == (
-        verifier_registry.snapshot_sha256
+    assert (
+        verification_plan.registry_snapshot_sha256
+        == verifier_registry.snapshot_sha256
     )
-    assert verification_plan.entries[0].predicate.predicate_type == (
-        "artifact.nonempty"
+    assert (
+        verification_plan.entries[0].predicate.predicate_type
+        == "artifact.nonempty"
     )
     assert result.proposed_only is True
     assert result.persistence_allowed is False
@@ -132,39 +168,35 @@ def test_shadow_adapter_proposes_exact_activation_and_p19_plan() -> None:
     assert result.confirms is False
     assert result.changes_risk is False
     assert result.may_execute is False
-    assert result.differential_trace.persisted is False
-    assert result.differential_trace.authorizes is False
-    assert result.differential_trace.may_execute is False
-    assert result.differential_trace.registry_subset is True
-    assert result.differential_trace.exact_action_set is True
-    assert result.differential_trace.verification_bindings_complete is True
-    assert result.differential_trace.limited_production_eligible is True
+    trace = result.differential_trace
+    assert trace.persisted is False
+    assert trace.authorizes is False
+    assert trace.may_execute is False
+    assert trace.registry_subset is True
+    assert trace.exact_action_set is True
+    assert trace.verification_bindings_complete is True
+    assert trace.limited_production_eligible is True
 
 
 def test_shadow_adapter_is_deterministic_and_records_legacy_difference() -> None:
     action_registry, plan, validation, verifier_registry, bindings = (
         _validated_read_plan()
     )
-    kwargs = dict(
-        issued_at_ms=20,
-        expires_at_ms=60,
+    first = _propose(
+        action_registry,
+        plan,
+        validation,
+        verifier_registry,
+        bindings,
         legacy_allowed_action_ids=("legacy.only",),
     )
-    first = propose_shadow_composition_activation(
+    second = _propose(
+        action_registry,
         plan,
         validation,
-        action_registry,
         verifier_registry,
         bindings,
-        **kwargs,
-    )
-    second = propose_shadow_composition_activation(
-        plan,
-        validation,
-        action_registry,
-        verifier_registry,
-        bindings,
-        **kwargs,
+        legacy_allowed_action_ids=("legacy.only",),
     )
     assert first == second
     assert first.proposal_sha256 == second.proposal_sha256
@@ -210,14 +242,12 @@ def test_missing_or_drifted_verification_binding_fails_closed() -> None:
         CompositionShadowActivationError,
         match="verification_bindings.incomplete",
     ):
-        propose_shadow_composition_activation(
+        _propose(
+            action_registry,
             plan,
             validation,
-            action_registry,
             verifier_registry,
             (),
-            issued_at_ms=20,
-            expires_at_ms=60,
         )
 
     drifted = bindings[0].model_copy(
@@ -227,14 +257,12 @@ def test_missing_or_drifted_verification_binding_fails_closed() -> None:
         CompositionShadowActivationError,
         match="verification_binding.invalid",
     ):
-        propose_shadow_composition_activation(
+        _propose(
+            action_registry,
             plan,
             validation,
-            action_registry,
             verifier_registry,
             (drifted,),
-            issued_at_ms=20,
-            expires_at_ms=60,
         )
 
 
@@ -258,14 +286,12 @@ def test_permission_expansion_and_source_drift_fail_closed() -> None:
         CompositionShadowActivationError,
         match="plan.action_set_inconsistent",
     ):
-        propose_shadow_composition_activation(
+        _propose(
+            action_registry,
             expanded,
             _validation_for(expanded),
-            action_registry,
             verifier_registry,
             bindings,
-            issued_at_ms=20,
-            expires_at_ms=60,
         )
 
     source = plan.action_source_refs[0].model_copy(
@@ -284,14 +310,12 @@ def test_permission_expansion_and_source_drift_fail_closed() -> None:
         CompositionShadowActivationError,
         match="source_manifest.hash_invalid|version_or_source_mismatch",
     ):
-        propose_shadow_composition_activation(
+        _propose(
+            action_registry,
             drifted,
             _validation_for(drifted),
-            action_registry,
             verifier_registry,
             bindings,
-            issued_at_ms=20,
-            expires_at_ms=60,
         )
 
 
@@ -300,14 +324,12 @@ def test_only_valid_or_provisional_unknown_validation_is_shadow_activatable() ->
         _validated_read_plan()
     )
     unknown = _validation_for(plan, result="UNKNOWN")
-    proposed = propose_shadow_composition_activation(
+    proposed = _propose(
+        action_registry,
         plan,
         unknown,
-        action_registry,
         verifier_registry,
         bindings,
-        issued_at_ms=20,
-        expires_at_ms=60,
     )
     assert proposed.validation_mode == "PROVISIONAL_UNKNOWN"
     assert proposed.verification_plan.entries[0].required is True
@@ -317,14 +339,52 @@ def test_only_valid_or_provisional_unknown_validation_is_shadow_activatable() ->
         CompositionShadowActivationError,
         match="validation.not_activatable",
     ):
-        propose_shadow_composition_activation(
+        _propose(
+            action_registry,
             plan,
             invalid,
-            action_registry,
             verifier_registry,
             bindings,
-            issued_at_ms=20,
-            expires_at_ms=60,
+        )
+
+
+def test_current_scope_world_state_and_time_are_required() -> None:
+    action_registry, plan, validation, verifier_registry, bindings = (
+        _validated_read_plan()
+    )
+    with pytest.raises(
+        CompositionShadowActivationError, match="world_state.mismatch"
+    ):
+        _propose(
+            action_registry,
+            plan,
+            validation,
+            verifier_registry,
+            bindings,
+            current_world_state_sha256="9" * 64,
+        )
+    with pytest.raises(
+        CompositionShadowActivationError, match="principal_scope.mismatch"
+    ):
+        _propose(
+            action_registry,
+            plan,
+            validation,
+            verifier_registry,
+            bindings,
+            expected_principal_scope_hash="8" * 64,
+        )
+    with pytest.raises(
+        CompositionShadowActivationError, match="activation.time_inverted"
+    ):
+        _propose(
+            action_registry,
+            plan,
+            validation,
+            verifier_registry,
+            bindings,
+            issued_at_ms=11,
+            expires_at_ms=50,
         )
 
 
@@ -380,14 +440,12 @@ def test_a2_write_can_be_compared_in_shadow_but_is_not_limited_eligible() -> Non
         evaluation_phase="POST_EXECUTION",
         registry_snapshot=verifier_registry,
     )
-    result = propose_shadow_composition_activation(
+    result = _propose(
+        action_registry,
         plan,
         validation,
-        action_registry,
         verifier_registry,
         (binding,),
-        issued_at_ms=20,
-        expires_at_ms=60,
     )
     assert result.proposed_only is True
     assert result.differential_trace.limited_production_eligible is False
@@ -406,19 +464,38 @@ def test_p7a_module_has_no_store_runtime_ticket_or_verifier_execution_path() -> 
         / "total_gateway"
         / "composition_activation_shadow.py"
     )
-    source = path.read_text(encoding="utf-8")
-    forbidden = (
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden_imports = {
         "GatewayStateStore",
-        "put_verification_plan",
-        "ExecutionTicket(",
-        "OmniCapabilityGrant(",
+        "ExecutionTicket",
+        "OmniCapabilityGrant",
         "BodyRuntime",
         "VerificationPlanExecutor",
         "VerificationRecorder",
-        ".execute(",
-        ".dispatch(",
-        "status=\"PASS\"",
-        "status='PASS'",
-    )
-    for token in forbidden:
-        assert token not in source, token
+        "VerificationRecord",
+    }
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert forbidden_imports.isdisjoint(imported)
+
+    forbidden_calls = {
+        "dispatch",
+        "execute",
+        "put_verification_plan",
+        "record",
+        "record_result",
+        "submit",
+    }
+    calls = {
+        node.func.id
+        if isinstance(node.func, ast.Name)
+        else node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Name, ast.Attribute))
+    }
+    assert forbidden_calls.isdisjoint(calls)


### PR DESCRIPTION
Implements P7A on top of `main @ ae601a9fd28b936f3f2d5e2b711669152697b271` after P6 merged with all gates green.

Scope:
- validates a system-compiled `CapabilityCompositionPlanV1` against the current Action Registry and P4 Tri-State validation result;
- accepts only `PROVED_VALID` or `UNKNOWN + PROVISIONAL_ALLOW + mandatory_verification`;
- recomputes the composition source-manifest hash and requires exact equality across Plan steps, permission requirements, Action source revisions, Action versions, capability manifest and Action Registry;
- resolves P19 verifiers mechanically from the current `RegistrySnapshot`; the model cannot name a verifier;
- requires every `plan.verification_intents` item to have exactly one complete deterministic L0 binding;
- constructs current `VerificationPlanEntryV2` records and one current-version `VerificationPlan` without persisting or executing it;
- constructs a proposed `CompositionActivationContractV1` bound to Plan/request/run/generation/principal/WorldState/source/capability manifest/Action versions/VerificationPlan/lifetime;
- emits a deterministic differential trace against an optional legacy Action set;
- computes first-batch limited-production eligibility separately: A0/A1, read/verify only, no Shell/Python/credential/destructive/external write or send, and complete VerificationPlan;
- allows A2+ or write/execute plans to be observed in shadow while marking them ineligible for the first limited-production batch;
- adds adversarial tests for permission expansion, source drift, verifier ambiguity/missing binding, invalid validation, deterministic replay and no-authority guarantees.

Authority boundary:
- `proposed_only=true`;
- `persistence_allowed=false`;
- `authorizes=false`;
- `confirms=false`;
- `changes_risk=false`;
- `may_execute=false`;
- no `GatewayStateStore`, `put_verification_plan`, `ExecutionTicket`, `OmniCapabilityGrant`, Runtime dispatch, verifier execution, VerificationRecord/PASS, P19 readiness or Completion mutation;
- no P19 frozen contract or implementation change;
- current Static Skill execution path remains production-authoritative.

Validation:
- focused P7A tests passed;
- source-authority passed on Ubuntu and Windows;
- full repository regression passed on Ubuntu and Windows, including the successful rerun of the unrelated Windows signal-drain flake;
- P14 repository perception and P19-R2 Golden Gate passed;
- no unresolved review threads.

P7B will add the first-class persisted `CompositionActivationGrantV1` and sole Total Gateway activation authority. P7C will perform the later Policy/Ticket/Grant/Runtime production wiring; neither is included here.