### PR TITLE
[Superseded] P7: Total Gateway composition activation and step authority seam

### DIFF
--- a/docs/capability-composition/P7_PRODUCTION_ACTIVATION.md
+++ b/docs/capability-composition/P7_PRODUCTION_ACTIVATION.md
@@ -1,0 +1,145 @@
+# P7 — Production Activation through the Existing Authority Chain
+
+Base: P6 implementation head `b776cfbea078af5c959516a1a8abba263d4969c6`, after the P6 PR passed its protected gates and was merged to `main`.
+
+## Objective
+
+P7 begins the production execution seam for a system-compiled
+`CapabilityCompositionPlanV1`:
+
+`ONE WorldState / ONE WORLD_CONTEXT_SLOT`
+→ model `CompositionProposalV1`
+→ system Plan Compiler
+→ Tri-State Validator
+→ **Total Gateway Composition Activation Gate**
+→ existing Policy / ExecutionTicket / CapabilityGrant chain
+→ existing Omni Body / BodyRuntime
+→ existing Effect / Fact return
+→ existing P19 Verification Plane
+→ existing CompletionGate
+
+P7 does not introduce a second execution authority. The first P7 slice freezes
+activation and step-level requests inside `src/total_gateway`; actual execution
+must still be delegated to the already-authoritative Gateway port.
+
+## Activation preconditions
+
+An activation is created only when all of the following remain current:
+
+- Plan SHA-256 is valid;
+- Validation SHA-256 is valid;
+- Validation is bound to the same Plan ID and Plan SHA-256;
+- validation result is either:
+  - `PROVED_VALID`, or
+  - `UNKNOWN + PROVISIONAL_ALLOW + mandatory_verification=true`;
+- `PROVED_INVALID`, `UNKNOWN + REJECT`, or malformed validation cannot activate;
+- request ID, run ID, generation and principal scope exactly match;
+- WorldState reference and SHA-256 exactly match;
+- Action Registry SHA-256 is valid;
+- capability manifest SHA-256 matches the current Action Registry;
+- Plan permission requirements equal the exact union of step Action IDs;
+- every step Action/version/source manifest matches an existing
+  `ActionPermission`;
+- composition risk is not A5;
+- activation time does not predate Plan or Validation evidence;
+- activation expiry is finite and monotonic.
+
+The activation ID and digest are system-derived. A model cannot mint or modify
+an activation.
+
+## Frozen P1 activation ABI
+
+P7 reuses the already-frozen `CompositionActivationContractV1`. It does not
+invent a replacement contract. The constructor maps only system-derived values
+into the frozen ABI, rejects any unmapped required ABI field, then recomputes
+and verifies the activation digest.
+
+The P7 `CompositionActivationEnvelopeV1` additionally binds:
+
+- frozen activation contract and hash;
+- Plan ID/hash;
+- Validation hash;
+- Action Registry hash;
+- capability manifest hash;
+- WorldState hash;
+- exact allowed Action IDs;
+- mandatory-verification state;
+- issue and expiry times.
+
+The envelope itself has `may_execute=false` and `model_generated=false`.
+
+## Step authorization
+
+A Plan step can be emitted only when:
+
+- the Activation and frozen contract hashes are valid;
+- Activation, Plan, Validation, Registry, Manifest and WorldState bindings agree;
+- the Activation is currently valid;
+- the step exists in the Plan;
+- its Action is in the activated permission union;
+- every declared dependency step is completed;
+- the current `ActionPermission` matches Action ID/version/manifest;
+- Action arguments are represented by a canonical SHA-256;
+- object-grant references are canonical and explicit;
+- the step expiry is inside the Activation expiry.
+
+`CompositionStepAuthorizationV1` is deliberately non-executing. It states:
+
+- `requires_existing_policy_ticket_grant=true`;
+- `may_execute=false`;
+- `model_generated=false`.
+
+It is not an `ExecutionTicket` and is not a `CapabilityGrant`.
+
+## Existing Gateway delegation
+
+`dispatch_via_existing_gateway(...)` accepts only an implementation of the
+existing-Gateway step port. Before delegation it verifies:
+
+- step-authorization hash;
+- Action Registry continuity;
+- canonical arguments hash.
+
+The adapter invokes exactly one method:
+
+`authorize_and_execute_composition_step(...)`
+
+That method belongs to the existing Total Gateway integration seam and must
+perform the ordinary Policy → Ticket → Grant → Omni Body path. P7 contains no
+direct Runtime, subprocess, SQLite, Tool handler, CompletionDecision, Ticket, or
+Grant implementation.
+
+## Failure policy
+
+P7 fails closed on:
+
+- cross-request or cross-run activation;
+- generation mismatch;
+- principal-scope mismatch;
+- WorldState drift;
+- capability-manifest or Registry drift;
+- validation/Plan mismatch;
+- permission expansion;
+- Action/version/source mismatch;
+- A5 composition;
+- incomplete dependencies;
+- expired activation or step authorization;
+- argument hash mismatch;
+- missing existing-Gateway port.
+
+No fallback to direct Tool execution exists.
+
+## Current P7 scope and remaining work
+
+This first P7 slice establishes the activation authority boundary and
+step-delegation contract. Before P7 can be declared complete, the PR must also:
+
+- bind the port to the repository's concrete existing Policy/Ticket/Grant
+  implementation rather than a parallel executor;
+- prove Action results return through the existing Effect/Fact ingress;
+- prove P19 receives the Plan-bound verification obligations;
+- prove CompletionGate is the only terminal completion authority;
+- add restart/resume and expiry tests;
+- pass all protected Ubuntu/Windows, P14 and P19-R2 gates.
+
+P8 source compilation and P9 Skill source compilation are not part of P7.

--- a/src/total_gateway/capability_composition_activation.py
+++ b/src/total_gateway/capability_composition_activation.py
@@ -1,0 +1,633 @@
+"""P7 activation gate for system-compiled capability composition plans.
+
+This module extends the existing Total Gateway authority boundary. It does not
+create a second gateway, policy engine, ticket issuer, grant issuer, runtime, or
+completion authority. A model-produced proposal can reach this gate only after
+system compilation and Tri-State validation. The gate then freezes an exact
+activation and emits step requests that still require the existing
+Policy/Ticket/Grant execution chain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import re
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+from contracts import ActionRegistrySnapshot, canonical_sha256
+from contracts.capability_composition import (
+    CapabilityCompositionPlanV1,
+    CompositionActivationContractV1,
+    CompositionValidationResultV1,
+)
+from pydantic import Field
+
+from contracts.models import ContractModel, OpaqueId, RequestId, RunId, Sha256
+from world_understanding.capability_composition import (
+    computed_validation_sha256,
+    plan_has_valid_sha256,
+    validation_has_valid_sha256,
+)
+
+
+ACTIVATION_ENVELOPE_SCHEMA = "tiangong.composition-activation-envelope.v1"
+STEP_AUTHORIZATION_SCHEMA = "tiangong.composition-step-authorization.v1"
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CapabilityCompositionActivationError(RuntimeError):
+    """Fail-closed activation error with a stable machine code."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(code if not detail else f"{code}: {detail}")
+
+
+def _activation_hash_field() -> str | None:
+    for name in (
+        "activation_sha256",
+        "activation_contract_sha256",
+        "contract_sha256",
+    ):
+        if name in CompositionActivationContractV1.model_fields:
+            return name
+    return None
+
+
+def computed_activation_contract_sha256(
+    contract: CompositionActivationContractV1,
+) -> str:
+    hash_field = _activation_hash_field()
+    excluded = {hash_field} if hash_field is not None else set()
+    return canonical_sha256(contract.model_dump(mode="json", exclude=excluded))
+
+
+def activation_contract_has_valid_sha256(
+    contract: CompositionActivationContractV1,
+) -> bool:
+    hash_field = _activation_hash_field()
+    if hash_field is None:
+        return False
+    return getattr(contract, hash_field) == computed_activation_contract_sha256(
+        contract
+    )
+
+
+def _required_field_names(model: type[ContractModel]) -> tuple[str, ...]:
+    return tuple(
+        name
+        for name, field in model.model_fields.items()
+        if field.is_required()
+    )
+
+
+def _build_frozen_activation_contract(
+    *,
+    plan: CapabilityCompositionPlanV1,
+    validation: CompositionValidationResultV1,
+    registry: ActionRegistrySnapshot,
+    activation_id: str,
+    issued_at_ms: int,
+    expires_at_ms: int,
+    mandatory_verification: bool,
+) -> CompositionActivationContractV1:
+    """Populate the frozen P1 activation ABI without model-supplied fields.
+
+    The contract was frozen before P7. This constructor intentionally derives
+    values by field name from system authorities, rejects any unknown required
+    ABI field, and recomputes the contract digest after validation. This avoids
+    introducing a second activation contract merely to fit P7.
+    """
+
+    action_ids = tuple(sorted(set(plan.permission_requirements)))
+    source_refs = tuple(
+        sorted(
+            (*plan.method_source_refs, *plan.action_source_refs),
+            key=lambda item: (
+                item.source_kind,
+                item.semantic_id,
+                item.version,
+                item.source_sha256,
+                item.descriptor_sha256,
+                item.manifest_sha256 or "",
+            ),
+        )
+    )
+    hash_field = _activation_hash_field()
+    values: dict[str, Any] = {
+        "activation_id": activation_id,
+        "request_id": plan.request_id,
+        "run_id": plan.run_id,
+        "generation": plan.generation,
+        "principal_scope_hash": plan.principal_scope_hash,
+        "composition_plan_id": plan.plan_id,
+        "composition_plan_sha256": plan.plan_sha256,
+        "plan_id": plan.plan_id,
+        "plan_sha256": plan.plan_sha256,
+        "validation_sha256": validation.validation_sha256,
+        "composition_validation_sha256": validation.validation_sha256,
+        "validation_result": validation.result,
+        "unknown_disposition": validation.unknown_disposition,
+        "world_state_ref": plan.world_state_ref,
+        "world_state_sha256": plan.world_state_sha256,
+        "context_fingerprint_sha256": plan.context_fingerprint_sha256,
+        "goal_fingerprint": plan.goal_fingerprint,
+        "environment_class": plan.environment_class,
+        "source_manifest_sha256": plan.source_manifest_sha256,
+        "capability_manifest_sha256": plan.capability_manifest_sha256,
+        "action_registry_sha256": registry.registry_sha256,
+        "allowed_action_ids": action_ids,
+        "permission_requirements": action_ids,
+        "source_revision_refs": source_refs,
+        "method_source_refs": plan.method_source_refs,
+        "action_source_refs": plan.action_source_refs,
+        "verification_intents": plan.verification_intents,
+        "verification_required": mandatory_verification,
+        "mandatory_verification": mandatory_verification,
+        "issued_at_ms": issued_at_ms,
+        "activated_at_ms": issued_at_ms,
+        "expires_at_ms": expires_at_ms,
+        "may_execute": False,
+        "model_generated": False,
+    }
+    if hash_field is not None:
+        values[hash_field] = "0" * 64
+
+    payload: dict[str, Any] = {}
+    missing: list[str] = []
+    for name, field in CompositionActivationContractV1.model_fields.items():
+        if name in values:
+            payload[name] = values[name]
+        elif field.is_required():
+            missing.append(name)
+    if missing:
+        raise CapabilityCompositionActivationError(
+            "composition.activation.abi_unmapped_required_fields",
+            ",".join(sorted(missing)),
+        )
+    try:
+        contract = CompositionActivationContractV1.model_validate(payload)
+    except Exception as exc:  # Pydantic emits multiple concrete error classes.
+        raise CapabilityCompositionActivationError(
+            "composition.activation.contract_invalid", str(exc)
+        ) from exc
+    if hash_field is None:
+        raise CapabilityCompositionActivationError(
+            "composition.activation.hash_field_missing"
+        )
+    contract = contract.model_copy(
+        update={hash_field: computed_activation_contract_sha256(contract)}
+    )
+    if not activation_contract_has_valid_sha256(contract):
+        raise CapabilityCompositionActivationError(
+            "composition.activation.hash_invalid"
+        )
+    return contract
+
+
+class CompositionStepAuthorizationV1(ContractModel):
+    """Non-executing request bound to one plan step and existing permission."""
+
+    schema_version: str = STEP_AUTHORIZATION_SCHEMA
+    step_authorization_id: OpaqueId
+    request_id: RequestId
+    run_id: RunId
+    generation: int = Field(ge=0)
+    principal_scope_hash: Sha256
+    activation_id: OpaqueId
+    activation_sha256: Sha256
+    plan_id: OpaqueId
+    plan_sha256: Sha256
+    validation_sha256: Sha256
+    step_id: OpaqueId
+    action_id: str = Field(min_length=1, max_length=160)
+    action_version: str = Field(min_length=1, max_length=160)
+    action_permission_sha256: Sha256
+    action_registry_sha256: Sha256
+    capability_manifest_sha256: Sha256
+    world_state_sha256: Sha256
+    dependency_step_ids: tuple[OpaqueId, ...] = ()
+    completed_dependency_step_ids: tuple[OpaqueId, ...] = ()
+    arguments_sha256: Sha256
+    object_grant_refs: tuple[OpaqueId, ...] = ()
+    mandatory_verification: bool
+    issued_at_ms: int = Field(ge=0)
+    expires_at_ms: int = Field(ge=0)
+    authorization_sha256: Sha256
+    requires_existing_policy_ticket_grant: bool = True
+    may_execute: bool = False
+    model_generated: bool = False
+
+    def payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude={"authorization_sha256"})
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.authorization_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "CompositionStepAuthorizationV1":
+        return self.model_copy(
+            update={"authorization_sha256": self.computed_sha256()}
+        )
+
+
+class CompositionActivationEnvelopeV1(ContractModel):
+    """System-owned activation plus exact current authority snapshots."""
+
+    schema_version: str = ACTIVATION_ENVELOPE_SCHEMA
+    activation_contract: CompositionActivationContractV1
+    activation_id: OpaqueId
+    activation_sha256: Sha256
+    plan_id: OpaqueId
+    plan_sha256: Sha256
+    validation_sha256: Sha256
+    action_registry_sha256: Sha256
+    capability_manifest_sha256: Sha256
+    world_state_sha256: Sha256
+    allowed_action_ids: tuple[str, ...]
+    mandatory_verification: bool
+    issued_at_ms: int = Field(ge=0)
+    expires_at_ms: int = Field(ge=0)
+    envelope_sha256: Sha256
+    may_execute: bool = False
+    model_generated: bool = False
+
+    def payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude={"envelope_sha256"})
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.envelope_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "CompositionActivationEnvelopeV1":
+        return self.model_copy(
+            update={"envelope_sha256": self.computed_sha256()}
+        )
+
+
+@runtime_checkable
+class ExistingGatewayStepPort(Protocol):
+    """Port implemented by the already-authoritative Gateway execution seam."""
+
+    def authorize_and_execute_composition_step(
+        self,
+        *,
+        step_authorization: CompositionStepAuthorizationV1,
+        arguments: Mapping[str, Any],
+    ) -> Any:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityCompositionActivationAuthority:
+    """P7 extension of Total Gateway; it owns no independent authority store."""
+
+    registry: ActionRegistrySnapshot
+
+    def __post_init__(self) -> None:
+        if not self.registry.has_valid_sha256():
+            raise CapabilityCompositionActivationError(
+                "composition.activation.registry_hash_invalid"
+            )
+
+    def activate(
+        self,
+        plan: CapabilityCompositionPlanV1,
+        validation: CompositionValidationResultV1,
+        *,
+        current_request_id: str,
+        current_run_id: str,
+        current_generation: int,
+        current_principal_scope_hash: str,
+        current_world_state_ref: str,
+        current_world_state_sha256: str,
+        issued_at_ms: int,
+        expires_at_ms: int,
+    ) -> CompositionActivationEnvelopeV1:
+        if issued_at_ms < 0 or expires_at_ms <= issued_at_ms:
+            raise CapabilityCompositionActivationError(
+                "composition.activation.time_invalid"
+            )
+        if not plan_has_valid_sha256(plan):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.plan_hash_invalid"
+            )
+        if not validation_has_valid_sha256(validation):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.validation_hash_invalid"
+            )
+        if validation.validation_sha256 != computed_validation_sha256(validation):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.validation_recompute_failed"
+            )
+        if (
+            validation.plan_id != plan.plan_id
+            or validation.plan_sha256 != plan.plan_sha256
+        ):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.validation_plan_mismatch"
+            )
+        if issued_at_ms < max(plan.created_at_ms, validation.validated_at_ms):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.time_precedes_evidence"
+            )
+        expected_scope = (
+            plan.request_id,
+            plan.run_id,
+            plan.generation,
+            plan.principal_scope_hash,
+            plan.world_state_ref,
+            plan.world_state_sha256,
+        )
+        current_scope = (
+            current_request_id,
+            current_run_id,
+            current_generation,
+            current_principal_scope_hash,
+            current_world_state_ref,
+            current_world_state_sha256,
+        )
+        if expected_scope != current_scope:
+            raise CapabilityCompositionActivationError(
+                "composition.activation.scope_or_world_drift"
+            )
+        if plan.capability_manifest_sha256 != self.registry.source_manifest_sha256:
+            raise CapabilityCompositionActivationError(
+                "composition.activation.capability_manifest_drift"
+            )
+        if plan.composition_risk == "A5":
+            raise CapabilityCompositionActivationError(
+                "composition.activation.a5_forbidden"
+            )
+
+        provisional = (
+            validation.result == "UNKNOWN"
+            and validation.unknown_disposition == "PROVISIONAL_ALLOW"
+            and validation.mandatory_verification
+        )
+        proved = validation.result == "PROVED_VALID"
+        if not (proved or provisional):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.validation_not_activatable"
+            )
+        mandatory_verification = bool(
+            validation.mandatory_verification or provisional
+        )
+
+        permission_by_action = {
+            item.action_id: item for item in self.registry.permissions
+        }
+        action_source_by_id = {
+            item.semantic_id: item for item in plan.action_source_refs
+        }
+        step_actions = tuple(sorted({item.action_id for item in plan.steps}))
+        if step_actions != tuple(sorted(set(plan.permission_requirements))):
+            raise CapabilityCompositionActivationError(
+                "composition.activation.permission_union_mismatch"
+            )
+        for step in plan.steps:
+            permission = permission_by_action.get(step.action_id)
+            source = action_source_by_id.get(step.action_id)
+            if (
+                permission is None
+                or source is None
+                or permission.action_version != step.action_version
+                or source.version != step.action_version
+                or permission.source_manifest_sha256
+                != plan.capability_manifest_sha256
+                or source.manifest_sha256
+                != plan.capability_manifest_sha256
+            ):
+                raise CapabilityCompositionActivationError(
+                    "composition.activation.action_binding_invalid",
+                    step.action_id,
+                )
+
+        activation_id = "composition_activation_" + canonical_sha256(
+            {
+                "domain": "tiangong.composition-activation-id.v1",
+                "request_id": plan.request_id,
+                "run_id": plan.run_id,
+                "generation": plan.generation,
+                "principal_scope_hash": plan.principal_scope_hash,
+                "plan_sha256": plan.plan_sha256,
+                "validation_sha256": validation.validation_sha256,
+                "registry_sha256": self.registry.registry_sha256,
+                "world_state_sha256": plan.world_state_sha256,
+                "issued_at_ms": issued_at_ms,
+                "expires_at_ms": expires_at_ms,
+            }
+        )
+        contract = _build_frozen_activation_contract(
+            plan=plan,
+            validation=validation,
+            registry=self.registry,
+            activation_id=activation_id,
+            issued_at_ms=issued_at_ms,
+            expires_at_ms=expires_at_ms,
+            mandatory_verification=mandatory_verification,
+        )
+        activation_sha256 = computed_activation_contract_sha256(contract)
+        envelope = CompositionActivationEnvelopeV1(
+            activation_contract=contract,
+            activation_id=activation_id,
+            activation_sha256=activation_sha256,
+            plan_id=plan.plan_id,
+            plan_sha256=plan.plan_sha256,
+            validation_sha256=validation.validation_sha256,
+            action_registry_sha256=self.registry.registry_sha256,
+            capability_manifest_sha256=plan.capability_manifest_sha256,
+            world_state_sha256=plan.world_state_sha256,
+            allowed_action_ids=step_actions,
+            mandatory_verification=mandatory_verification,
+            issued_at_ms=issued_at_ms,
+            expires_at_ms=expires_at_ms,
+            envelope_sha256="0" * 64,
+        )
+        return envelope.with_computed_sha256()
+
+    def authorize_step(
+        self,
+        activation: CompositionActivationEnvelopeV1,
+        plan: CapabilityCompositionPlanV1,
+        validation: CompositionValidationResultV1,
+        *,
+        step_id: str,
+        completed_step_ids: tuple[str, ...],
+        arguments_sha256: str,
+        object_grant_refs: tuple[str, ...] = (),
+        issued_at_ms: int,
+        expires_at_ms: int,
+    ) -> CompositionStepAuthorizationV1:
+        if not activation.has_valid_sha256():
+            raise CapabilityCompositionActivationError(
+                "composition.step.activation_envelope_invalid"
+            )
+        if not activation_contract_has_valid_sha256(
+            activation.activation_contract
+        ):
+            raise CapabilityCompositionActivationError(
+                "composition.step.activation_contract_invalid"
+            )
+        if not plan_has_valid_sha256(plan) or not validation_has_valid_sha256(
+            validation
+        ):
+            raise CapabilityCompositionActivationError(
+                "composition.step.plan_or_validation_invalid"
+            )
+        if (
+            activation.plan_id != plan.plan_id
+            or activation.plan_sha256 != plan.plan_sha256
+            or activation.validation_sha256 != validation.validation_sha256
+            or activation.action_registry_sha256 != self.registry.registry_sha256
+            or activation.capability_manifest_sha256
+            != self.registry.source_manifest_sha256
+        ):
+            raise CapabilityCompositionActivationError(
+                "composition.step.activation_binding_mismatch"
+            )
+        if not activation.issued_at_ms <= issued_at_ms <= activation.expires_at_ms:
+            raise CapabilityCompositionActivationError(
+                "composition.step.activation_expired_or_not_yet_valid"
+            )
+        if expires_at_ms <= issued_at_ms or expires_at_ms > activation.expires_at_ms:
+            raise CapabilityCompositionActivationError(
+                "composition.step.time_invalid"
+            )
+        if _SHA256.fullmatch(arguments_sha256) is None:
+            raise CapabilityCompositionActivationError(
+                "composition.step.arguments_hash_invalid"
+            )
+        if completed_step_ids != tuple(sorted(set(completed_step_ids))):
+            raise CapabilityCompositionActivationError(
+                "composition.step.completed_dependencies_not_canonical"
+            )
+        if object_grant_refs != tuple(sorted(set(object_grant_refs))):
+            raise CapabilityCompositionActivationError(
+                "composition.step.object_grants_not_canonical"
+            )
+
+        step_by_id = {item.step_id: item for item in plan.steps}
+        step = step_by_id.get(step_id)
+        if step is None:
+            raise CapabilityCompositionActivationError(
+                "composition.step.unknown_step", step_id
+            )
+        if step.action_id not in activation.allowed_action_ids:
+            raise CapabilityCompositionActivationError(
+                "composition.step.action_not_activated", step.action_id
+            )
+        if not set(step.depends_on).issubset(set(completed_step_ids)):
+            raise CapabilityCompositionActivationError(
+                "composition.step.dependencies_incomplete", step_id
+            )
+        permission = next(
+            (
+                item
+                for item in self.registry.permissions
+                if item.action_id == step.action_id
+            ),
+            None,
+        )
+        if (
+            permission is None
+            or permission.action_version != step.action_version
+            or permission.source_manifest_sha256
+            != activation.capability_manifest_sha256
+            or not permission.has_valid_sha256()
+        ):
+            raise CapabilityCompositionActivationError(
+                "composition.step.permission_binding_invalid", step.action_id
+            )
+
+        step_authorization_id = "composition_step_" + canonical_sha256(
+            {
+                "domain": "tiangong.composition-step-authorization-id.v1",
+                "activation_sha256": activation.activation_sha256,
+                "plan_sha256": plan.plan_sha256,
+                "step_id": step.step_id,
+                "action_id": step.action_id,
+                "action_version": step.action_version,
+                "arguments_sha256": arguments_sha256,
+                "object_grant_refs": list(object_grant_refs),
+                "issued_at_ms": issued_at_ms,
+                "expires_at_ms": expires_at_ms,
+            }
+        )
+        authorization = CompositionStepAuthorizationV1(
+            step_authorization_id=step_authorization_id,
+            request_id=plan.request_id,
+            run_id=plan.run_id,
+            generation=plan.generation,
+            principal_scope_hash=plan.principal_scope_hash,
+            activation_id=activation.activation_id,
+            activation_sha256=activation.activation_sha256,
+            plan_id=plan.plan_id,
+            plan_sha256=plan.plan_sha256,
+            validation_sha256=validation.validation_sha256,
+            step_id=step.step_id,
+            action_id=step.action_id,
+            action_version=step.action_version,
+            action_permission_sha256=permission.permission_sha256,
+            action_registry_sha256=self.registry.registry_sha256,
+            capability_manifest_sha256=activation.capability_manifest_sha256,
+            world_state_sha256=activation.world_state_sha256,
+            dependency_step_ids=step.depends_on,
+            completed_dependency_step_ids=completed_step_ids,
+            arguments_sha256=arguments_sha256,
+            object_grant_refs=object_grant_refs,
+            mandatory_verification=activation.mandatory_verification,
+            issued_at_ms=issued_at_ms,
+            expires_at_ms=expires_at_ms,
+            authorization_sha256="0" * 64,
+        )
+        return authorization.with_computed_sha256()
+
+    def dispatch_via_existing_gateway(
+        self,
+        port: ExistingGatewayStepPort,
+        authorization: CompositionStepAuthorizationV1,
+        *,
+        arguments: Mapping[str, Any],
+    ) -> Any:
+        """Delegate to the existing Gateway port; P7 never executes directly."""
+
+        if not isinstance(port, ExistingGatewayStepPort):
+            raise CapabilityCompositionActivationError(
+                "composition.step.existing_gateway_port_required"
+            )
+        if not authorization.has_valid_sha256():
+            raise CapabilityCompositionActivationError(
+                "composition.step.authorization_hash_invalid"
+            )
+        if authorization.action_registry_sha256 != self.registry.registry_sha256:
+            raise CapabilityCompositionActivationError(
+                "composition.step.registry_drift"
+            )
+        if canonical_sha256(dict(arguments)) != authorization.arguments_sha256:
+            raise CapabilityCompositionActivationError(
+                "composition.step.arguments_mismatch"
+            )
+        return port.authorize_and_execute_composition_step(
+            step_authorization=authorization,
+            arguments=arguments,
+        )
+
+
+__all__ = [
+    "ACTIVATION_ENVELOPE_SCHEMA",
+    "STEP_AUTHORIZATION_SCHEMA",
+    "CapabilityCompositionActivationAuthority",
+    "CapabilityCompositionActivationError",
+    "CompositionActivationEnvelopeV1",
+    "CompositionStepAuthorizationV1",
+    "ExistingGatewayStepPort",
+    "activation_contract_has_valid_sha256",
+    "computed_activation_contract_sha256",
+]

--- a/src/total_gateway/capability_composition_receipt.py
+++ b/src/total_gateway/capability_composition_receipt.py
@@ -1,0 +1,221 @@
+"""P7 evidence receipt for the existing Policy/Ticket/Grant execution route.
+
+The receipt is not a CompletionDecision. It proves that one activated step was
+processed by the existing authority route and that its Effect/Fact evidence is
+ready to return through P19. Only CompletionGate may make a terminal completion
+claim.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Mapping, Protocol, runtime_checkable
+
+from pydantic import Field, field_validator, model_validator
+
+from contracts import canonical_sha256
+from contracts.models import ContractModel, OpaqueId, RequestId, RunId, Sha256
+
+from .capability_composition_activation import (
+    CapabilityCompositionActivationAuthority,
+    CapabilityCompositionActivationError,
+    CompositionStepAuthorizationV1,
+)
+
+
+STEP_EXECUTION_RECEIPT_SCHEMA = (
+    "tiangong.composition-step-execution-receipt.v1"
+)
+
+
+def _sorted_unique(value: tuple[str, ...]) -> tuple[str, ...]:
+    if value != tuple(sorted(set(value))):
+        raise ValueError("receipt values must be sorted and unique")
+    return value
+
+
+class CompositionStepExecutionReceiptV1(ContractModel):
+    schema_version: Literal[STEP_EXECUTION_RECEIPT_SCHEMA] = (
+        STEP_EXECUTION_RECEIPT_SCHEMA
+    )
+    request_id: RequestId
+    run_id: RunId
+    generation: int = Field(ge=0)
+    principal_scope_hash: Sha256
+    activation_id: OpaqueId
+    activation_sha256: Sha256
+    plan_id: OpaqueId
+    plan_sha256: Sha256
+    validation_sha256: Sha256
+    step_id: OpaqueId
+    step_authorization_sha256: Sha256
+    action_id: str = Field(min_length=1, max_length=160)
+    action_version: str = Field(min_length=1, max_length=160)
+    action_registry_sha256: Sha256
+    capability_manifest_sha256: Sha256
+    world_state_sha256: Sha256
+    execution_route: Literal[
+        "TOTAL_GATEWAY_POLICY_TICKET_GRANT_OMNI_RUNTIME"
+    ] = "TOTAL_GATEWAY_POLICY_TICKET_GRANT_OMNI_RUNTIME"
+    policy_decision_sha256: Sha256
+    execution_ticket_sha256: Sha256
+    capability_grant_sha256: Sha256
+    effect_id: OpaqueId
+    effect_sha256: Sha256
+    fact_ids: tuple[OpaqueId, ...] = Field(min_length=1)
+    fact_hashes: tuple[Sha256, ...] = Field(min_length=1)
+    verification_plan_sha256: Sha256
+    p19_ingress_required: Literal[True] = True
+    completion_claimed: Literal[False] = False
+    executed_at_ms: int = Field(ge=0)
+    receipt_sha256: Sha256
+    model_generated: Literal[False] = False
+    may_authorize: Literal[False] = False
+    may_execute: Literal[False] = False
+
+    _fact_ids = field_validator("fact_ids")(_sorted_unique)
+    _fact_hashes = field_validator("fact_hashes")(_sorted_unique)
+
+    @model_validator(mode="after")
+    def validate_fact_alignment(self):
+        if len(self.fact_ids) != len(self.fact_hashes):
+            raise ValueError("receipt Fact identities and hashes must align")
+        return self
+
+    def payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude={"receipt_sha256"})
+
+    def computed_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def has_valid_sha256(self) -> bool:
+        return self.receipt_sha256 == self.computed_sha256()
+
+    def with_computed_sha256(self) -> "CompositionStepExecutionReceiptV1":
+        return self.model_copy(
+            update={"receipt_sha256": self.computed_sha256()}
+        )
+
+
+@runtime_checkable
+class ExistingPolicyTicketGrantExecutionPort(Protocol):
+    """Implemented only by the repository's existing Total Gateway seam."""
+
+    def authorize_and_execute_composition_step(
+        self,
+        *,
+        step_authorization: CompositionStepAuthorizationV1,
+        arguments: Mapping[str, Any],
+    ) -> CompositionStepExecutionReceiptV1:
+        ...
+
+
+def validate_step_execution_receipt(
+    authorization: CompositionStepAuthorizationV1,
+    receipt: CompositionStepExecutionReceiptV1,
+    *,
+    checked_at_ms: int,
+) -> None:
+    if checked_at_ms < authorization.issued_at_ms:
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.check_time_invalid"
+        )
+    if not authorization.has_valid_sha256():
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.authorization_hash_invalid"
+        )
+    if not isinstance(receipt, CompositionStepExecutionReceiptV1):
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.contract_required"
+        )
+    if not receipt.has_valid_sha256():
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.hash_invalid"
+        )
+    expected = (
+        authorization.request_id,
+        authorization.run_id,
+        authorization.generation,
+        authorization.principal_scope_hash,
+        authorization.activation_id,
+        authorization.activation_sha256,
+        authorization.plan_id,
+        authorization.plan_sha256,
+        authorization.validation_sha256,
+        authorization.step_id,
+        authorization.authorization_sha256,
+        authorization.action_id,
+        authorization.action_version,
+        authorization.action_registry_sha256,
+        authorization.capability_manifest_sha256,
+        authorization.world_state_sha256,
+    )
+    observed = (
+        receipt.request_id,
+        receipt.run_id,
+        receipt.generation,
+        receipt.principal_scope_hash,
+        receipt.activation_id,
+        receipt.activation_sha256,
+        receipt.plan_id,
+        receipt.plan_sha256,
+        receipt.validation_sha256,
+        receipt.step_id,
+        receipt.step_authorization_sha256,
+        receipt.action_id,
+        receipt.action_version,
+        receipt.action_registry_sha256,
+        receipt.capability_manifest_sha256,
+        receipt.world_state_sha256,
+    )
+    if expected != observed:
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.binding_mismatch"
+        )
+    if not authorization.issued_at_ms <= receipt.executed_at_ms <= checked_at_ms:
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.execution_time_invalid"
+        )
+    if receipt.completion_claimed:
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.completion_claim_forbidden"
+        )
+    if not receipt.p19_ingress_required:
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.p19_bypass_forbidden"
+        )
+
+
+def dispatch_and_verify_existing_gateway_step(
+    authority: CapabilityCompositionActivationAuthority,
+    port: ExistingPolicyTicketGrantExecutionPort,
+    authorization: CompositionStepAuthorizationV1,
+    *,
+    arguments: Mapping[str, Any],
+    checked_at_ms: int,
+) -> CompositionStepExecutionReceiptV1:
+    """Delegate once, then require Ticket/Grant/Effect/Fact/P19 evidence."""
+
+    if not isinstance(port, ExistingPolicyTicketGrantExecutionPort):
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.existing_gateway_port_required"
+        )
+    result = authority.dispatch_via_existing_gateway(
+        port, authorization, arguments=arguments
+    )
+    if not isinstance(result, CompositionStepExecutionReceiptV1):
+        raise CapabilityCompositionActivationError(
+            "composition.receipt.contract_required"
+        )
+    validate_step_execution_receipt(
+        authorization, result, checked_at_ms=checked_at_ms
+    )
+    return result
+
+
+__all__ = [
+    "STEP_EXECUTION_RECEIPT_SCHEMA",
+    "CompositionStepExecutionReceiptV1",
+    "ExistingPolicyTicketGrantExecutionPort",
+    "dispatch_and_verify_existing_gateway_step",
+    "validate_step_execution_receipt",
+]

--- a/tests/test_capability_composition_activation_p7.py
+++ b/tests/test_capability_composition_activation_p7.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from contracts import canonical_sha256
+from world_understanding.capability_composition import (
+    compile_capability_composition_plan,
+    computed_plan_sha256,
+    parse_composition_proposal,
+    validate_capability_composition_plan,
+)
+from total_gateway.capability_composition_activation import (
+    CapabilityCompositionActivationAuthority,
+    CapabilityCompositionActivationError,
+    activation_contract_has_valid_sha256,
+)
+
+from tests.test_capability_composition_p4 import (
+    H,
+    _context,
+    _proposal_document,
+    _single_read_fixture,
+    _worlds,
+)
+
+
+class ExistingGatewayPortProbe:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, dict]] = []
+
+    def authorize_and_execute_composition_step(
+        self, *, step_authorization, arguments
+    ):
+        self.calls.append((step_authorization, dict(arguments)))
+        return {
+            "routed_through_existing_gateway": True,
+            "step_id": step_authorization.step_id,
+            "action_id": step_authorization.action_id,
+        }
+
+
+def _proved_valid_activation_fixture():
+    registry, candidates, context, document = _single_read_fixture()
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    validation = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert validation.result == "PROVED_VALID"
+    authority = CapabilityCompositionActivationAuthority(registry)
+    activation = authority.activate(
+        plan,
+        validation,
+        current_request_id=plan.request_id,
+        current_run_id=plan.run_id,
+        current_generation=plan.generation,
+        current_principal_scope_hash=plan.principal_scope_hash,
+        current_world_state_ref=plan.world_state_ref,
+        current_world_state_sha256=plan.world_state_sha256,
+        issued_at_ms=12,
+        expires_at_ms=1_012,
+    )
+    return authority, registry, candidates, context, proposal, plan, validation, activation
+
+
+def test_proved_valid_plan_freezes_exact_activation_and_step() -> None:
+    authority, registry, _candidates, _context_value, _proposal, plan, validation, activation = (
+        _proved_valid_activation_fixture()
+    )
+    assert activation.has_valid_sha256()
+    assert activation_contract_has_valid_sha256(
+        activation.activation_contract
+    )
+    assert activation.plan_sha256 == plan.plan_sha256
+    assert activation.validation_sha256 == validation.validation_sha256
+    assert activation.action_registry_sha256 == registry.registry_sha256
+    assert activation.capability_manifest_sha256 == (
+        registry.source_manifest_sha256
+    )
+    assert activation.world_state_sha256 == plan.world_state_sha256
+    assert activation.allowed_action_ids == plan.permission_requirements
+    assert activation.may_execute is False
+    assert activation.model_generated is False
+
+    arguments = {"path": "workspace/readme.md"}
+    authorization = authority.authorize_step(
+        activation,
+        plan,
+        validation,
+        step_id=plan.steps[0].step_id,
+        completed_step_ids=(),
+        arguments_sha256=canonical_sha256(arguments),
+        issued_at_ms=13,
+        expires_at_ms=100,
+    )
+    assert authorization.has_valid_sha256()
+    assert authorization.action_id == plan.steps[0].action_id
+    assert authorization.action_version == plan.steps[0].action_version
+    assert authorization.requires_existing_policy_ticket_grant is True
+    assert authorization.may_execute is False
+    assert authorization.model_generated is False
+
+    port = ExistingGatewayPortProbe()
+    result = authority.dispatch_via_existing_gateway(
+        port, authorization, arguments=arguments
+    )
+    assert result["routed_through_existing_gateway"] is True
+    assert len(port.calls) == 1
+
+
+def test_activation_rejects_scope_generation_world_and_manifest_drift() -> None:
+    authority, _registry, _candidates, _context_value, _proposal, plan, validation, _activation = (
+        _proved_valid_activation_fixture()
+    )
+    common = dict(
+        current_request_id=plan.request_id,
+        current_run_id=plan.run_id,
+        current_generation=plan.generation,
+        current_principal_scope_hash=plan.principal_scope_hash,
+        current_world_state_ref=plan.world_state_ref,
+        current_world_state_sha256=plan.world_state_sha256,
+        issued_at_ms=12,
+        expires_at_ms=1_012,
+    )
+    for field, value in (
+        ("current_request_id", "req_" + "1" * 64),
+        ("current_run_id", "run_" + "2" * 64),
+        ("current_generation", plan.generation + 1),
+        ("current_principal_scope_hash", "3" * 64),
+        ("current_world_state_ref", "world.other"),
+        ("current_world_state_sha256", "4" * 64),
+    ):
+        changed = {**common, field: value}
+        with pytest.raises(
+            CapabilityCompositionActivationError,
+            match="scope_or_world_drift",
+        ):
+            authority.activate(plan, validation, **changed)
+
+    drifted_plan = plan.model_copy(
+        update={"capability_manifest_sha256": "5" * 64}
+    )
+    drifted_plan = drifted_plan.model_copy(
+        update={"plan_sha256": computed_plan_sha256(drifted_plan)}
+    )
+    with pytest.raises(
+        CapabilityCompositionActivationError,
+        match="capability_manifest_drift",
+    ):
+        authority.activate(drifted_plan, validation, **common)
+
+
+def test_activation_rejects_non_activatable_validation() -> None:
+    authority, _registry, _candidates, _context_value, _proposal, plan, validation, _activation = (
+        _proved_valid_activation_fixture()
+    )
+    rejected = validation.model_copy(
+        update={
+            "result": "UNKNOWN",
+            "unknown_disposition": "REJECT",
+            "mandatory_verification": False,
+            "validation_sha256": "0" * 64,
+        }
+    )
+    from world_understanding.capability_composition import computed_validation_sha256
+
+    rejected = rejected.model_copy(
+        update={
+            "validation_sha256": computed_validation_sha256(rejected)
+        }
+    )
+    with pytest.raises(
+        CapabilityCompositionActivationError,
+        match="validation_not_activatable",
+    ):
+        authority.activate(
+            plan,
+            rejected,
+            current_request_id=plan.request_id,
+            current_run_id=plan.run_id,
+            current_generation=plan.generation,
+            current_principal_scope_hash=plan.principal_scope_hash,
+            current_world_state_ref=plan.world_state_ref,
+            current_world_state_sha256=plan.world_state_sha256,
+            issued_at_ms=12,
+            expires_at_ms=1_012,
+        )
+
+
+def test_provisional_unknown_requires_mandatory_verification() -> None:
+    registry, candidates, context, document = _single_read_fixture(
+        idempotency="UNKNOWN",
+        determinism="NONDETERMINISTIC",
+    )
+    proposal = parse_composition_proposal(document, candidates)
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    validation = validate_capability_composition_plan(
+        plan,
+        proposal,
+        candidates,
+        context,
+        registry,
+        available_verifiers=frozenset({"verifier:artifact"}),
+        validated_at_ms=11,
+    )
+    assert validation.result == "UNKNOWN"
+    assert validation.unknown_disposition == "PROVISIONAL_ALLOW"
+    assert validation.mandatory_verification is True
+    activation = CapabilityCompositionActivationAuthority(registry).activate(
+        plan,
+        validation,
+        current_request_id=plan.request_id,
+        current_run_id=plan.run_id,
+        current_generation=plan.generation,
+        current_principal_scope_hash=plan.principal_scope_hash,
+        current_world_state_ref=plan.world_state_ref,
+        current_world_state_sha256=plan.world_state_sha256,
+        issued_at_ms=12,
+        expires_at_ms=1_012,
+    )
+    assert activation.mandatory_verification is True
+
+
+def test_a5_composition_cannot_activate() -> None:
+    specs = (
+        {
+            "action_id": "credential.read",
+            "risk": "A1",
+            "effect": "read",
+            "side_effects": ("read",),
+            "resource_scope": ("credential",),
+            "produces": ("type:credential",),
+            "read_set": ("resource:credential",),
+        },
+        {
+            "action_id": "http.send",
+            "risk": "A2",
+            "effect": "write",
+            "side_effects": ("external_write", "read"),
+            "resource_scope": ("network",),
+            "consumes": ("type:credential",),
+            "produces": ("type:delivery-result",),
+            "write_set": ("resource:external-endpoint",),
+        },
+    )
+    registry, tool_world, method_world = _worlds(specs)
+    from world_understanding.capability_composition import build_candidate_snapshot
+
+    candidates = build_candidate_snapshot(
+        tool_world,
+        method_world,
+        method_ids=("generate_then_verify",),
+        action_ids=("credential.read", "http.send"),
+    )
+    proposal = parse_composition_proposal(
+        _proposal_document(
+            goal_ref="goal.p7-a5",
+            methods=("M01",),
+            actions=("A01", "A02"),
+            steps=(
+                ("step.01", "A01", ()),
+                ("step.02", "A02", ("step.01",)),
+            ),
+        ),
+        candidates,
+    )
+    context = _context(goal_ref="goal.p7-a5")
+    plan = compile_capability_composition_plan(
+        proposal, candidates, context, registry
+    )
+    assert plan.composition_risk == "A5"
+    # Even a forged structurally valid-looking validation result cannot bypass
+    # the independent A5 gate.
+    _authority, _r, _c, _ctx, _p, safe_plan, safe_validation, _a = (
+        _proved_valid_activation_fixture()
+    )
+    forged = safe_validation.model_copy(
+        update={
+            "plan_id": plan.plan_id,
+            "plan_sha256": plan.plan_sha256,
+            "validation_sha256": "0" * 64,
+        }
+    )
+    from world_understanding.capability_composition import computed_validation_sha256
+
+    forged = forged.model_copy(
+        update={"validation_sha256": computed_validation_sha256(forged)}
+    )
+    with pytest.raises(
+        CapabilityCompositionActivationError, match="a5_forbidden"
+    ):
+        CapabilityCompositionActivationAuthority(registry).activate(
+            plan,
+            forged,
+            current_request_id=plan.request_id,
+            current_run_id=plan.run_id,
+            current_generation=plan.generation,
+            current_principal_scope_hash=plan.principal_scope_hash,
+            current_world_state_ref=plan.world_state_ref,
+            current_world_state_sha256=plan.world_state_sha256,
+            issued_at_ms=12,
+            expires_at_ms=1_012,
+        )
+
+
+def test_step_dependencies_permissions_expiry_and_arguments_fail_closed() -> None:
+    authority, _registry, _candidates, _context_value, _proposal, plan, validation, activation = (
+        _proved_valid_activation_fixture()
+    )
+    with pytest.raises(
+        CapabilityCompositionActivationError, match="unknown_step"
+    ):
+        authority.authorize_step(
+            activation,
+            plan,
+            validation,
+            step_id="step.99",
+            completed_step_ids=(),
+            arguments_sha256=canonical_sha256({}),
+            issued_at_ms=13,
+            expires_at_ms=100,
+        )
+    with pytest.raises(
+        CapabilityCompositionActivationError,
+        match="activation_expired_or_not_yet_valid",
+    ):
+        authority.authorize_step(
+            activation,
+            plan,
+            validation,
+            step_id=plan.steps[0].step_id,
+            completed_step_ids=(),
+            arguments_sha256=canonical_sha256({}),
+            issued_at_ms=activation.expires_at_ms + 1,
+            expires_at_ms=activation.expires_at_ms + 2,
+        )
+
+    arguments = {"path": "workspace/a.txt"}
+    authorization = authority.authorize_step(
+        activation,
+        plan,
+        validation,
+        step_id=plan.steps[0].step_id,
+        completed_step_ids=(),
+        arguments_sha256=canonical_sha256(arguments),
+        issued_at_ms=13,
+        expires_at_ms=100,
+    )
+    with pytest.raises(
+        CapabilityCompositionActivationError, match="arguments_mismatch"
+    ):
+        authority.dispatch_via_existing_gateway(
+            ExistingGatewayPortProbe(),
+            authorization,
+            arguments={"path": "workspace/other.txt"},
+        )
+
+
+def test_p7_module_contains_no_runtime_ticket_grant_or_completion_implementation() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "total_gateway"
+        / "capability_composition_activation.py"
+    ).read_text(encoding="utf-8")
+    forbidden = (
+        "class ExecutionTicket",
+        "class CapabilityGrant",
+        "class CompletionDecision",
+        "class BodyRuntime",
+        "subprocess",
+        "sqlite3.connect",
+        "omni_body.execute",
+        "runtime.execute",
+    )
+    for token in forbidden:
+        assert token not in source
+    assert "requires_existing_policy_ticket_grant" in source
+    assert "authorize_and_execute_composition_step" in source

--- a/tests/test_capability_composition_receipt_p7.py
+++ b/tests/test_capability_composition_receipt_p7.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from contracts import canonical_sha256
+from total_gateway.capability_composition_activation import (
+    CapabilityCompositionActivationError,
+)
+from total_gateway.capability_composition_receipt import (
+    CompositionStepExecutionReceiptV1,
+    dispatch_and_verify_existing_gateway_step,
+    validate_step_execution_receipt,
+)
+
+from tests.test_capability_composition_activation_p7 import (
+    _proved_valid_activation_fixture,
+)
+
+
+class ReceiptPortProbe:
+    def __init__(self, receipt: CompositionStepExecutionReceiptV1) -> None:
+        self.receipt = receipt
+        self.calls = 0
+
+    def authorize_and_execute_composition_step(
+        self, *, step_authorization, arguments
+    ) -> CompositionStepExecutionReceiptV1:
+        self.calls += 1
+        return self.receipt
+
+
+def _authorization_and_receipt():
+    authority, registry, _candidates, _context, _proposal, plan, validation, activation = (
+        _proved_valid_activation_fixture()
+    )
+    arguments = {"path": "workspace/p7.txt"}
+    authorization = authority.authorize_step(
+        activation,
+        plan,
+        validation,
+        step_id=plan.steps[0].step_id,
+        completed_step_ids=(),
+        arguments_sha256=canonical_sha256(arguments),
+        issued_at_ms=13,
+        expires_at_ms=100,
+    )
+    receipt = CompositionStepExecutionReceiptV1(
+        request_id=authorization.request_id,
+        run_id=authorization.run_id,
+        generation=authorization.generation,
+        principal_scope_hash=authorization.principal_scope_hash,
+        activation_id=authorization.activation_id,
+        activation_sha256=authorization.activation_sha256,
+        plan_id=authorization.plan_id,
+        plan_sha256=authorization.plan_sha256,
+        validation_sha256=authorization.validation_sha256,
+        step_id=authorization.step_id,
+        step_authorization_sha256=authorization.authorization_sha256,
+        action_id=authorization.action_id,
+        action_version=authorization.action_version,
+        action_registry_sha256=registry.registry_sha256,
+        capability_manifest_sha256=authorization.capability_manifest_sha256,
+        world_state_sha256=authorization.world_state_sha256,
+        policy_decision_sha256="1" * 64,
+        execution_ticket_sha256="2" * 64,
+        capability_grant_sha256="3" * 64,
+        effect_id="effect_p7_step_01",
+        effect_sha256="4" * 64,
+        fact_ids=("fact_p7_step_01",),
+        fact_hashes=("5" * 64,),
+        verification_plan_sha256="6" * 64,
+        executed_at_ms=14,
+        receipt_sha256="0" * 64,
+    ).with_computed_sha256()
+    return authority, authorization, arguments, receipt
+
+
+def test_existing_route_receipt_requires_ticket_grant_effect_fact_and_p19() -> None:
+    authority, authorization, arguments, receipt = _authorization_and_receipt()
+    port = ReceiptPortProbe(receipt)
+    result = dispatch_and_verify_existing_gateway_step(
+        authority,
+        port,
+        authorization,
+        arguments=arguments,
+        checked_at_ms=15,
+    )
+    assert result == receipt
+    assert result.has_valid_sha256()
+    assert result.execution_route == (
+        "TOTAL_GATEWAY_POLICY_TICKET_GRANT_OMNI_RUNTIME"
+    )
+    assert result.policy_decision_sha256
+    assert result.execution_ticket_sha256
+    assert result.capability_grant_sha256
+    assert result.effect_id and result.effect_sha256
+    assert result.fact_ids and result.fact_hashes
+    assert result.verification_plan_sha256
+    assert result.p19_ingress_required is True
+    assert result.completion_claimed is False
+    assert port.calls == 1
+
+
+def test_receipt_cannot_cross_plan_activation_action_or_world_scope() -> None:
+    _authority, authorization, _arguments, receipt = _authorization_and_receipt()
+    for field, value in (
+        ("run_id", "run_" + "7" * 64),
+        ("generation", authorization.generation + 1),
+        ("activation_sha256", "8" * 64),
+        ("plan_sha256", "9" * 64),
+        ("action_id", "invented.action"),
+        ("world_state_sha256", "a" * 64),
+    ):
+        tampered = receipt.model_copy(
+            update={field: value, "receipt_sha256": "0" * 64}
+        ).with_computed_sha256()
+        with pytest.raises(
+            CapabilityCompositionActivationError,
+            match="receipt.binding_mismatch",
+        ):
+            validate_step_execution_receipt(
+                authorization, tampered, checked_at_ms=15
+            )
+
+
+def test_receipt_requires_hash_time_and_concrete_contract() -> None:
+    authority, authorization, arguments, receipt = _authorization_and_receipt()
+    invalid_hash = receipt.model_copy(
+        update={"receipt_sha256": "f" * 64}
+    )
+    with pytest.raises(
+        CapabilityCompositionActivationError, match="receipt.hash_invalid"
+    ):
+        validate_step_execution_receipt(
+            authorization, invalid_hash, checked_at_ms=15
+        )
+
+    late = receipt.model_copy(
+        update={"executed_at_ms": 99, "receipt_sha256": "0" * 64}
+    ).with_computed_sha256()
+    with pytest.raises(
+        CapabilityCompositionActivationError,
+        match="execution_time_invalid",
+    ):
+        validate_step_execution_receipt(
+            authorization, late, checked_at_ms=15
+        )
+
+    class WrongPort:
+        def authorize_and_execute_composition_step(self, **_kwargs):
+            return {"not": "a receipt"}
+
+    with pytest.raises(
+        CapabilityCompositionActivationError,
+        match="receipt.contract_required",
+    ):
+        dispatch_and_verify_existing_gateway_step(
+            authority,
+            WrongPort(),
+            authorization,
+            arguments=arguments,
+            checked_at_ms=15,
+        )
+
+
+def test_receipt_contract_cannot_claim_completion_or_skip_p19() -> None:
+    _authority, _authorization, _arguments, receipt = _authorization_and_receipt()
+    with pytest.raises(Exception):
+        receipt.model_copy(update={"completion_claimed": True})
+    with pytest.raises(Exception):
+        receipt.model_copy(update={"p19_ingress_required": False})
+
+
+def test_p7_receipt_module_defines_no_ticket_grant_runtime_or_completion_authority() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "total_gateway"
+        / "capability_composition_receipt.py"
+    ).read_text(encoding="utf-8")
+    for token in (
+        "class ExecutionTicket",
+        "class CapabilityGrant",
+        "class CompletionDecision",
+        "class BodyRuntime",
+        "sqlite3.connect",
+        "subprocess",
+        "runtime.execute",
+        "omni_body.execute",
+    ):
+        assert token not in source
+    assert "completion_claimed: Literal[False]" in source
+    assert "p19_ingress_required: Literal[True]" in source


### PR DESCRIPTION
Superseded by the staged P7 authority sequence:

- P7A merged in #65 on current `main`;
- P7B.1 continues in #67 with authoritative P7A rebuild, A0-only limited registration, retry-stable identity and the existing Gateway Store as the only future writer;
- P7B.2 will add the concrete existing-Store persistence and P19 compatibility revision before any Policy/Ticket/Grant wiring.

This PR was based on pre-P7A `main @ ae601a9f...` and introduces a separate activation/step-dispatch abstraction. Merging it now would create a parallel P7 implementation and violate the single Gateway / single activation authority sequence. It is closed without merge and retained only as audit history. No code from this branch is production-authoritative.