### PR TITLE
P7D.1: execute static composition root through existing runtime

### DIFF
--- a/app/life-service/runtime314/contracts/.tiangong-generated-source.json
+++ b/app/life-service/runtime314/contracts/.tiangong-generated-source.json
@@ -3,6 +3,6 @@
   "mapping_id": "shared-contracts",
   "schema": "tiangong.generated-source-marker.v1",
   "source": "src/contracts",
-  "tree_sha256": "8d12fd9d33b8461b2a34aed347438f429d49fd2e0ec283ed51f33823daf695a5",
+  "tree_sha256": "2550a86f3691163f35f154e8e853d795595da7a0a6ba582706e848c638864282",
   "warning": "Generated mirror. Edit the authoritative source and run scripts/sync-generated-sources.py --write."
 }

--- a/app/life-service/runtime314/contracts/authorization.py
+++ b/app/life-service/runtime314/contracts/authorization.py
@@ -267,7 +267,17 @@ def authorize_execution_contract(
             not claim.has_valid_sha256()
             or claim.claim_sha256 != payload.claim_sha256
             or claim.claim_revision != payload.claim_revision
-            or claim.intent_sha256 != payload.intent_sha256
+            # Composition uses a separate deterministic effect-intent hash to
+            # derive the pre-bound Effect ID.  Its ActionIntent hash includes
+            # that Effect/binding and therefore cannot equal the effect-intent
+            # hash without an identity cycle.  The signed claim digest plus
+            # the independently rebuilt CompositionExecutionBinding still
+            # binds both identities exactly.  Non-composition tickets retain
+            # the legacy same-intent invariant.
+            or (
+                not composition_present
+                and claim.intent_sha256 != payload.intent_sha256
+            )
             or claim.effect_id != payload.effect_id
         ):
             raise ExecutionAuthorizationError("ticket.claim.mismatch")

--- a/docs/capability-composition/P7C_P7D_PROGRESS.md
+++ b/docs/capability-composition/P7C_P7D_PROGRESS.md
@@ -1,6 +1,6 @@
 # P7C / P7D Continuous Progress and Evidence Ledger
 
-Last updated: 2026-09-04 12:32 +08:00.
+Last updated: 2026-09-04 15:40 +08:00.
 
 This file is the continuous status ledger for P7C.0, P7C.1, P7D.1 and P7D.2.
 It separates observed baseline evidence from planned or not-yet-run evidence.
@@ -10,12 +10,12 @@ It separates observed baseline evidence from planned or not-yet-run evidence.
 
 | Item | Value | Evidence status |
 |---|---|---|
-| Worktree | `C:\Users\77571\Documents\天工造物v3-p7c-p7d` | Observed in this work session |
-| Baseline commit | `14f6946a9d994e70654b9d64ecfcaae9c74baba4` | `git rev-parse HEAD` matched before document edits |
+| Worktree | `C:\Users\77571\Documents\天工造物v3-p7d1` | Independent P7D.1 worktree observed in this work session |
+| Baseline commit | `acb39a63bd267b5db1b9c0b7076110c5391704c8` | Exact merged P7C.1 `main` tip from which P7D.1 was branched |
 | Baseline branch relationship | Based on latest `main` fixed by the task | Exact remote/head-match evidence still required before a stage closes |
 | Baseline focused suite | `75 passed` | Inherited baseline evidence supplied for this work; not rerun by this documentation change |
-| Store baseline | schema v30 | Observed at baseline source (`STORE_SCHEMA_VERSION = 30`) |
-| Durable P7B baseline | P19 RegistrySnapshot + VerificationPlan + activation + limited registration in one existing-Store UoW | Observed at baseline source |
+| Store baseline | schema v32 | Observed at P7D.1 baseline source (`STORE_SCHEMA_VERSION = 32`) |
+| Durable P7C baseline | P19 RegistrySnapshot + VerificationPlan + activation + limited registration + executable plan + immutable authorization receipt in the existing Store | Observed at merged P7C.1 baseline source |
 | Production authority baseline | one existing Gateway/Store/Policy/Ticket/Grant/Runtime/P19/Completion chain | Must remain invariant through every stage |
 
 The `75 passed` row records the supplied baseline only. Its original command,
@@ -27,9 +27,9 @@ release/merge claim. This document does not represent that suite as rerun.
 | Stage | State | Completed in current work | Still required |
 |---|---|---|---|
 | P7C.0 | `MERGED / CLOSED` | Final successor `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` passed all nine checks with exact local/remote/PR/check head match; immutable evidence is recorded in PR #69; PR #69 merged as `b75d0c8aec926e18bebbf92938ded423b44a8016` | None for P7C.0; preserve the immutable PR evidence while later stages extend the same authorities |
-| P7C.1 | `FIRST_REMOTE_GATE_PASS / EVIDENCE_COMMIT_PREP` | One verified manifest read now owns the current Action Registry and exact argument-schema catalog; exact active registration/plan/generation/fence/object bytes are rechecked before the existing Policy/Ticket/Grant chain signs one `CompositionExecutionBindingV1`; Store v32 persists an insert-only receipt and revalidates it transactionally; the issuance-only adapter is exposed on the existing worker and delegates to `OmniGrantAuthority`; it does not consume nonces, invoke Runtime/handlers, or record action Effect/Fact; all local gates and the first nine-check remote round passed on candidate `9e744d0b2185f0b6e4abca0981daa62dc9494a7c`; PR #70 had no reviews, comments or review threads and was `CLEAN` when captured | Commit this evidence-only ledger update, rerun all nine checks on the successor HEAD, prove exact local/remote/PR/check head match, post immutable PR evidence, then merge |
-| P7D.1 | `NOT_STARTED` | Unique Runtime seam and A0 first-slice boundary documented | Existing-worker/regenerative/Effect/Fact/BackendClient/Omni integration and evidence |
-| P7D.2 | `NOT_STARTED` | DAG/`STEP_OUTPUT`/P19/Completion boundary documented | Durable DAG/restart/reconcile, P19 readiness, CompletionGate closeout, production A0 evidence |
+| P7C.1 | `MERGED / CLOSED` | Final successor `e6023ba100f2b8a19331e1a0b0b46e0251533a32` passed all nine checks with exact local/remote/PR/check head match; immutable evidence is recorded in PR #70; PR #70 merged as `acb39a63bd267b5db1b9c0b7076110c5391704c8` | None for P7C.1; P7D must continue to consume the same Policy/Ticket/Grant authorities rather than minting replacements |
+| P7D.1 | `ALL LOCAL GATES PASS / CANDIDATE PREP` | The existing `GatewayOrchestrationWorker` dispatches one persisted static A0 root through the existing Backend compatibility client into Omni Body and `BodyRuntime`; exact receipt/plan/registry/schema/object/fence/trust are revalidated, ticket and grant nonces are consumed at the handler boundary, Gateway Fact precedes terminal Effect, and timeout/restart recovery never replays an unknown `STARTED` attempt | Create the first immutable candidate commit, pass all nine remote checks, record exact head match and merge; this stage intentionally does not claim DAG, dynamic `STEP_OUTPUT`, P19 closeout or production completion before P7D.2 |
+| P7D.2 | `DESIGN RECON ACTIVE / IMPLEMENTATION NOT STARTED` | Read-only production-path reconnaissance identified the no-second-frontier design, dynamic-result authority gap, multi-Fact CompletionGate bug, and restart/epoch continuation-authority requirement | Durable DAG/restart/reconcile, result-schema authority, current-epoch continuation issuance, exact P19 readiness, CompletionGate closeout and production A0 evidence |
 
 ## 3. P7C.0 implementation checklist
 
@@ -118,24 +118,32 @@ does not change the tested product/test tree.
   evidence is recorded on code candidate
   `9e744d0b2185f0b6e4abca0981daa62dc9494a7c`.
 - [x] The first nine-check remote round passed on that unchanged code candidate.
-- [ ] Pass all nine remote checks again on the evidence-only successor SHA that
+- [x] Pass all nine remote checks again on the evidence-only successor SHA that
   is intended to merge.
-- [ ] Record exact local/remote/PR/check head match for that successor SHA.
+- [x] Record exact local/remote/PR/check head match for that successor SHA and
+  merge PR #70 as `acb39a63bd267b5db1b9c0b7076110c5391704c8`.
 
 ### P7D.1
 
-- [ ] Existing `GatewayOrchestrationWorker` is the only scheduler.
-- [ ] Existing regenerative execution seam and canonical Gateway Effect/Fact
+- [x] Existing `GatewayOrchestrationWorker` is the only scheduler.
+- [x] Existing worker dispatch seam and canonical Gateway Effect/Fact
   authorities own durable progress; `ExecutionEngine` is not introduced as a
   production scheduler/outcome ledger.
-- [ ] A0 read/verify goes through existing `BackendClient` → Omni Body →
+- [x] A0 read/verify goes through existing `BackendClient` → Omni Body →
   `BodyRuntime` using exact Ticket/Grant bindings.
-- [ ] Pre-dispatch rejection invokes no handler.
-- [ ] Timeout/error after the execution boundary becomes `AMBIGUOUS` or
+- [x] Pre-dispatch rejection invokes no handler and consumes no handler nonce.
+- [x] Timeout/error after the execution boundary becomes `AMBIGUOUS` or
   reconcile-required and is not replayed blindly.
-- [ ] Single-step restart cut points prove no duplicate handler call.
-- [ ] P7D.1 cannot claim production completion before P7D.2.
-- [ ] Focused/local evidence, nine remote checks and head-match are recorded.
+- [x] Single-step restart cut points prove no duplicate handler call; exact Fact
+  recovers terminal Effect, while missing Fact closes unknown work
+  `AMBIGUOUS`.
+- [x] P7D.1 cannot claim production completion before P7D.2.
+- [x] Focused, adversarial, generated-source, P14, P19 and Node local evidence
+  is recorded on the current pre-commit candidate tree.
+- [x] Full Python final rerun is recorded on the current pre-commit candidate
+  tree.
+- [ ] Nine remote checks and exact head-match are recorded on the immutable
+  candidate/successor heads.
 
 ### P7D.2
 
@@ -185,9 +193,13 @@ assumption.
 | P7C.1 | P19 Golden Gate | `python -m pytest tests/golden/p19_r2/ -q` | Windows / Python 3.12.10 | `PASS` | 55 passed | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | 38.08 s; completed in this work session before the candidate commit |
 | P7C.1 | P19/verification/repair selection | `python -m pytest tests/ -k "p19 or verification or repair" -q` | Windows / Python 3.12.10 | `PASS` | 316 passed, 3594 deselected | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | 76.66 s; completed in this work session before the candidate commit |
 | P7C.1 | Official generation, mirrors and Source Authority | `python scripts/sync-generated-sources.py --check`; `python scripts/sync-generated-sources.py --check-committed`; `python scripts/sync_omni_capability_manifest.py --check`; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary; both mirror modes and manifest check passed | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | Final staged-tree checks completed in this work session before the candidate commit |
-| P7D.1 | runtime/effect/fact/restart/timeout | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
-| P7D.1 | generated-source sync/check + mirrors | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
-| P7D.1 | selected/full local regression | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
+| P7D.1 | Runtime/Effect/Fact/restart/timeout focused regression | `python -m pytest -q tests/test_composition_step_execution_p7d1.py tests/test_composition_backend_transport_p7d1.py tests/test_composition_execution_manifest_p7d1.py tests/test_gateway_worker_composition_integration_p7d1.py tests/test_gateway_worker_composition_recovery_p7d1.py tests/test_effect_fact_chain_v14.py tests/test_execution_contract_epoch.py tests/test_p18_m4_authority_repairs.py tests/test_effect_ledger.py` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 97 passed | `PENDING FIRST COMMIT` | 67.27 s; rerun after timeout-permit repair |
+| P7D.1 | P19 Golden Gate | `python -m pytest tests/golden/p19_r2/ -q` | Windows / Python 3.12.10, refreshed 1.4 freeze/fingerprint | `PASS` | 55 passed | `PENDING FIRST COMMIT` | 38.48 s; rerun after final watchdog compatibility fix |
+| P7D.1 | P19/verification/repair selection | `python -m pytest tests/ -k "p19 or verification or repair" -q` | Windows / Python 3.12.10 | `PASS` | 316 passed, 3670 deselected | `PENDING FIRST COMMIT` | 77.42 s |
+| P7D.1 | P14 focused regression | `python -m pytest -q tests/test_repository_structure_p14_m2.py tests/test_repository_structure_p14_m2_wiring.py tests/test_repository_query_p14_m3.py tests/test_repository_query_p14_m3_coherence.py tests/test_repository_query_p14_m3_wiring.py tests/test_repository_context_p14_m4.py tests/test_repository_context_p14_m4_wiring.py tests/test_repository_incremental_p14_m5.py tests/test_repository_security_p14.py tests/test_life_repository_bridge_p14.py tests/test_reflection_capability_p8.py tests/test_life_capability_health_flow.py` | Windows / Python 3.12.10 | `PASS` | 109 passed | `PENDING FIRST COMMIT` | 13.98 s; rerun after final product changes |
+| P7D.1 | Full Node regression | `$NodeTests = @(Get-ChildItem -LiteralPath tests -Filter '*.test.mjs' -File \| Sort-Object FullName \| ForEach-Object { $_.FullName }); node --test @NodeTests` | Windows / Node v24.14.0 | `PASS` | 224 passed, 2 skipped, 0 failed in 29 files | `PENDING FIRST COMMIT` | 2011.00 ms Node duration; worktree byte-equivalent before/after |
+| P7D.1 | Official generation, manifests and Source Authority | `python scripts/sync-generated-sources.py --write`; `python scripts/sync-generated-sources.py --check`; `python scripts/sync_omni_capability_manifest.py --check`; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 19 managed novel Actions, 790 total, 290 executable; 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary | `PENDING FIRST COMMIT` | Final official write/check completed after product fixes |
+| P7D.1 | Full Python regression | `python -m pytest -q` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 3969 passed, 17 skipped, 847 subtests passed | `PENDING FIRST COMMIT` | 709.48 s; final clean rerun after all product/test fixes |
 | P7D.2 | DAG/`STEP_OUTPUT`/reconcile/P19/Completion | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 | P7D.2 | generated-source sync/check + mirrors | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 | P7D.2 | selected/full local regression | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
@@ -207,6 +219,15 @@ as PASS. After `npm ci --ignore-scripts --no-audit --no-fund`, the unchanged
 Node suite was rerun without concurrent Python load and completed with 224
 passed, 2 skipped and 0 failed.
 
+The first P7D.1 full Python run is not counted as PASS: it exposed one missing
+reviewed-lineage successor for the deliberately changed authorization contract
+and two legacy watchdog-test doubles without a production `claim` field. The
+minimal lineage and compatibility fixes passed a 14-test targeted rerun. The
+subsequent complete unchanged-tree run is the 3969-pass result recorded above.
+An exploratory non-canonical Node run with forced test concurrency also hit the
+same pre-existing avatar readiness timing failure; the repository-defined
+sorted `node --test` command passed and is the only P7D.1 Node PASS evidence.
+
 ## 7. Nine required GitHub checks per stage
 
 Focused/migration/tamper tests and local sync/check evidence must be green
@@ -215,15 +236,15 @@ checks against one unchanged candidate SHA.
 
 | Required GitHub check | P7C.0 | P7C.1 | P7D.1 | P7D.2 |
 |---|---|---|---|---|
-| `source-authority-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `source-authority-windows-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `full-regression-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `full-regression-windows-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `p14-focused-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `p14-focused-windows-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `full-regression-ubuntu` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `p19-r2-golden-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
-| `p19-r2-golden-windows-latest` | `FINAL PASS @ c7b1ba1…` | `ROUND 1 PASS @ 9e744d0… / FINAL HEAD RERUN PENDING` | `PENDING` | `PENDING` |
+| `source-authority-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `source-authority-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `full-regression-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `full-regression-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `p14-focused-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `p14-focused-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `full-regression-ubuntu` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `p19-r2-golden-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `p19-r2-golden-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
 
 For every non-pending cell, attach the GitHub run URL, conclusion, checked SHA
 and completion time below. A green check on another SHA does not count.
@@ -250,26 +271,35 @@ and completion time below. A green check on another SHA does not count.
 | P7C.1 | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `full-regression-ubuntu` | [job 100907261791 / run 33835568522](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33835568522/job/100907261791) | `SUCCESS` | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `2026-09-04T04:13:55Z` |
 | P7C.1 | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `p19-r2-golden-ubuntu-latest` | [job 100907262023 / run 33835568541](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33835568541/job/100907262023) | `SUCCESS` | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `2026-09-04T04:08:34Z` |
 | P7C.1 | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `p19-r2-golden-windows-latest` | [job 100907261769 / run 33835568541](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33835568541/job/100907261769) | `SUCCESS` | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `2026-09-04T04:11:05Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `source-authority-ubuntu-latest` | [job 100914435934 / run 33838030691](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030691/job/100914435934) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:46:59Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `source-authority-windows-latest` | [job 100914435969 / run 33838030691](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030691/job/100914435969) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:48:01Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `full-regression-ubuntu-latest` | [job 100914435711 / run 33838030691](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030691/job/100914435711) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:53:18Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `full-regression-windows-latest` | [job 100914435873 / run 33838030691](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030691/job/100914435873) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T05:08:45Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `p14-focused-ubuntu-latest` | [job 100914435922 / run 33838030697](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030697/job/100914435922) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:46:54Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `p14-focused-windows-latest` | [job 100914435661 / run 33838030697](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030697/job/100914435661) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:48:11Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `full-regression-ubuntu` | [job 100914435835 / run 33838030697](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030697/job/100914435835) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:53:19Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `p19-r2-golden-ubuntu-latest` | [job 100914435755 / run 33838030724](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030724/job/100914435755) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:48:18Z` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `p19-r2-golden-windows-latest` | [job 100914435931 / run 33838030724](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030724/job/100914435931) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:51:21Z` |
 | P7D.1 | `TBD` | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` |
 | P7D.2 | `TBD` | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` |
 
 Add nine rows for a stage when its candidate is pushed; do not summarize mixed
 SHAs into one PASS.
 
-The P7C.0 rows above are its first remote round. Its exact successor-head rerun
-matrix is preserved in the immutable PR #69 comment, and that successor was
-merged. The P7C.1 rows above are likewise the first remote round. Committing
-this evidence changes PR #70's head and therefore resets final closure. The
-exact successor-head rerun matrix will be posted as an immutable PR #70 comment
-after all nine checks finish, so recording it does not create an endlessly
-self-invalidating repository commit.
+The P7C.0 first-round rows above are supplemented by the exact successor-head
+rerun matrix in the immutable PR #69 comment. The P7C.1 rows above are its first
+remote round; the exact final `e6023ba100f2b8a19331e1a0b0b46e0251533a32`
+successor-head matrix is preserved in the immutable PR #70 evidence comment.
+Both exact successor heads were merged. Keeping final rerun matrices in
+immutable PR comments avoids creating an endlessly self-invalidating evidence
+commit.
 
 ## 9. Head-match closure
 
 | Stage | Local reviewed HEAD | Remote branch tip | PR head SHA | Nine-check SHA | Worktree clean | Status |
 |---|---|---|---|---|---|---|
 | P7C.0 | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `YES` | `CLOSED / PR #69 MERGED AS b75d0c8…` |
-| P7C.1 | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | `YES` | `ROUND 1 PASS / EVIDENCE COMMIT WILL RESET` |
+| P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `YES` | `CLOSED / PR #70 MERGED AS acb39a63…` |
 | P7D.1 | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | `PENDING` |
 | P7D.2 | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | `PENDING` |
 
@@ -287,15 +317,19 @@ remote-check and head-match cells to `PENDING`.
 | Same object identity replaced/deleted/rebound across owners or requests | Store-wide pre-insert check + canonical REQUEST owner + append-only schema guards + legacy integrity scan | P7C.0 | `CLOSED @ c7b1ba1… / MERGED IN b75d0c8…` |
 | Sealed executable companion replaced, changed or deleted after commit | identity INSERT/REPLACE/UPSERT guard + unconditional UPDATE/DELETE guards + schema fingerprint + integrity scan | P7C.0 | `CLOSED @ c7b1ba1… / MERGED IN b75d0c8…` |
 | Marker-1 companion corruption bypasses P7B paths | registration-scoped full companion parse/cross-authority validation on each P7B read/recovery/expiry/replay target; global open/health scan | P7C.0 | `CLOSED @ c7b1ba1… / MERGED IN b75d0c8…` |
-| Dynamic result drift/substitution | exact upstream Effect+Fact+lineage and schema-bound `STEP_OUTPUT` | P7D.2 | `OPEN` |
-| Plan A0 label used as permission | current compiled permission + Policy at immediate boundary | P7C.1 | `CONTROL IMPLEMENTED / FULL LOCAL PASS / FIRST REMOTE PASS / FINAL HEAD RERUN PENDING` |
-| Capability manifest changes between model loading and authorization authority compilation | compile Registry and schema catalog from the same single verified file read, then reuse that authority in orchestration | P7C.1 | `CONTROL IMPLEMENTED / FULL LOCAL PASS / FIRST REMOTE PASS / FINAL HEAD RERUN PENDING` |
-| Request/plan/step/arguments/target/generation crossing under a valid signature | exact `CompositionExecutionBindingV1` on Intent, Decision, Ticket and Grant plus independent expected binding | P7C.1 | `CONTROL IMPLEMENTED / FULL LOCAL PASS / FIRST REMOTE PASS / FINAL HEAD RERUN PENDING` |
-| Durable receipt treated as signature authority after restart | Store validates canonical structure and hashes; `OmniGrantAuthority` must reverify current ticket/grant signatures before return or replay; P7D consumers must preserve that gate | P7C.1/P7D.1 | `P7C.1 CONTROL IMPLEMENTED / P7D CONSUMER OPEN` |
+| Dynamic result drift/substitution | exact upstream Effect+Fact+lineage and schema-bound `STEP_OUTPUT` backed by an explicit result/value schema body in the existing Omni catalog | P7D.2 | `OPEN; CURRENT CATALOG HAS ARGUMENT SCHEMAS BUT NO RESULT/VALUE SCHEMA AUTHORITY` |
+| Parent authorization disappears after unregister or gateway epoch restart | insert-only, non-executable continuation delegation may only re-enter the current Policy/Ticket/Grant chain; it can never authorize Runtime directly | P7D.2 | `OPEN; OLD RECEIPT/TICKET MUST NOT CROSS EPOCH` |
+| Pre-start receipt cannot be safely resumed in a new epoch | Store proves handler count zero and nonces unconsumed before bounded attempt+1/new Effect ID supersession | P7D.2 | `OPEN; STARTED REMAINS NO-REPLAY` |
+| Existing CompletionGate treats a legal multi-Fact batch as a conflict | compare the complete exact FactBatch ID tuple and bind every required leaf Effect/Fact | P7D.2 | `OPEN` |
+| Composition writes the regenerative `execution_frontier` | derive a read-only frontier from sealed plan + receipts + Effect heads + Fact batches; preserve the existing single writer | P7D.2 | `PROHIBITED / DESIGN CONTROL IDENTIFIED` |
+| Plan A0 label used as permission | current compiled permission + Policy at immediate boundary | P7C.1 | `CLOSED @ e6023ba… / MERGED IN acb39a63…` |
+| Capability manifest changes between model loading and authorization authority compilation | compile Registry and schema catalog from the same single verified file read, then reuse that authority in orchestration | P7C.1 | `CLOSED @ e6023ba… / MERGED IN acb39a63…` |
+| Request/plan/step/arguments/target/generation crossing under a valid signature | exact `CompositionExecutionBindingV1` on Intent, Decision, Ticket and Grant plus independent expected binding | P7C.1 | `CLOSED @ e6023ba… / MERGED IN acb39a63…` |
+| Durable receipt treated as signature authority after restart | Store validates canonical structure and hashes; the P7D consumer revalidates the immutable receipt, current trust, ticket and grant before dispatch | P7C.1/P7D.1 | `P7D.1 STATIC-ROOT CONTROL IMPLEMENTED / MULTI-STEP CURRENT-EPOCH CONTINUATION OPEN IN P7D.2` |
 | Same-size path content changes after snapshot | strengthen path snapshot before any path-based composition execution | P7D.1 | `OPEN BEFORE PATH-BASED EXECUTION` |
-| Second scheduler/outcome authority | only `GatewayOrchestrationWorker` + existing regenerative/Effect/Fact seams | P7D.1 | `OPEN` |
-| Cross-boundary timeout replay | `AMBIGUOUS`/reconcile-required; no blind replay | P7D.1/P7D.2 | `OPEN` |
-| Grant-admission evidence mistaken for action success | require canonical action Effect head + Gateway execution fact | P7D.1/P7D.2 | `OPEN` |
+| Second scheduler/outcome authority | only `GatewayOrchestrationWorker` + canonical Effect/Fact seams | P7D.1 | `P7D.1 STATIC ROOT CONTROL IMPLEMENTED / DAG DERIVATION OPEN IN P7D.2` |
+| Cross-boundary timeout replay | `AMBIGUOUS`/reconcile-required; no blind replay | P7D.1/P7D.2 | `P7D.1 STATIC ROOT CONTROL IMPLEMENTED / DAG CUT-POINT MATRIX OPEN IN P7D.2` |
+| Grant-admission evidence mistaken for action success | require canonical action Effect head + Gateway execution fact | P7D.1/P7D.2 | `P7D.1 STATIC ROOT CONTROL IMPLEMENTED / LEAF BARRIER OPEN IN P7D.2` |
 | Verification or repair escapes A0 | exact P19 plan; no A1+ repair dispatch in first batch | P7D.2 | `OPEN` |
 | Partial leaf success declared complete | CompletionGate requires every required leaf Effect/fact | P7D.2 | `OPEN` |
 | Read-only composition triggers channel delivery | initial P7D batch excludes external delivery/send | P7D.2 | `OPEN` |

--- a/docs/capability-composition/P7C_P7D_PROGRESS.md
+++ b/docs/capability-composition/P7C_P7D_PROGRESS.md
@@ -1,6 +1,6 @@
 # P7C / P7D Continuous Progress and Evidence Ledger
 
-Last updated: 2026-09-04 16:17 +08:00.
+Last updated: 2026-09-04 17:22 +08:00.
 
 This file is the continuous status ledger for P7C.0, P7C.1, P7D.1 and P7D.2.
 It separates observed baseline evidence from planned or not-yet-run evidence.
@@ -28,8 +28,8 @@ release/merge claim. This document does not represent that suite as rerun.
 |---|---|---|---|
 | P7C.0 | `MERGED / CLOSED` | Final successor `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` passed all nine checks with exact local/remote/PR/check head match; immutable evidence is recorded in PR #69; PR #69 merged as `b75d0c8aec926e18bebbf92938ded423b44a8016` | None for P7C.0; preserve the immutable PR evidence while later stages extend the same authorities |
 | P7C.1 | `MERGED / CLOSED` | Final successor `e6023ba100f2b8a19331e1a0b0b46e0251533a32` passed all nine checks with exact local/remote/PR/check head match; immutable evidence is recorded in PR #70; PR #70 merged as `acb39a63bd267b5db1b9c0b7076110c5391704c8` | None for P7C.1; P7D must continue to consume the same Policy/Ticket/Grant authorities rather than minting replacements |
-| P7D.1 | `FIRST REMOTE GATE PASS / EVIDENCE COMMIT PREP` | The existing `GatewayOrchestrationWorker` dispatches one persisted static A0 root through the existing Backend compatibility client into Omni Body and `BodyRuntime`; exact receipt/plan/registry/schema/object/fence/trust are revalidated, ticket and grant nonces are consumed at the handler boundary, Gateway Fact precedes terminal Effect, and timeout/restart recovery never replays an unknown `STARTED` attempt; every local gate and all nine first-round remote checks passed on `c327851a1e18deb7c602673c3f3f87c6afa785f7`; PR #71 was `CLEAN` with no comments or reviews when captured | Commit this evidence-only update, rerun all nine checks on the successor HEAD, record exact local/remote/PR/check head match in immutable PR evidence and merge; this stage intentionally does not claim DAG, dynamic `STEP_OUTPUT`, P19 closeout or production completion before P7D.2 |
-| P7D.2 | `DESIGN RECON ACTIVE / IMPLEMENTATION NOT STARTED` | Read-only production-path reconnaissance identified the no-second-frontier design, dynamic-result authority gap, multi-Fact CompletionGate bug, and restart/epoch continuation-authority requirement | Durable DAG/restart/reconcile, result-schema authority, current-epoch continuation issuance, exact P19 readiness, CompletionGate closeout and production A0 evidence |
+| P7D.1 | `FINAL-RERUN DEFECT REPAIRED / NEW SUCCESSOR PREP` | The existing `GatewayOrchestrationWorker` dispatches one persisted static A0 root through the existing Backend compatibility client into Omni Body and `BodyRuntime`; exact receipt/plan/registry/schema/object/fence/trust are revalidated, ticket and grant nonces are consumed at the handler boundary, Gateway Fact precedes terminal Effect, and timeout/restart recovery never replays an unknown `STARTED` attempt. All nine first-round checks passed on `c327851a1e18deb7c602673c3f3f87c6afa785f7`. The evidence successor `331e675a7e159493d78fc4242612a1bdb8aed41f` was correctly rejected at 8/9 when Windows exposed a cross-ledger `os.replace` race; product/test repair `24937b440746ec90b4e0000723280bef0e88f49e` now uses atomic no-clobber publication with exact-byte validation and has complete local gates | Commit this ledger-only successor, rerun all nine checks on that exact head, record immutable local/remote/PR/check head-match evidence and merge; this stage intentionally does not claim DAG, dynamic `STEP_OUTPUT`, P19 closeout or production completion before P7D.2 |
+| P7D.2 | `DESIGN RECON COMPLETE / IMPLEMENTATION NOT STARTED` | Read-only production-path and v1.2 cross-checks identified the no-second-frontier design, explicit result-schema authority, final-output alias, multi-disposition and multi-Fact CompletionGate gaps, restart/epoch continuation-authority requirement, dependency-edge leaf semantics, exact P19 subject coverage and running-manifest-lock conflict | Durable DAG/restart/reconcile, result/value-schema authority, current-epoch continuation issuance, exact P19 readiness/disposition aggregation, CompletionGate closeout and production A0 evidence |
 
 ## 3. P7C.0 implementation checklist
 
@@ -144,8 +144,9 @@ does not change the tested product/test tree.
   tree.
 - [x] The first nine-check remote round and exact head match are recorded on
   candidate `c327851a1e18deb7c602673c3f3f87c6afa785f7`.
-- [ ] Nine remote checks and exact head-match are recorded on the evidence-only
-  successor head intended to merge.
+- [ ] Nine remote checks and exact head-match are recorded on the new successor
+  that contains repair `24937b440746ec90b4e0000723280bef0e88f49e` plus this
+  evidence update and is intended to merge.
 
 ### P7D.2
 
@@ -202,16 +203,31 @@ assumption.
 | P7D.1 | Full Node regression | `$NodeTests = @(Get-ChildItem -LiteralPath tests -Filter '*.test.mjs' -File \| Sort-Object FullName \| ForEach-Object { $_.FullName }); node --test @NodeTests` | Windows / Node v24.14.0 | `PASS` | 224 passed, 2 skipped, 0 failed in 29 files | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 2011.00 ms Node duration; worktree byte-equivalent before/after |
 | P7D.1 | Official generation, manifests and Source Authority | `python scripts/sync-generated-sources.py --write`; `python scripts/sync-generated-sources.py --check`; `python scripts/sync_omni_capability_manifest.py --check`; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 19 managed novel Actions, 790 total, 290 executable; 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | Final official write/check completed after product fixes |
 | P7D.1 | Full Python regression | `python -m pytest -q` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 3969 passed, 17 skipped, 847 subtests passed | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 709.48 s; final clean rerun after all product/test fixes |
+| P7D.1 remediation | P7D runtime + evidence concurrency focused regression | `python -m pytest -q tests/test_composition_step_execution_p7d1.py tests/test_composition_backend_transport_p7d1.py tests/test_composition_execution_manifest_p7d1.py tests/test_gateway_worker_composition_integration_p7d1.py tests/test_gateway_worker_composition_recovery_p7d1.py tests/test_effect_fact_chain_v14.py tests/test_execution_contract_epoch.py tests/test_p18_m4_authority_repairs.py tests/test_effect_ledger.py tests/test_policy_evidence_concurrency.py` | Windows / Python 3.12.10, exact product repair commit | `PASS` | 99 passed | `24937b440746ec90b4e0000723280bef0e88f49e` | 77.70 s; includes deterministic two-ledger no-clobber race and publication-failure cleanup |
+| P7D.1 remediation | P7C.1 authority + evidence concurrency regression | `python -m pytest -q tests/test_policy_evidence_concurrency.py tests/test_composition_grant_authority_p7c1.py` | Windows / Python 3.12.10, repaired product/test tree | `PASS` | 30 passed | `24937b440746ec90b4e0000723280bef0e88f49e` | 13.45 s; original two-authority race also passed 20/20 isolated repetitions |
+| P7D.1 remediation | Full Python regression after official mirror sync | `python -m pytest -q` | Windows / Python 3.12.10, repaired product/test tree | `PASS` | 3971 passed, 17 skipped, 847 subtests passed | `24937b440746ec90b4e0000723280bef0e88f49e` | 723.92 s; 8 existing warnings |
+| P7D.1 remediation | P19 Golden Gate | `python -m pytest tests/golden/p19_r2/ -q` | Windows / Python 3.12.10 | `PASS` | 55 passed | `24937b440746ec90b4e0000723280bef0e88f49e` | 39.40 s |
+| P7D.1 remediation | P19/verification/repair selection | `python -m pytest tests/ -k "p19 or verification or repair" -q` | Windows / Python 3.12.10 | `PASS` | 316 passed, 3672 deselected | `24937b440746ec90b4e0000723280bef0e88f49e` | 77.75 s |
+| P7D.1 remediation | P14 focused regression | Same 12-file P14 selection recorded above | Windows / Python 3.12.10 | `PASS` | 109 passed | `24937b440746ec90b4e0000723280bef0e88f49e` | 14.53 s |
+| P7D.1 remediation | Full Node regression | `$NodeTests = @(Get-ChildItem -LiteralPath tests -Filter '*.test.mjs' -File \| Sort-Object FullName \| ForEach-Object { $_.FullName }); node --test @NodeTests` | Windows / Node v24.14.0 | `PASS` | 224 passed, 2 skipped, 0 failed in 29 files | `24937b440746ec90b4e0000723280bef0e88f49e` | 1960.69 ms; repaired transport wait helper also passed 50/50 isolated stress runs |
+| P7D.1 remediation | Official generation, manifests and Source Authority | `python scripts/sync-generated-sources.py --write`; both mirror checks; Omni manifest check; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 19 managed novel Actions, 790 total, 290 executable; 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary | `24937b440746ec90b4e0000723280bef0e88f49e` | Official write followed by final check/check-committed and source-authority PASS |
 | P7D.2 | DAG/`STEP_OUTPUT`/reconcile/P19/Completion | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 | P7D.2 | generated-source sync/check + mirrors | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 | P7D.2 | selected/full local regression | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 
-The first discovered Node full-suite run had one timeout before the `cancel`
+An earlier discovered Node full-suite run had one timeout before the `cancel`
 assertions in the pre-existing `test_avatar_p2b_transport.test.mjs` readiness
 helper. The same unchanged test failed on baseline `main`; repeated isolation
-was 20/20 green, and a subsequent discovered full suite was 224 passed / 2
-skipped / 0 failed. This is recorded as a baseline timing flake, not hidden as
-a product-code pass.
+was then 20/20 green, and a subsequent discovered full suite passed. During the
+P7D.1 remediation gate, the canonical suite hit the same helper in `cancel`,
+then an isolated rerun hit the adjacent backpressure test at the same initial
+wait. The helper comment prohibited fixed-turn timing assumptions, but its code
+still exhausted 200 `setImmediate` turns before real file I/O was guaranteed to
+complete. Repair `24937b440746ec90b4e0000723280bef0e88f49e` replaces that
+non-contract turn count with the file's existing two-second wall-clock pattern;
+all protocol assertions remain unchanged. The file passed 28/28, isolated
+stress passed 50/50, and the canonical suite passed 224/2/0 afterward. The two
+failed discovery runs are not counted as PASS.
 
 The first P7C.1 Node discovery run was executed before this independent
 worktree had installed the locked `app/package-lock.json` dependencies. Six
@@ -226,9 +242,20 @@ reviewed-lineage successor for the deliberately changed authorization contract
 and two legacy watchdog-test doubles without a production `claim` field. The
 minimal lineage and compatibility fixes passed a 14-test targeted rerun. The
 subsequent complete unchanged-tree run is the 3969-pass result recorded above.
-An exploratory non-canonical Node run with forced test concurrency also hit the
-same pre-existing avatar readiness timing failure; the repository-defined
-sorted `node --test` command passed and is the only P7D.1 Node PASS evidence.
+
+The first remediation full Python run is also not counted as PASS: it was run
+before the mandatory generated-source write and correctly reported only the
+authoritative `policy_evidence.py` mirror and marker as stale (3970 passed, two
+source-authority failures). After the official write/check, both exact failures
+passed and the complete unchanged-tree rerun passed 3971 tests.
+
+The evidence-only successor `331e675a7e159493d78fc4242612a1bdb8aed41f`
+is not a final PASS. Eight checks succeeded, but Windows full regression failed
+when two independent policy-evidence ledgers concurrently published the same
+digest path and Windows rejected the second `os.replace` with `WinError 5`.
+Repair `24937b440746ec90b4e0000723280bef0e88f49e` uses atomic no-clobber
+publication, validates the winning bytes and cleans temporary files. Independent
+review found no P0/P1 defect in that repair or in the bounded Node wait repair.
 
 ## 7. Nine required GitHub checks per stage
 
@@ -238,15 +265,15 @@ checks against one unchanged candidate SHA.
 
 | Required GitHub check | P7C.0 | P7C.1 | P7D.1 | P7D.2 |
 |---|---|---|---|---|
-| `source-authority-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `source-authority-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `full-regression-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `full-regression-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `p14-focused-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `p14-focused-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `full-regression-ubuntu` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `p19-r2-golden-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
-| `p19-r2-golden-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `source-authority-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `source-authority-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `full-regression-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `full-regression-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `FAIL @ 331e675… / REPAIRED / NEW HEAD RERUN PENDING` | `PENDING` |
+| `p14-focused-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `p14-focused-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `full-regression-ubuntu` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `p19-r2-golden-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
+| `p19-r2-golden-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PASS @ 331e675… / NEW HEAD RERUN PENDING` | `PENDING` |
 
 For every non-pending cell, attach the GitHub run URL, conclusion, checked SHA
 and completion time below. A green check on another SHA does not count.
@@ -291,6 +318,15 @@ and completion time below. A green check on another SHA does not count.
 | P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `full-regression-ubuntu` | [job 100951168672 / run 33850249966](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249966/job/100951168672) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:55:14Z` |
 | P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `p19-r2-golden-ubuntu-latest` | [job 100951168883 / run 33850250071](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850250071/job/100951168883) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:48:34Z` |
 | P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `p19-r2-golden-windows-latest` | [job 100951169066 / run 33850250071](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850250071/job/100951169066) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:52:56Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `source-authority-ubuntu-latest` | [job 100959704470 / run 33852963416](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963416/job/100959704470) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:21:22Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `source-authority-windows-latest` | [job 100959704672 / run 33852963416](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963416/job/100959704672) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:22:27Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `full-regression-ubuntu-latest` | [job 100959704749 / run 33852963416](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963416/job/100959704749) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:29:24Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `full-regression-windows-latest` | [job 100959704783 / run 33852963416](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963416/job/100959704783) | `FAILURE` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:43:54Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `p14-focused-ubuntu-latest` | [job 100959705011 / run 33852963463](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963463/job/100959705011) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:21:10Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `p14-focused-windows-latest` | [job 100959705060 / run 33852963463](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963463/job/100959705060) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:23:23Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `full-regression-ubuntu` | [job 100959704863 / run 33852963463](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963463/job/100959704863) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:30:09Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `p19-r2-golden-ubuntu-latest` | [job 100959704524 / run 33852963431](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963431/job/100959704524) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:22:52Z` |
+| P7D.1 | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `p19-r2-golden-windows-latest` | [job 100959704620 / run 33852963431](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33852963431/job/100959704620) | `SUCCESS` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `2026-09-04T08:26:08Z` |
 | P7D.2 | `TBD` | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` |
 
 Add nine rows for a stage when its candidate is pushed; do not summarize mixed
@@ -302,9 +338,9 @@ remote round; the exact final `e6023ba100f2b8a19331e1a0b0b46e0251533a32`
 successor-head matrix is preserved in the immutable PR #70 evidence comment.
 Both exact successor heads were merged. Keeping final rerun matrices in
 immutable PR comments avoids creating an endlessly self-invalidating evidence
-commit. The P7D.1 rows record its first remote round; this evidence-only update
-changes PR #71's head and therefore resets final closure until all nine checks
-pass again on the successor.
+commit. The P7D.1 rows include its successful first round and the rejected
+eight-of-nine evidence-only successor. Only an exact new successor-head rerun,
+immutable PR #71 evidence and four-way head match can close P7D.1.
 
 ## 9. Head-match closure
 
@@ -312,7 +348,7 @@ pass again on the successor.
 |---|---|---|---|---|---|---|
 | P7C.0 | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `YES` | `CLOSED / PR #69 MERGED AS b75d0c8…` |
 | P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `YES` | `CLOSED / PR #70 MERGED AS acb39a63…` |
-| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `YES` | `ROUND 1 PASS / EVIDENCE COMMIT WILL RESET` |
+| P7D.1 | `24937b440746ec90b4e0000723280bef0e88f49e` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `331e675a7e159493d78fc4242612a1bdb8aed41f` | `REJECTED 8/9 @ 331e675a7e159493d78fc4242612a1bdb8aed41f` | `YES BEFORE THIS LEDGER-ONLY UPDATE` | `REMEDIATION PRODUCT COMMITTED / FINAL EVIDENCE SUCCESSOR PENDING` |
 | P7D.2 | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | `PENDING` |
 
 Closure requires all four SHA columns to be identical, all nine checks green on

--- a/docs/capability-composition/P7C_P7D_PROGRESS.md
+++ b/docs/capability-composition/P7C_P7D_PROGRESS.md
@@ -1,6 +1,6 @@
 # P7C / P7D Continuous Progress and Evidence Ledger
 
-Last updated: 2026-09-04 15:40 +08:00.
+Last updated: 2026-09-04 16:17 +08:00.
 
 This file is the continuous status ledger for P7C.0, P7C.1, P7D.1 and P7D.2.
 It separates observed baseline evidence from planned or not-yet-run evidence.
@@ -28,7 +28,7 @@ release/merge claim. This document does not represent that suite as rerun.
 |---|---|---|---|
 | P7C.0 | `MERGED / CLOSED` | Final successor `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` passed all nine checks with exact local/remote/PR/check head match; immutable evidence is recorded in PR #69; PR #69 merged as `b75d0c8aec926e18bebbf92938ded423b44a8016` | None for P7C.0; preserve the immutable PR evidence while later stages extend the same authorities |
 | P7C.1 | `MERGED / CLOSED` | Final successor `e6023ba100f2b8a19331e1a0b0b46e0251533a32` passed all nine checks with exact local/remote/PR/check head match; immutable evidence is recorded in PR #70; PR #70 merged as `acb39a63bd267b5db1b9c0b7076110c5391704c8` | None for P7C.1; P7D must continue to consume the same Policy/Ticket/Grant authorities rather than minting replacements |
-| P7D.1 | `ALL LOCAL GATES PASS / CANDIDATE PREP` | The existing `GatewayOrchestrationWorker` dispatches one persisted static A0 root through the existing Backend compatibility client into Omni Body and `BodyRuntime`; exact receipt/plan/registry/schema/object/fence/trust are revalidated, ticket and grant nonces are consumed at the handler boundary, Gateway Fact precedes terminal Effect, and timeout/restart recovery never replays an unknown `STARTED` attempt | Create the first immutable candidate commit, pass all nine remote checks, record exact head match and merge; this stage intentionally does not claim DAG, dynamic `STEP_OUTPUT`, P19 closeout or production completion before P7D.2 |
+| P7D.1 | `FIRST REMOTE GATE PASS / EVIDENCE COMMIT PREP` | The existing `GatewayOrchestrationWorker` dispatches one persisted static A0 root through the existing Backend compatibility client into Omni Body and `BodyRuntime`; exact receipt/plan/registry/schema/object/fence/trust are revalidated, ticket and grant nonces are consumed at the handler boundary, Gateway Fact precedes terminal Effect, and timeout/restart recovery never replays an unknown `STARTED` attempt; every local gate and all nine first-round remote checks passed on `c327851a1e18deb7c602673c3f3f87c6afa785f7`; PR #71 was `CLEAN` with no comments or reviews when captured | Commit this evidence-only update, rerun all nine checks on the successor HEAD, record exact local/remote/PR/check head match in immutable PR evidence and merge; this stage intentionally does not claim DAG, dynamic `STEP_OUTPUT`, P19 closeout or production completion before P7D.2 |
 | P7D.2 | `DESIGN RECON ACTIVE / IMPLEMENTATION NOT STARTED` | Read-only production-path reconnaissance identified the no-second-frontier design, dynamic-result authority gap, multi-Fact CompletionGate bug, and restart/epoch continuation-authority requirement | Durable DAG/restart/reconcile, result-schema authority, current-epoch continuation issuance, exact P19 readiness, CompletionGate closeout and production A0 evidence |
 
 ## 3. P7C.0 implementation checklist
@@ -142,8 +142,10 @@ does not change the tested product/test tree.
   is recorded on the current pre-commit candidate tree.
 - [x] Full Python final rerun is recorded on the current pre-commit candidate
   tree.
-- [ ] Nine remote checks and exact head-match are recorded on the immutable
-  candidate/successor heads.
+- [x] The first nine-check remote round and exact head match are recorded on
+  candidate `c327851a1e18deb7c602673c3f3f87c6afa785f7`.
+- [ ] Nine remote checks and exact head-match are recorded on the evidence-only
+  successor head intended to merge.
 
 ### P7D.2
 
@@ -193,13 +195,13 @@ assumption.
 | P7C.1 | P19 Golden Gate | `python -m pytest tests/golden/p19_r2/ -q` | Windows / Python 3.12.10 | `PASS` | 55 passed | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | 38.08 s; completed in this work session before the candidate commit |
 | P7C.1 | P19/verification/repair selection | `python -m pytest tests/ -k "p19 or verification or repair" -q` | Windows / Python 3.12.10 | `PASS` | 316 passed, 3594 deselected | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | 76.66 s; completed in this work session before the candidate commit |
 | P7C.1 | Official generation, mirrors and Source Authority | `python scripts/sync-generated-sources.py --check`; `python scripts/sync-generated-sources.py --check-committed`; `python scripts/sync_omni_capability_manifest.py --check`; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary; both mirror modes and manifest check passed | `9e744d0b2185f0b6e4abca0981daa62dc9494a7c` | Final staged-tree checks completed in this work session before the candidate commit |
-| P7D.1 | Runtime/Effect/Fact/restart/timeout focused regression | `python -m pytest -q tests/test_composition_step_execution_p7d1.py tests/test_composition_backend_transport_p7d1.py tests/test_composition_execution_manifest_p7d1.py tests/test_gateway_worker_composition_integration_p7d1.py tests/test_gateway_worker_composition_recovery_p7d1.py tests/test_effect_fact_chain_v14.py tests/test_execution_contract_epoch.py tests/test_p18_m4_authority_repairs.py tests/test_effect_ledger.py` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 97 passed | `PENDING FIRST COMMIT` | 67.27 s; rerun after timeout-permit repair |
-| P7D.1 | P19 Golden Gate | `python -m pytest tests/golden/p19_r2/ -q` | Windows / Python 3.12.10, refreshed 1.4 freeze/fingerprint | `PASS` | 55 passed | `PENDING FIRST COMMIT` | 38.48 s; rerun after final watchdog compatibility fix |
-| P7D.1 | P19/verification/repair selection | `python -m pytest tests/ -k "p19 or verification or repair" -q` | Windows / Python 3.12.10 | `PASS` | 316 passed, 3670 deselected | `PENDING FIRST COMMIT` | 77.42 s |
-| P7D.1 | P14 focused regression | `python -m pytest -q tests/test_repository_structure_p14_m2.py tests/test_repository_structure_p14_m2_wiring.py tests/test_repository_query_p14_m3.py tests/test_repository_query_p14_m3_coherence.py tests/test_repository_query_p14_m3_wiring.py tests/test_repository_context_p14_m4.py tests/test_repository_context_p14_m4_wiring.py tests/test_repository_incremental_p14_m5.py tests/test_repository_security_p14.py tests/test_life_repository_bridge_p14.py tests/test_reflection_capability_p8.py tests/test_life_capability_health_flow.py` | Windows / Python 3.12.10 | `PASS` | 109 passed | `PENDING FIRST COMMIT` | 13.98 s; rerun after final product changes |
-| P7D.1 | Full Node regression | `$NodeTests = @(Get-ChildItem -LiteralPath tests -Filter '*.test.mjs' -File \| Sort-Object FullName \| ForEach-Object { $_.FullName }); node --test @NodeTests` | Windows / Node v24.14.0 | `PASS` | 224 passed, 2 skipped, 0 failed in 29 files | `PENDING FIRST COMMIT` | 2011.00 ms Node duration; worktree byte-equivalent before/after |
-| P7D.1 | Official generation, manifests and Source Authority | `python scripts/sync-generated-sources.py --write`; `python scripts/sync-generated-sources.py --check`; `python scripts/sync_omni_capability_manifest.py --check`; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 19 managed novel Actions, 790 total, 290 executable; 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary | `PENDING FIRST COMMIT` | Final official write/check completed after product fixes |
-| P7D.1 | Full Python regression | `python -m pytest -q` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 3969 passed, 17 skipped, 847 subtests passed | `PENDING FIRST COMMIT` | 709.48 s; final clean rerun after all product/test fixes |
+| P7D.1 | Runtime/Effect/Fact/restart/timeout focused regression | `python -m pytest -q tests/test_composition_step_execution_p7d1.py tests/test_composition_backend_transport_p7d1.py tests/test_composition_execution_manifest_p7d1.py tests/test_gateway_worker_composition_integration_p7d1.py tests/test_gateway_worker_composition_recovery_p7d1.py tests/test_effect_fact_chain_v14.py tests/test_execution_contract_epoch.py tests/test_p18_m4_authority_repairs.py tests/test_effect_ledger.py` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 97 passed | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 67.27 s; rerun after timeout-permit repair |
+| P7D.1 | P19 Golden Gate | `python -m pytest tests/golden/p19_r2/ -q` | Windows / Python 3.12.10, refreshed 1.4 freeze/fingerprint | `PASS` | 55 passed | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 38.48 s; rerun after final watchdog compatibility fix |
+| P7D.1 | P19/verification/repair selection | `python -m pytest tests/ -k "p19 or verification or repair" -q` | Windows / Python 3.12.10 | `PASS` | 316 passed, 3670 deselected | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 77.42 s |
+| P7D.1 | P14 focused regression | `python -m pytest -q tests/test_repository_structure_p14_m2.py tests/test_repository_structure_p14_m2_wiring.py tests/test_repository_query_p14_m3.py tests/test_repository_query_p14_m3_coherence.py tests/test_repository_query_p14_m3_wiring.py tests/test_repository_context_p14_m4.py tests/test_repository_context_p14_m4_wiring.py tests/test_repository_incremental_p14_m5.py tests/test_repository_security_p14.py tests/test_life_repository_bridge_p14.py tests/test_reflection_capability_p8.py tests/test_life_capability_health_flow.py` | Windows / Python 3.12.10 | `PASS` | 109 passed | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 13.98 s; rerun after final product changes |
+| P7D.1 | Full Node regression | `$NodeTests = @(Get-ChildItem -LiteralPath tests -Filter '*.test.mjs' -File \| Sort-Object FullName \| ForEach-Object { $_.FullName }); node --test @NodeTests` | Windows / Node v24.14.0 | `PASS` | 224 passed, 2 skipped, 0 failed in 29 files | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 2011.00 ms Node duration; worktree byte-equivalent before/after |
+| P7D.1 | Official generation, manifests and Source Authority | `python scripts/sync-generated-sources.py --write`; `python scripts/sync-generated-sources.py --check`; `python scripts/sync_omni_capability_manifest.py --check`; `python scripts/check-source-authority.py`; `git diff --check` | Windows / Python 3.12.10 + Git | `PASS` | 19 managed novel Actions, 790 total, 290 executable; 16 independent authorities, 1 alias, 24 generated targets, 1 closed-world boundary | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | Final official write/check completed after product fixes |
+| P7D.1 | Full Python regression | `python -m pytest -q` | Windows / Python 3.12.10, current-worktree sources | `PASS` | 3969 passed, 17 skipped, 847 subtests passed | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | 709.48 s; final clean rerun after all product/test fixes |
 | P7D.2 | DAG/`STEP_OUTPUT`/reconcile/P19/Completion | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 | P7D.2 | generated-source sync/check + mirrors | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
 | P7D.2 | selected/full local regression | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` | `TBD` |
@@ -236,15 +238,15 @@ checks against one unchanged candidate SHA.
 
 | Required GitHub check | P7C.0 | P7C.1 | P7D.1 | P7D.2 |
 |---|---|---|---|---|
-| `source-authority-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `source-authority-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `full-regression-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `full-regression-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `p14-focused-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `p14-focused-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `full-regression-ubuntu` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `p19-r2-golden-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
-| `p19-r2-golden-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `PENDING` | `PENDING` |
+| `source-authority-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `source-authority-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `full-regression-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `full-regression-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `p14-focused-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `p14-focused-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `full-regression-ubuntu` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `p19-r2-golden-ubuntu-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
+| `p19-r2-golden-windows-latest` | `FINAL PASS @ c7b1ba1…` | `FINAL PASS @ e6023ba…` | `ROUND 1 PASS @ c327851… / FINAL HEAD RERUN PENDING` | `PENDING` |
 
 For every non-pending cell, attach the GitHub run URL, conclusion, checked SHA
 and completion time below. A green check on another SHA does not count.
@@ -280,7 +282,15 @@ and completion time below. A green check on another SHA does not count.
 | P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `full-regression-ubuntu` | [job 100914435835 / run 33838030697](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030697/job/100914435835) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:53:19Z` |
 | P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `p19-r2-golden-ubuntu-latest` | [job 100914435755 / run 33838030724](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030724/job/100914435755) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:48:18Z` |
 | P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `p19-r2-golden-windows-latest` | [job 100914435931 / run 33838030724](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33838030724/job/100914435931) | `SUCCESS` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `2026-09-04T04:51:21Z` |
-| P7D.1 | `TBD` | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `source-authority-ubuntu-latest` | [job 100951168554 / run 33850249911](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249911/job/100951168554) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:47:03Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `source-authority-windows-latest` | [job 100951168479 / run 33850249911](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249911/job/100951168479) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:48:01Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `full-regression-ubuntu-latest` | [job 100951168374 / run 33850249911](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249911/job/100951168374) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:55:48Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `full-regression-windows-latest` | [job 100951168645 / run 33850249911](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249911/job/100951168645) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T08:16:29Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `p14-focused-ubuntu-latest` | [job 100951168818 / run 33850249966](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249966/job/100951168818) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:47:21Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `p14-focused-windows-latest` | [job 100951168990 / run 33850249966](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249966/job/100951168990) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:49:51Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `full-regression-ubuntu` | [job 100951168672 / run 33850249966](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850249966/job/100951168672) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:55:14Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `p19-r2-golden-ubuntu-latest` | [job 100951168883 / run 33850250071](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850250071/job/100951168883) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:48:34Z` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `p19-r2-golden-windows-latest` | [job 100951169066 / run 33850250071](https://github.com/simahanfeng007-lgtm/Tiangongzaowu-V3/actions/runs/33850250071/job/100951169066) | `SUCCESS` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `2026-09-04T07:52:56Z` |
 | P7D.2 | `TBD` | `TBD` | `TBD` | `PENDING` | `TBD` | `TBD` |
 
 Add nine rows for a stage when its candidate is pushed; do not summarize mixed
@@ -292,7 +302,9 @@ remote round; the exact final `e6023ba100f2b8a19331e1a0b0b46e0251533a32`
 successor-head matrix is preserved in the immutable PR #70 evidence comment.
 Both exact successor heads were merged. Keeping final rerun matrices in
 immutable PR comments avoids creating an endlessly self-invalidating evidence
-commit.
+commit. The P7D.1 rows record its first remote round; this evidence-only update
+changes PR #71's head and therefore resets final closure until all nine checks
+pass again on the successor.
 
 ## 9. Head-match closure
 
@@ -300,7 +312,7 @@ commit.
 |---|---|---|---|---|---|---|
 | P7C.0 | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `c7b1ba1d33bf12e8e66eed1940be248b7d048adc` | `YES` | `CLOSED / PR #69 MERGED AS b75d0c8…` |
 | P7C.1 | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `e6023ba100f2b8a19331e1a0b0b46e0251533a32` | `YES` | `CLOSED / PR #70 MERGED AS acb39a63…` |
-| P7D.1 | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | `PENDING` |
+| P7D.1 | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `c327851a1e18deb7c602673c3f3f87c6afa785f7` | `YES` | `ROUND 1 PASS / EVIDENCE COMMIT WILL RESET` |
 | P7D.2 | `TBD` | `TBD` | `TBD` | `TBD` | `TBD` | `PENDING` |
 
 Closure requires all four SHA columns to be identical, all nine checks green on

--- a/docs/capability-composition/P7D1_RUNTIME_EXECUTION.md
+++ b/docs/capability-composition/P7D1_RUNTIME_EXECUTION.md
@@ -1,0 +1,139 @@
+# P7D.1 Single-worker A0 Composition Execution
+
+Status: implementation candidate. P7D.1 is intentionally not a production
+completion claim; P7D.2 must still close DAG, `STEP_OUTPUT`, P19 and all-leaf
+completion.
+
+## Authority path
+
+There is no second scheduler, Gateway, Runtime, Store, Policy engine, Fact
+ledger or Completion authority. The only production path is:
+
+```text
+GatewayOrchestrationWorker
+  -> CompositionStepExecutionCoordinator
+  -> BackendClient
+  -> CompositionBackendExecutionTransport
+  -> EmbeddedBackendRuntime private composition route
+  -> v3.jineng.jirou_ceng._run_omni_body_tool
+  -> run_omni_body
+  -> BodyRuntime
+```
+
+The coordinator is an adapter owned by the existing worker. It does not run an
+idle/global scan and is invoked only for the exact request/run/generation that
+the worker currently owns. `ExecutionEngine` is not used as a competing
+scheduler or result authority.
+
+## Dispatch sequence
+
+P7D.1 supports exactly one static root step. It rejects dependencies and
+`STEP_OUTPUT`; those belong to P7D.2.
+
+1. The normal parent backend call returns and its Omni authority is
+   unregistered, releasing the embedded core lock.
+2. The Gateway records the exact parent execution Fact batch.
+3. The Gateway commits the parent `SUCCEEDED` Effect.
+4. The worker resolves the immutable executable-plan obligation for the exact
+   request/run/generation. This lookup does not hide expired plans.
+5. The coordinator reloads and verifies the receipt, plan, current Registry,
+   schema, permission, current object bytes, target snapshot, parent
+   Effect/Fact, current trust bundle, grant and deterministic execution
+   binding.
+6. The child Effect claim is committed.
+7. One Store transaction verifies the still-current generation owner/lease,
+   active generation fence, open global action fence and exact successful
+   parent Effect, then commits `DISPATCH_PERMIT` and `STARTED`.
+8. `BackendClient` consumes the ticket nonce and calls only the private
+   composition transport.
+9. Immediately before Omni Body, the private embedded route calls the pinned
+   Gateway authorizer. The Store rechecks the immutable P7C receipt, exact
+   `STARTED` attempt and ticket nonce consumer, then consumes the grant nonce
+   in the same transaction. The route cannot self-describe its own authority.
+10. The transport invokes Omni Body directly; it does not enter
+    chat/simple-chain/model routing and does not mint a grant.
+11. The Gateway commits the child Fact batch before the child terminal Effect.
+12. Only a successful child outcome permits the legacy parent path to continue.
+    Failed or ambiguous composition outcomes terminalize the aggregate request
+    before artifact, Life, outbox or delivery commits.
+
+## Fail-closed rules
+
+- No executable plan means the request has no composition obligation. A plan
+  that exists but has a missing, expired, corrupt or inactive receipt is an
+  execution failure, not the absence of work.
+- An unavailable embedded executor blocks both new receipt issuance and any
+  persisted plan obligation.
+- A pre-dispatch rejection calls no handler and consumes no ticket nonce. A
+  direct call to the private embedded route without the worker-installed
+  authorizer also calls no handler, even if the caller supplies structurally
+  valid signed-looking inputs.
+- Handler admission is two-stage and one-shot: `BackendClient` must have
+  consumed the exact ticket nonce for this dispatch, then the pinned route
+  authorizer consumes the exact grant nonce. A replay fails before the handler.
+- A non-empty opaque target is legal. A raw host path remains forbidden by the
+  P7C object-grant-only path policy and the live schema validator.
+- Only A0 permissions with `read`/`verify` effect, no shell, no Python, no
+  confirmation and `none`/`read` side effects are accepted.
+- The persisted runtime receipt retains `fact_kernel_enabled=true`. P7D derives
+  a detached execution copy with `fact_kernel_enabled=false`, leaving the
+  Gateway FactLedger as the sole machine-fact writer.
+- The timeout wrapper begins only after the durable permit and ticket nonce
+  boundary. Its process-wide bounded watchdog slot rejects saturation before
+  another handler can start. A timeout is `AMBIGUOUS`; both the watchdog slot
+  and the Store inflight permit remain occupied until the in-process call
+  actually exits, and a late result is discarded without racing a Fact or
+  terminal Effect. On process restart, startup recovery may release an orphaned
+  terminal composition permit because no handler from the exited process can
+  still be running.
+- `STARTED` is never replayed. Restart recovery accepts an exact immutable Fact
+  for the same effect/ticket/action/attempt/scope or closes the Effect
+  `AMBIGUOUS` when no Fact exists.
+- An already-terminal child is returned as an outcome. `FAILED_FINAL` and
+  `AMBIGUOUS` are never collapsed into `None`.
+- A stale `CLAIMED` child has not crossed the dispatch permit. If its current
+  preflight or receipt window is no longer valid, it is atomically closed
+  `FAILED_FINAL` rather than left as an orphan.
+
+## Current execution manifest
+
+The model-facing capability manifest and Action Registry use different action
+version projections. `compile_composition_execution_manifest` verifies the
+model manifest, Registry and schema catalog as one source-bound set, then emits
+a real `CapabilityManifest` whose versions and argument schemas match current
+Registry permissions while retaining the model manifest's provider, result
+schema, availability and resource limits. Policy, child Ticket, Omni grant and
+`BackendClient` all bind to that compiled manifest hash; the raw source-file
+hash is drift evidence only.
+
+## Restart boundary
+
+The worker first recovers composition `STARTED` Effects through the exact Fact
+adapter, then recovers parent Fact-before-Effect crash windows, and only then
+runs the generic conservative recovery with the composition pipeline excluded.
+Any composition/parent/generic recovery corruption prevents the worker from
+starting. Wall-clock rollback cannot create a terminal observation timestamp
+earlier than the durable start boundary.
+
+P7D.1 proves the child handler is never called twice across its single-step
+`STARTED` crash windows. Full request continuation after process restart,
+multi-step frontier replay and reauthorization are P7D.2 obligations.
+
+## Activation status and limits
+
+P7C.1 exposes the current registration-to-authorization adapter, but this
+repository still has no automatic production planner/issuer that creates a
+composition registration from ordinary chat. Therefore P7D.1 consumes an
+explicitly registered and authorized obligation; it does not claim that normal
+chat is already routed through composition by default.
+
+P7D.1 does not implement:
+
+- multi-step topological scheduling;
+- dynamic `STEP_OUTPUT` resolution;
+- P19 readiness execution for the composition leaf set;
+- repair dispatch;
+- authoritative all-leaf CompletionGate closeout;
+- production enablement of A1+, external writes or external sends.
+
+These remain hard gates for P7D.2.

--- a/docs/p19-r2/AUTHORITY_MAP.txt
+++ b/docs/p19-r2/AUTHORITY_MAP.txt
@@ -250,3 +250,24 @@ principal/workspace、活跃时间窗、精确 ObjectGrant 以及同一组 inten
 decision/ticket/grant/runtime-response 证据。表、identity、UPDATE 与 DELETE guards
 均保持 append-only；重放必须重新校验当前 parent 权威，不得将该 receipt
 解释为执行、验证通过或完成声明。
+
+P7D.1｜Single-worker A0 Composition Execution（Verification Plane 1.4）
+----------------------------------------------------------------------
+
+src/total_gateway/composition_step_execution.py
+src/total_gateway/composition_backend_transport.py
+src/total_gateway/composition_execution_binding.py
+src/total_gateway/orchestration.py
+src/total_gateway/store.py
+src/total_gateway/fact_ledger.py
+
+上述运行接缝只由既有 GatewayOrchestrationWorker 调用，并复用唯一 BackendClient、
+Omni Body、BodyRuntime、GatewayStateStore Effect head 与 FactLedger。Store 的 scoped
+dispatch permit 在一个事务内重验 current request/run/generation、owner/lease、
+generation fence、全局 action fence 以及已成功 parent Effect；拒绝发生在 handler 与
+nonce 前。STARTED 重启只从 exact Fact 收口，无 Fact 则 AMBIGUOUS，禁止重放。
+
+持久 executable plan 是不可撤销的执行 obligation：receipt 缺失、过期、损坏或
+executor 不可用都不得退化为“没有组合步骤”，已有 FAILED_FINAL/AMBIGUOUS child 也
+不得被 None 吞掉。P7D.1 仅覆盖单个静态 A0 read/verify root；DAG、STEP_OUTPUT、
+P19 readiness、repair 与 CompletionGate all-leaf closeout 仍由 P7D.2 完成。

--- a/docs/p19-r2/VERIFICATION_PLANE_1_4.txt
+++ b/docs/p19-r2/VERIFICATION_PLANE_1_4.txt
@@ -1,0 +1,68 @@
+P19-R2 VERIFICATION PLANE 1.4 — P7D.1 RUNTIME COMPATIBILITY REVISION
+======================================================================
+
+性质
+----------------------------------------------------------------------
+
+本版本是 P7D.1 对既有 P19 Verification Plane 的显式兼容修订。
+
+它只增加：
+
+1. 既有 GatewayStateStore Effect/Fact 边界对 composition pipeline 的精确查询、
+   dispatch permit 与重启对账约束；
+2. request/run/generation 当前租约、generation fence、全局 action fence 和已成功
+   parent Effect 在同一 Store 事务内的 dispatch 前校验；
+3. 已持久化 executable composition plan 的 obligation 查询。该查询不会因 plan
+   或 receipt 过期而把“必须执行但已不可执行”误判为“没有组合步骤”；
+4. P7D.1 新增的单步 A0 read/verify 运行接缝和对抗测试所需 authority-surface
+   冻结更新。
+
+它不改变：
+
+- verifier PASS / FAIL / INCONCLUSIVE 语义；
+- VerificationRecord 结构与记录规则；
+- VerificationReadiness 推导；
+- Artifact / Effect / Repository Oracle；
+- Evidence-driven Repair Policy；
+- CompletionGate；
+- P19 对完成声明的最终验证权。
+
+版本与权威
+----------------------------------------------------------------------
+
+VERIFICATION_PLANE_VERSION = "1.4"
+唯一机器可读来源：
+
+    src/total_gateway/verification_plane.py
+
+Gateway Store schema 仍为 32；本修订不新增 Store、表或第二执行状态权威。
+基线为 P7C.1 合并后的 main：
+
+    acb39a63bd267b5db1b9c0b7076110c5391704c8
+
+运行边界
+----------------------------------------------------------------------
+
+P7D.1 仅允许既有 GatewayOrchestrationWorker 在 parent execution 的 Gateway Fact
+和 SUCCEEDED Effect 均已提交后，消费一个仍可执行的 A0 read/verify composition
+receipt。调用链保持为既有 BackendClient → Omni Body → BodyRuntime；Gateway
+FactLedger 和 GatewayStateStore 仍分别持有机器事实与 Effect head。
+
+dispatch 前的拒绝不得调用 handler 或消费 nonce。STARTED 后结果未知必须进入
+AMBIGUOUS/reconcile-required，重启时只允许从 exact immutable Fact 收口，不得重放
+handler。已存在的 FAILED_FINAL/AMBIGUOUS child、缺失或过期 receipt、不可用 executor
+都必须在 artifact、Life、outbox 和 delivery 前 fail closed。
+
+P7D.1 仍不声明组合体系 production complete。DAG、STEP_OUTPUT、P19 执行、A0-only
+repair 和 all-leaf CompletionGate closeout 属于 P7D.2。
+
+冻结
+----------------------------------------------------------------------
+
+Freeze manifest：
+
+    docs/p19-r2/m6/VERIFICATION_PLANE_FREEZE.json
+
+本次修订显式更新版本、主干基线、AUTHORITY_MAP 和 authority surface hashes；历史
+1.0/1.1/1.2/1.3 声明与冻结语义保留，不覆盖。禁止在不推进
+VERIFICATION_PLANE_VERSION 的情况下静默修改该权威面。

--- a/docs/p19-r2/m6/VERIFICATION_PLANE_FINGERPRINT.json
+++ b/docs/p19-r2/m6/VERIFICATION_PLANE_FINGERPRINT.json
@@ -9,7 +9,7 @@
  "repair_policy_config_sha256": "a7002f614547ff00b5cd48b201c8b8c1873578531b165d216cf27f662e45c9ba",
  "completion_gate_sha256": "cea2905d4a1098e5389e078911753df4598b75bdf68de30bf6aee47d14937c13",
  "store_schema_version": 32,
- "authority_map_sha256": "5d0a355b4176b896fa437986ecc68ec63c6347d2bd3f1e93eaefc8ae38a96fea",
+ "authority_map_sha256": "f2c0331d1824e59fd4f2e73981f4c62a8f756033bf3fe849daed7b2f55f4c8b6",
  "golden_corpus_files": 13,
  "golden_corpus_sha256": "cf904ee6c4a26c3fb48ca0a8bafca272bfcdd5dfab5a4b514bf984d37e8e458a",
  "golden_trace_version": "1"

--- a/docs/p19-r2/m6/VERIFICATION_PLANE_FREEZE.json
+++ b/docs/p19-r2/m6/VERIFICATION_PLANE_FREEZE.json
@@ -1,19 +1,19 @@
 {
- "verification_plane_version": "1.3",
- "baseline_sha": "b75d0c8aec926e18bebbf92938ded423b44a8016",
+ "verification_plane_version": "1.4",
+ "baseline_sha": "acb39a63bd267b5db1b9c0b7076110c5391704c8",
  "store_schema_version": 32,
  "contract_schema_versions": {
   "verification": "0fb2a60a472b761a3ca04d26f02bfb3a8004d74c3bc4ddcdcbceb101d3a8fa15",
   "verification_repair": "d0d6e5c423bcf7d7084842fa4ee076ff7cd2d329a1d80817ef81488e0c7568cb"
  },
  "registry_fingerprint": "6216982d89b5e18aac4026b063fb264ad787b1a2334e05a63a77411a28b45ec9",
- "authority_map_sha256": "5d0a355b4176b896fa437986ecc68ec63c6347d2bd3f1e93eaefc8ae38a96fea",
+ "authority_map_sha256": "f2c0331d1824e59fd4f2e73981f4c62a8f756033bf3fe849daed7b2f55f4c8b6",
  "completion_authority_sha256": "cea2905d4a1098e5389e078911753df4598b75bdf68de30bf6aee47d14937c13",
  "repair_policy_sha256": "bb2ac036d01a516729d43cc068b37bb3e92f71983004275937fcfab82b2e9eaf",
  "golden_corpus_sha256": "cf904ee6c4a26c3fb48ca0a8bafca272bfcdd5dfab5a4b514bf984d37e8e458a",
  "golden_trace_version": "1",
  "authority_surface_sha256": {
-  "src/total_gateway/store.py": "64e968327ebcaacccf8b6a710c05f0c71c7b5290b380bbf2421b23c2afcceb46",
+  "src/total_gateway/store.py": "ab819d87dd1fabb18f46792c87e197bcfe5b20dfff967fa01b4a410c5b941817",
   "src/total_gateway/store_unit_of_work.py": "fc5cf98d9377cce92a83a6003f15ac873a3c20a695aae89c2b00a42d81af29fd",
   "src/total_gateway/composition_activation_shadow.py": "f545fb5e6541997b85567f65fb1b430d7cc242dabbcfddb158d83cb3564b15be",
   "src/total_gateway/composition_activation_registration.py": "9e98e250887f461f20e09a025f7d2cf2aa37fb316d8286957cb4c74ed666a0ec",

--- a/src/contracts/authorization.py
+++ b/src/contracts/authorization.py
@@ -267,7 +267,17 @@ def authorize_execution_contract(
             not claim.has_valid_sha256()
             or claim.claim_sha256 != payload.claim_sha256
             or claim.claim_revision != payload.claim_revision
-            or claim.intent_sha256 != payload.intent_sha256
+            # Composition uses a separate deterministic effect-intent hash to
+            # derive the pre-bound Effect ID.  Its ActionIntent hash includes
+            # that Effect/binding and therefore cannot equal the effect-intent
+            # hash without an identity cycle.  The signed claim digest plus
+            # the independently rebuilt CompositionExecutionBinding still
+            # binds both identities exactly.  Non-composition tickets retain
+            # the legacy same-intent invariant.
+            or (
+                not composition_present
+                and claim.intent_sha256 != payload.intent_sha256
+            )
             or claim.effect_id != payload.effect_id
         ):
             raise ExecutionAuthorizationError("ticket.claim.mismatch")

--- a/src/total_gateway/backend_client.py
+++ b/src/total_gateway/backend_client.py
@@ -8,10 +8,11 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from contracts import (
     CapabilityManifest,
+    CompositionExecutionBindingV1,
     ExecutionResult,
     ExecutionTicket,
     TrustBundle,
@@ -30,11 +31,26 @@ _BACKEND_VERIFIED_RESPONSE = object()
 
 
 class BackendClientError(RuntimeError):
-    def __init__(self, code: str, *, status: int = 0, ambiguous: bool = False) -> None:
+    def __init__(
+        self,
+        code: str,
+        *,
+        status: int = 0,
+        ambiguous: bool = False,
+        pending_transport_future: object | None = None,
+    ) -> None:
         super().__init__(code)
+        if pending_transport_future is not None and not callable(
+            getattr(pending_transport_future, "add_done_callback", None)
+        ):
+            raise TypeError("pending transport future is invalid")
         self.code = code
         self.status = status
         self.ambiguous = ambiguous
+        # A running in-process transport cannot be killed when its caller's
+        # timeout expires.  The composition owner uses this handle only to
+        # retain its durable dispatch permit until the real call has stopped.
+        self.pending_transport_future = pending_transport_future
 
 
 class BackendExecutionTransport(Protocol):
@@ -242,15 +258,39 @@ class BackendClient:
         expected_fence_epoch: int | None = None,
         active_lease_epoch: int | None = None,
         expected_target_snapshot_sha256: str | None = None,
+        expected_composition_binding: CompositionExecutionBindingV1 | None = None,
+        actual_target_snapshot_sha256: str | None = None,
+        before_dispatch: Callable[[int], None] | None = None,
+        transport_runner: Callable[
+            [Callable[[], dict[str, Any]], float], dict[str, Any]
+        ]
+        | None = None,
     ) -> BackendExecutionResponse:
         if now_ms < 0 or expected_gateway_epoch < 1 or minimum_generation < 0:
             raise ValueError("backend execution boundary time or generation is invalid")
+        if transport_runner is not None and not callable(transport_runner):
+            raise ValueError("backend transport runner is invalid")
         _reject_host_paths(arguments)
         argument_bytes = canonical_json_bytes(arguments)
         if len(argument_bytes) > 8 * 1024 * 1024:
             raise BackendClientError("backend.arguments.too_large")
         if canonical_sha256(arguments) != ticket.payload.arguments_hash:
             raise BackendClientError("backend.arguments.digest_mismatch")
+
+        composition_arguments_sha256: str | None = None
+        composition_target_sha256: str | None = None
+        if expected_composition_binding is not None:
+            if (
+                set(arguments) != {"action", "target", "args"}
+                or not isinstance(arguments.get("action"), str)
+                or not isinstance(arguments.get("target"), str)
+                or not isinstance(arguments.get("args"), dict)
+                or arguments.get("action")
+                != expected_composition_binding.action_id
+            ):
+                raise BackendClientError("backend.composition.invocation_invalid")
+            composition_arguments_sha256 = canonical_sha256(arguments["args"])
+            composition_target_sha256 = canonical_sha256(arguments["target"])
 
         verify_execution_ticket(ticket, trust_bundle, now_ms=now_ms)
         authorize_execution_contract(
@@ -269,7 +309,19 @@ class BackendClient:
             active_lease_epoch=active_lease_epoch,
             expected_target_snapshot_sha256=expected_target_snapshot_sha256,
             actual_arguments_sha256=canonical_sha256(arguments),
+            expected_composition_binding=expected_composition_binding,
+            actual_materialized_arguments_sha256=(
+                composition_arguments_sha256
+            ),
+            actual_target_sha256=composition_target_sha256,
+            actual_target_snapshot_sha256=(
+                actual_target_snapshot_sha256
+            ),
         )
+        dispatch_boundary_crossed = False
+        if before_dispatch is not None:
+            before_dispatch(now_ms)
+            dispatch_boundary_crossed = True
         ticket_sha256 = canonical_sha256(ticket.model_dump(mode="json"))
         try:
             consumed = self._nonce_store.consume_security_nonce(
@@ -284,19 +336,51 @@ class BackendClient:
                 expires_at_ms=ticket.payload.expires_at_ms,
             )
         except StoreConflictError as exc:
-            raise BackendClientError("backend.ticket.replay_conflict") from exc
+            raise BackendClientError(
+                "backend.ticket.replay_conflict",
+                ambiguous=dispatch_boundary_crossed,
+            ) from exc
         if not consumed.consumed_by_this_call:
-            raise BackendClientError("backend.ticket.replay_forbidden")
+            raise BackendClientError(
+                "backend.ticket.replay_forbidden",
+                ambiguous=dispatch_boundary_crossed,
+            )
 
         wire = {
             "schema": "tiangong.backend.execute-ticket.v1",
             "ticket": ticket.model_dump(mode="json"),
             "arguments": arguments,
         }
-        payload = self._transport.execute(
-            canonical_json_bytes(wire),
-            timeout_seconds=ticket.payload.max_runtime_ms / 1000,
-        )
+        timeout_seconds = ticket.payload.max_runtime_ms / 1000
+        request_bytes = canonical_json_bytes(wire)
+        try:
+            if transport_runner is None:
+                payload = self._transport.execute(
+                    request_bytes,
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                payload = transport_runner(
+                    lambda: self._transport.execute(
+                        request_bytes,
+                        timeout_seconds=timeout_seconds,
+                    ),
+                    timeout_seconds,
+                )
+        except BackendClientError as exc:
+            if dispatch_boundary_crossed and not exc.ambiguous:
+                raise BackendClientError(
+                    exc.code,
+                    status=exc.status,
+                    ambiguous=True,
+                    pending_transport_future=exc.pending_transport_future,
+                ) from exc
+            raise
+        except Exception as exc:
+            raise BackendClientError(
+                "backend.transport.failed",
+                ambiguous=dispatch_boundary_crossed,
+            ) from exc
         if set(payload) != {"ok", "api_contract", "execution_result", "result_payload"}:
             raise BackendClientError("backend.result.envelope_invalid", ambiguous=True)
         if payload.get("ok") is not True or payload.get("api_contract") != BACKEND_API_CONTRACT:
@@ -322,6 +406,7 @@ class BackendClient:
             or result.effect_id != expected.effect_id
             or result.action_id != expected.action_id
             or result.action_version != expected.action_version
+            or (claim is not None and result.attempt != claim.attempt)
             or result.result_payload_sha256 != result_payload_sha256
         ):
             raise BackendClientError("backend.result.binding_mismatch", ambiguous=True)

--- a/src/total_gateway/composition_activation_adapter.py
+++ b/src/total_gateway/composition_activation_adapter.py
@@ -246,10 +246,18 @@ def materialize_static_root_step(
 class CompositionActivationAdapter:
     """Narrow P7C.1 entry point backed by the one existing grant authority."""
 
-    def __init__(self, issuer: _CompositionGrantIssuer) -> None:
+    def __init__(
+        self,
+        issuer: _CompositionGrantIssuer,
+        *,
+        execution_available: bool = True,
+    ) -> None:
         if not callable(getattr(issuer, "issue_composition_step", None)):
             raise ValueError("composition adapter requires the Omni grant authority")
+        if type(execution_available) is not bool:
+            raise ValueError("composition execution availability is invalid")
         self._issuer = issuer
+        self._execution_available = execution_available
 
     def authorize_step(
         self,
@@ -259,6 +267,8 @@ class CompositionActivationAdapter:
         step_id: str,
         now_ms: int | None = None,
     ) -> dict[str, Any]:
+        if not self._execution_available:
+            _error("composition.authorization.execution_unavailable")
         for value in (parent_ticket_id, registration_id, step_id):
             if not isinstance(value, str) or _OPAQUE_ID.fullmatch(value) is None:
                 _error("composition.authorization.identity_invalid")

--- a/src/total_gateway/composition_backend_transport.py
+++ b/src/total_gateway/composition_backend_transport.py
@@ -1,0 +1,325 @@
+"""Ticket-gated in-process transport for one authorized composition step.
+
+This is a narrow ``BackendExecutionTransport`` implementation, not a Runtime
+or scheduler.  ``BackendClient`` has already verified the ExecutionTicket and
+calls this transport only after the canonical Effect dispatch permit exists.
+The transport binds that ticket to the persisted Omni grant/runtime metadata,
+uses the embedded backend's private composition route, and translates the raw
+Omni result into the existing backend execution envelope.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Protocol
+
+from contracts import (
+    ExecutionResult,
+    ExecutionTicket,
+    OmniCapabilityGrant,
+    canonical_json_bytes,
+    canonical_sha256,
+)
+
+from .backend_client import BACKEND_API_CONTRACT, BackendClientError
+
+
+COMPOSITION_BACKEND_PATH = "/api/v1/internal/composition/execute-ticket"
+COMPOSITION_BACKEND_REQUEST_SCHEMA = (
+    "tiangong.backend.composition-execute-ticket.v1"
+)
+COMPOSITION_RESULT_PAYLOAD_SCHEMA = (
+    "tiangong.backend.composition-result-payload.v1"
+)
+
+
+class _CompatibilityJsonClient(Protocol):
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: Mapping[str, Any] | None,
+        *,
+        timeout_seconds: float,
+        backend_started: bool = False,
+        before_request: Any = None,
+    ) -> tuple[int, dict[str, Any], str]: ...
+
+
+def _strict_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise BackendClientError("backend.composition.duplicate_json_key")
+        value[key] = item
+    return value
+
+
+def _decode_wire(body: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            body.decode("utf-8", errors="strict"),
+            object_pairs_hook=_strict_pairs,
+            parse_constant=lambda _value: (_ for _ in ()).throw(
+                BackendClientError("backend.composition.non_finite_json")
+            ),
+        )
+    except BackendClientError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BackendClientError("backend.composition.invalid_json") from exc
+    if not isinstance(value, dict):
+        raise BackendClientError("backend.composition.envelope_invalid")
+    return value
+
+
+def _safe_error_message(payload: Mapping[str, Any]) -> str:
+    value = str(
+        payload.get("cuowu")
+        or payload.get("error")
+        or payload.get("message")
+        or "composition action returned failure"
+    )
+    return value[:512]
+
+
+class CompositionBackendExecutionTransport:
+    """Call only the embedded Omni Body composition route.
+
+    The signed grant and runtime metadata are constructor-bound so no caller
+    can substitute them through the normal BackendClient argument map.
+    """
+
+    def __init__(
+        self,
+        client: _CompatibilityJsonClient,
+        *,
+        signed_grant: Mapping[str, Any],
+        runtime_meta: Mapping[str, Any],
+    ) -> None:
+        if not callable(getattr(client, "request", None)):
+            raise ValueError("composition backend client is unavailable")
+        try:
+            self._grant = json.loads(canonical_json_bytes(dict(signed_grant)))
+            self._runtime = json.loads(canonical_json_bytes(dict(runtime_meta)))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("composition backend authority payload is invalid") from exc
+        if not isinstance(self._grant, dict) or not isinstance(self._runtime, dict):
+            raise ValueError("composition backend authority payload is invalid")
+        self._client = client
+
+    def execute(self, body: bytes, *, timeout_seconds: float) -> dict[str, Any]:
+        if not body or len(body) > 16 * 1024 * 1024 or not 0.1 <= timeout_seconds <= 3_600:
+            raise ValueError("composition backend request size or timeout is invalid")
+        wire = _decode_wire(body)
+        if (
+            set(wire) != {"schema", "ticket", "arguments"}
+            or wire.get("schema") != "tiangong.backend.execute-ticket.v1"
+        ):
+            raise BackendClientError("backend.composition.envelope_invalid")
+        try:
+            ticket = ExecutionTicket.model_validate_json(
+                canonical_json_bytes(wire["ticket"]), strict=True
+            )
+            grant = OmniCapabilityGrant.model_validate_json(
+                canonical_json_bytes(self._grant), strict=True
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BackendClientError("backend.composition.ticket_invalid") from exc
+        invocation = wire.get("arguments")
+        if (
+            not isinstance(invocation, dict)
+            or set(invocation) != {"action", "target", "args"}
+            or not isinstance(invocation.get("action"), str)
+            or not isinstance(invocation.get("target"), str)
+            or not isinstance(invocation.get("args"), dict)
+            or canonical_sha256(invocation) != ticket.payload.arguments_hash
+        ):
+            raise BackendClientError("backend.composition.arguments_invalid")
+
+        grant_payload = grant.payload
+        ticket_binding = ticket.payload.composition_execution_binding
+        if (
+            ticket_binding is None
+            or grant_payload.composition_execution_binding != ticket_binding
+            or grant_payload.ticket_id != ticket.payload.ticket_id
+            or grant_payload.ticket_sha256
+            != canonical_sha256(ticket.payload.model_dump(mode="json"))
+            or grant_payload.effect_id != ticket.payload.effect_id
+            or grant_payload.arguments_sha256 != ticket.payload.arguments_hash
+            or grant_payload.action_id != invocation["action"]
+            or grant_payload.action_version != ticket.payload.action_version
+            or self._runtime.get("execution_ticket_id") != ticket.payload.ticket_id
+            or self._runtime.get("effect_id") != ticket.payload.effect_id
+            or self._runtime.get("action_id") != invocation["action"]
+            or self._runtime.get("composition_execution_binding")
+            != ticket_binding.model_dump(mode="json")
+            or self._runtime.get("composition_binding_sha256")
+            != ticket_binding.binding_sha256
+            or self._runtime.get("fact_kernel_enabled") is not False
+        ):
+            raise BackendClientError("backend.composition.authority_mismatch")
+
+        request_payload = {
+            "schema": COMPOSITION_BACKEND_REQUEST_SCHEMA,
+            "execute_ticket": wire,
+            "capability_grant": self._grant,
+            "runtime": self._runtime,
+        }
+        started_at_ms = time.time_ns() // 1_000_000
+        try:
+            status, backend_payload, backend_sha256 = self._client.request(
+                "POST",
+                COMPOSITION_BACKEND_PATH,
+                request_payload,
+                timeout_seconds=timeout_seconds,
+                backend_started=True,
+            )
+        except BackendClientError:
+            raise
+        except Exception as exc:
+            raise BackendClientError(
+                "backend.composition.outcome_unknown", ambiguous=True
+            ) from exc
+        finished_at_ms = time.time_ns() // 1_000_000
+        if not isinstance(backend_payload, dict):
+            raise BackendClientError(
+                "backend.composition.response_invalid", ambiguous=True
+            )
+        if status >= 500:
+            raise BackendClientError(
+                "backend.composition.outcome_unknown",
+                status=status,
+                ambiguous=True,
+            )
+
+        try:
+            raw_result_bytes = json.dumps(
+                backend_payload,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError, RecursionError, OverflowError) as exc:
+            raise BackendClientError(
+                "backend.composition.response_invalid", ambiguous=True
+            ) from exc
+        raw_result_sha256 = hashlib.sha256(raw_result_bytes).hexdigest()
+        if raw_result_sha256 != backend_sha256:
+            raise BackendClientError(
+                "backend.composition.response_digest_mismatch", ambiguous=True
+            )
+
+        succeeded = status < 400 and backend_payload.get("ok") is True
+        output_too_large = len(raw_result_bytes) > ticket.payload.max_output_bytes
+        result_status = (
+            "SUCCEEDED"
+            if succeeded and not output_too_large
+            else "FAILED_FINAL"
+        )
+        result_payload: object = {
+            "schema": COMPOSITION_RESULT_PAYLOAD_SCHEMA,
+            "backend_http_status": status,
+            "backend_response_sha256": backend_sha256,
+            "execution_boundary": "embedded-omni-body-composition-v1",
+            "omni_ok": backend_payload.get("ok") is True,
+            # The legacy Omni result may legitimately contain finite floats
+            # (for example elapsed_seconds).  Store its strict JSON bytes as a
+            # string so Gateway canonical JSON remains integer-only while the
+            # exact result is still content-addressed and inspectable.
+            "omni_result_json": raw_result_bytes.decode("utf-8"),
+            "omni_result_sha256": raw_result_sha256,
+            "omni_result_size_bytes": len(raw_result_bytes),
+        }
+        if (
+            output_too_large
+            or len(canonical_json_bytes(result_payload))
+            > ticket.payload.max_output_bytes
+        ):
+            output_too_large = True
+            result_status = "FAILED_FINAL"
+            result_payload = {
+                "error_code": "composition.runtime.output_too_large",
+                "omni_result_sha256": raw_result_sha256,
+                "omni_result_size_bytes": len(raw_result_bytes),
+            }
+            # The manifest compiler should never admit an Action whose output
+            # ceiling cannot hold this bounded failure receipt.  If authority
+            # is nevertheless inconsistent, the outcome after STARTED is
+            # unknown rather than silently violating the signed envelope.
+            if len(canonical_json_bytes(result_payload)) > ticket.payload.max_output_bytes:
+                raise BackendClientError(
+                    "backend.composition.output_envelope_impossible",
+                    ambiguous=True,
+                )
+        result_payload_sha256 = canonical_sha256(result_payload)
+        fact_id = "fact_" + canonical_sha256(
+            {
+                "domain": "tiangong.gateway.composition-execution-fact.v1",
+                "ticket_id": ticket.payload.ticket_id,
+                "effect_id": ticket.payload.effect_id,
+                "result_payload_sha256": result_payload_sha256,
+            }
+        )
+        error_code = (
+            None
+            if result_status == "SUCCEEDED"
+            else "composition.runtime.output_too_large"
+            if output_too_large
+            else "composition.runtime.action_failed"
+        )
+        result = ExecutionResult(
+            result_id="result_" + canonical_sha256(
+                {
+                    "domain": "tiangong.gateway.composition-execution-result.v1",
+                    "ticket_id": ticket.payload.ticket_id,
+                    "effect_id": ticket.payload.effect_id,
+                }
+            ),
+            ticket_id=ticket.payload.ticket_id,
+            request_id=ticket.payload.request_id,
+            run_id=ticket.payload.run_id,
+            generation=ticket.payload.generation,
+            effect_id=ticket.payload.effect_id,
+            action_id=ticket.payload.action_id,
+            action_version=ticket.payload.action_version,
+            status=result_status,
+            attempt=1,
+            started_at_ms=started_at_ms,
+            finished_at_ms=finished_at_ms,
+            side_effect_started=True,
+            result_payload_sha256=result_payload_sha256,
+            receipt_sha256=canonical_sha256(
+                {
+                    "backend_http_status": status,
+                    "backend_response_sha256": backend_sha256,
+                }
+            ),
+            output_object_refs=(),
+            fact_ids=(fact_id,),
+            error_code=error_code,
+            error_message=(
+                None
+                if result_status == "SUCCEEDED"
+                else "composition result exceeded the signed output envelope"
+                if output_too_large
+                else _safe_error_message(backend_payload)
+            ),
+        )
+        return {
+            "ok": True,
+            "api_contract": BACKEND_API_CONTRACT,
+            "execution_result": result.model_dump(mode="json"),
+            "result_payload": result_payload,
+        }
+
+
+__all__ = [
+    "COMPOSITION_BACKEND_PATH",
+    "COMPOSITION_BACKEND_REQUEST_SCHEMA",
+    "COMPOSITION_RESULT_PAYLOAD_SCHEMA",
+    "CompositionBackendExecutionTransport",
+]

--- a/src/total_gateway/composition_execution_binding.py
+++ b/src/total_gateway/composition_execution_binding.py
@@ -1,0 +1,224 @@
+"""Pure identity derivation shared by composition issuance and execution.
+
+The helpers in this module read no Store, sign no contract, consume no nonce,
+and dispatch no handler.  They keep the P7C issuer and P7D consumer on one
+deterministic derivation for the pre-bound Effect and
+``CompositionExecutionBindingV1``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contracts import (
+    CompositionExecutionBindingV1,
+    canonical_sha256,
+    derive_effect_identity,
+    derive_run_identity,
+)
+
+from .composition_activation_adapter import MaterializedCompositionStepV1
+from .composition_executable_plan import ExecutableCompositionPlanV1
+from .composition_step_authorization import CompositionStepAuthorizationRequest
+from .effects import EffectClaim
+
+
+COMPOSITION_STEP_PIPELINE_VERSION = (
+    "tiangong.composition-step-authorization.v1"
+)
+_RUN_SEQUENCE_PROBE_LIMIT = 256
+
+
+class CompositionExecutionBindingError(ValueError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedCompositionExecutionBinding:
+    run_sequence: int
+    ordinal: int
+    effect_intent_sha256: str
+    effect_id: str
+    binding: CompositionExecutionBindingV1
+
+
+def derive_run_sequence(request_id: str, run_id: str) -> int:
+    for candidate in range(1, _RUN_SEQUENCE_PROBE_LIMIT + 1):
+        if derive_run_identity(request_id, candidate).run_id == run_id:
+            return candidate
+    raise CompositionExecutionBindingError("composition.run_identity.unbound")
+
+
+def derive_composition_execution_binding(
+    plan: ExecutableCompositionPlanV1,
+    materialized: MaterializedCompositionStepV1,
+    *,
+    parent_ticket_id: str,
+    workspace_id: str,
+    workspace_scope_hash: str,
+    target_snapshot_sha256: str | None,
+) -> DerivedCompositionExecutionBinding:
+    """Derive the exact signed binding from a live plan and actual invocation."""
+
+    if (
+        not isinstance(plan, ExecutableCompositionPlanV1)
+        or not plan.has_valid_identity()
+        or materialized.executable_plan_id != plan.executable_plan_id
+        or materialized.executable_plan_sha256
+        != plan.executable_plan_sha256
+        or materialized.registration_id != plan.registration_id
+        or materialized.request_id != plan.request_id
+        or materialized.run_id != plan.run_id
+        or materialized.generation != plan.generation
+        or materialized.principal_scope_hash != plan.principal_scope_hash
+        or workspace_id != plan.workspace.workspace_id
+        or workspace_scope_hash != plan.workspace.workspace_scope_sha256
+    ):
+        raise CompositionExecutionBindingError(
+            "composition.execution.plan_projection_mismatch"
+        )
+    steps = tuple(
+        item for item in plan.step_bindings if item.step_id == materialized.step.step_id
+    )
+    if len(steps) != 1 or steps[0] != materialized.step:
+        raise CompositionExecutionBindingError(
+            "composition.execution.step_projection_mismatch"
+        )
+    ordinal = next(
+        index + 1
+        for index, item in enumerate(plan.step_bindings)
+        if item.step_id == materialized.step.step_id
+    )
+    run_sequence = derive_run_sequence(plan.request_id, plan.run_id)
+    materialized_arguments_sha256 = canonical_sha256(materialized.arguments)
+    arguments_sha256 = canonical_sha256(
+        {
+            "action": materialized.step.action_id,
+            "args": materialized.arguments,
+            "target": materialized.target,
+        }
+    )
+    target_sha256 = canonical_sha256(materialized.target)
+    target_ref = (
+        "target-"
+        + canonical_sha256(
+            {
+                "action": materialized.step.action_id,
+                "target": materialized.target,
+            }
+        )
+        if materialized.target
+        else None
+    )
+    canonical_invocation_sha256 = canonical_sha256(
+        {
+            "action_id": materialized.step.action_id,
+            "action_version": materialized.step.action_version,
+            "payload_sha256": materialized_arguments_sha256,
+            "target_ref": target_ref,
+            "workspace_id": workspace_id,
+        }
+    )
+    effect_intent_sha256 = canonical_sha256(
+        {
+            "domain": "tiangong.composition-step-effect-intent.v1",
+            "parent_ticket_id": parent_ticket_id,
+            "registration_id": plan.registration_id,
+            "executable_plan_id": plan.executable_plan_id,
+            "executable_plan_sha256": plan.executable_plan_sha256,
+            "step_id": materialized.step.step_id,
+            "step_binding_sha256": materialized.step.sha256,
+            "action_id": materialized.step.action_id,
+            "action_version": materialized.step.action_version,
+            "arguments_sha256": arguments_sha256,
+            "materialized_arguments_sha256": materialized_arguments_sha256,
+            "target_sha256": target_sha256,
+            "target_snapshot_sha256": target_snapshot_sha256,
+            "workspace_id": workspace_id,
+            "workspace_scope_hash": workspace_scope_hash,
+            "request_id": plan.request_id,
+            "run_id": plan.run_id,
+            "generation": plan.generation,
+        }
+    )
+    effect_id = derive_effect_identity(
+        request_id=plan.request_id,
+        run_id=plan.run_id,
+        run_sequence=run_sequence,
+        generation=plan.generation,
+        effect_kind="execution",
+        ordinal=ordinal,
+        intent_sha256=effect_intent_sha256,
+    ).effect_id
+    binding = CompositionExecutionBindingV1(
+        executable_plan_id=plan.executable_plan_id,
+        executable_plan_sha256=plan.executable_plan_sha256,
+        step_id=materialized.step.step_id,
+        step_binding_sha256=materialized.step.sha256,
+        request_id=plan.request_id,
+        run_id=plan.run_id,
+        generation=plan.generation,
+        effect_id=effect_id,
+        action_id=materialized.step.action_id,
+        action_version=materialized.step.action_version,
+        materialized_arguments_sha256=materialized_arguments_sha256,
+        canonical_invocation_sha256=canonical_invocation_sha256,
+        target_sha256=target_sha256,
+        target_snapshot_sha256=target_snapshot_sha256,
+        workspace_id=workspace_id,
+        workspace_scope_hash=workspace_scope_hash,
+        binding_sha256="0" * 64,
+    ).with_computed_sha256()
+    return DerivedCompositionExecutionBinding(
+        run_sequence=run_sequence,
+        ordinal=ordinal,
+        effect_intent_sha256=effect_intent_sha256,
+        effect_id=effect_id,
+        binding=binding,
+    )
+
+
+def rebuild_composition_effect_claim(
+    request: CompositionStepAuthorizationRequest,
+    *,
+    run_sequence: int,
+    ordinal: int,
+    lease_epoch: int,
+) -> EffectClaim:
+    """Rebuild the claim signed into a P7C child ticket after restart."""
+
+    if lease_epoch < 1:
+        raise CompositionExecutionBindingError(
+            "composition.execution.lease_epoch_invalid"
+        )
+    claim = EffectClaim(
+        effect_id=request.prebound_effect_id,
+        request_id=request.request_id,
+        run_id=request.run_id,
+        run_sequence=run_sequence,
+        generation=request.generation,
+        effect_kind="execution",
+        ordinal=ordinal,
+        intent_sha256=request.prebound_effect_intent_sha256,
+        pipeline_version=COMPOSITION_STEP_PIPELINE_VERSION,
+        attempt=request.attempt,
+        claim_revision=1,
+        lease_epoch=lease_epoch,
+        supersedes_claim_sha256=None,
+        owner_component_id="tiangong-backend",
+        claimed_at_ms=request.issued_at_ms,
+        claim_sha256="0" * 64,
+    ).with_computed_sha256()
+    return claim
+
+
+__all__ = [
+    "COMPOSITION_STEP_PIPELINE_VERSION",
+    "CompositionExecutionBindingError",
+    "DerivedCompositionExecutionBinding",
+    "derive_composition_execution_binding",
+    "derive_run_sequence",
+    "rebuild_composition_effect_claim",
+]

--- a/src/total_gateway/composition_step_execution.py
+++ b/src/total_gateway/composition_step_execution.py
@@ -1,0 +1,1106 @@
+"""Durable P7D.1 execution seam for one authorized composition root step.
+
+This module is deliberately not a scheduler or Runtime.  The existing
+``GatewayOrchestrationWorker`` calls it, the existing Store owns Effect state,
+``FactLedger`` owns machine results, ``BackendClient`` owns the ticket gate,
+and Omni ``BodyRuntime`` remains the only action runtime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from contracts import (
+    ActionRegistrySnapshot,
+    CapabilityManifest,
+    TrustBundle,
+    canonical_sha256,
+)
+from runtime_security import verify_omni_capability_grant
+
+from .action_registry import ActionRegistryError, ActionSchemaCatalog
+from .backend_client import BackendClient, BackendClientError
+from .composition_activation_adapter import (
+    CompositionActivationAdapterError,
+    materialize_static_root_step,
+)
+from .composition_backend_transport import CompositionBackendExecutionTransport
+from .composition_execution_binding import (
+    COMPOSITION_STEP_PIPELINE_VERSION,
+    CompositionExecutionBindingError,
+    derive_composition_execution_binding,
+    rebuild_composition_effect_claim,
+)
+from .effects import EffectClaim, EffectResult
+from .fact_ledger import FactBatchRecord, FactLedger
+from .impact_evaluator import probe_target_state
+
+
+_SAFE_SIDE_EFFECTS = frozenset({"none", "read"})
+
+
+class CompositionStepExecutionError(RuntimeError):
+    def __init__(self, code: str, *, ambiguous: bool = False) -> None:
+        super().__init__(code)
+        self.code = code
+        self.ambiguous = ambiguous
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionStepExecutionOutcome:
+    authorization_id: str
+    executable_plan_id: str
+    step_id: str
+    effect_id: str
+    status: str
+    fact_ids: tuple[str, ...]
+    recovered: bool = False
+
+
+class CompositionStepExecutionCoordinator:
+    """Project persisted P7C authority through the one existing runtime chain."""
+
+    def __init__(
+        self,
+        *,
+        store: Any,
+        objects: Any,
+        facts: FactLedger,
+        registry: ActionRegistrySnapshot,
+        schema_catalog: ActionSchemaCatalog,
+        capability_manifest: CapabilityManifest,
+        trust_bundle_provider: Callable[[int], TrustBundle],
+        backend_compat_client: Any,
+        workspace_root: Path,
+        gateway_epoch: int,
+        gateway_instance_id: str,
+        append_effect_event: Callable[..., bool] | None = None,
+        transport_runner: Callable[
+            [Callable[[], dict[str, Any]], float], dict[str, Any]
+        ]
+        | None = None,
+    ) -> None:
+        if (
+            not registry.has_valid_sha256()
+            or not schema_catalog.has_valid_sha256()
+            or schema_catalog.source_manifest_sha256
+            != registry.source_manifest_sha256
+            or not capability_manifest.has_valid_sha256()
+        ):
+            raise ValueError("composition execution authority is invalid")
+        if (
+            not workspace_root.is_absolute()
+            or not workspace_root.is_dir()
+            or workspace_root.is_symlink()
+            or gateway_epoch < 1
+            or not gateway_instance_id
+            or not callable(trust_bundle_provider)
+            or not callable(getattr(backend_compat_client, "request", None))
+            or (transport_runner is not None and not callable(transport_runner))
+        ):
+            raise ValueError("composition execution runtime is invalid")
+        required_store = (
+            "recover_live_composition_step_authorizations",
+            "get_executable_composition_plan_for_request",
+            "get_active_executable_composition_plan",
+            "get_composition_step_authorization",
+            "get_composition_step_authorization_for_effect",
+            "list_effects_for_pipeline",
+            "get_effect",
+            "claim_effect",
+            "acquire_dispatch_permit",
+            "release_dispatch_permit",
+            "recover_terminal_dispatch_permits",
+            "complete_effect",
+            "action_fence_status",
+        )
+        if any(not callable(getattr(store, name, None)) for name in required_store):
+            raise ValueError("composition execution Store is incomplete")
+        if any(
+            not callable(getattr(objects, name, None))
+            for name in ("get_reference", "read_bytes")
+        ):
+            raise ValueError("composition execution object authority is invalid")
+        if any(
+            not callable(getattr(facts, name, None))
+            for name in (
+                "record_execution",
+                "get_batch_for_effect",
+                "get_batch_for_ticket",
+            )
+        ):
+            raise ValueError("composition execution FactLedger is incomplete")
+        self._store = store
+        self._objects = objects
+        self._facts = facts
+        self._registry = registry
+        self._schemas = schema_catalog
+        self._manifest = capability_manifest
+        self._trust_bundle_provider = trust_bundle_provider
+        self._backend = backend_compat_client
+        self._workspace_root = workspace_root.resolve(strict=True)
+        self._gateway_epoch = gateway_epoch
+        self._instance_id = gateway_instance_id
+        self._append_effect_event = append_effect_event
+        self._transport_runner = transport_runner
+
+    def _event(
+        self,
+        *,
+        event_type: str,
+        effect_id: str,
+        request_id: str,
+        run_id: str,
+        generation: int,
+        created_at_ms: int,
+        payload: dict[str, object],
+    ) -> None:
+        if self._append_effect_event is None:
+            return
+        # The execution ledger is a projection when its P18 task authority is
+        # present.  Its absence must not replace or invalidate the canonical
+        # Effect/Fact commit.
+        self._append_effect_event(
+            self._store,
+            event_key=f"{event_type}:{effect_id}",
+            event_type=event_type,
+            payload=payload,
+            request_id=request_id,
+            run_id=run_id,
+            generation=generation,
+            effect_id=effect_id,
+            created_at_ms=created_at_ms,
+        )
+
+    @staticmethod
+    def _permission_for_step(registry: ActionRegistrySnapshot, step: Any) -> Any:
+        matches = tuple(
+            permission
+            for permission in registry.permissions
+            if permission.action_id == step.action_id
+            and permission.action_version == step.action_version
+        )
+        if len(matches) != 1:
+            raise CompositionStepExecutionError(
+                "composition.execution.permission_missing"
+            )
+        permission = matches[0]
+        if (
+            not permission.has_valid_sha256()
+            or permission != step.permission
+            or permission.permission_sha256 != step.permission_sha256
+            or permission.registry_risk != "A0"
+            or permission.effective_risk != "A0"
+            or permission.effect not in {"read", "verify"}
+            or not set(permission.allowed_side_effects).issubset(
+                _SAFE_SIDE_EFFECTS
+            )
+            or permission.allow_shell
+            or permission.allow_python
+            or permission.requires_confirmation
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.a0_ceiling_exceeded"
+            )
+        return permission
+
+    def _verify_objects(self, request: Any, ticket: Any) -> None:
+        expected = [item.model_dump(mode="json") for item in ticket.payload.input_objects]
+        if request.object_grants != expected:
+            raise CompositionStepExecutionError(
+                "composition.execution.object_grants_mismatch"
+            )
+        for grant in ticket.payload.input_objects:
+            try:
+                reference = self._objects.get_reference(grant.object_id)
+                body = self._objects.read_bytes(grant.object_id)
+            except Exception as exc:
+                raise CompositionStepExecutionError(
+                    "composition.execution.object_unavailable"
+                ) from exc
+            if (
+                reference is None
+                or not reference.has_valid_sha256()
+                or reference.object_id != grant.object_id
+                or reference.sha256 != grant.sha256
+                or reference.size_bytes != grant.size_bytes
+                or reference.tenant_id != grant.tenant_id
+                or reference.link_account_id != grant.link_account_id
+                or reference.conversation_scope_hash
+                != grant.conversation_scope_hash
+                or len(body) != grant.size_bytes
+                or hashlib.sha256(body).hexdigest() != grant.sha256
+            ):
+                raise CompositionStepExecutionError(
+                    "composition.execution.object_changed"
+                )
+
+    def _verify_parent_success(self, request: Any) -> str:
+        """Bind child dispatch to the exact successful parent Effect and Fact."""
+
+        batch = self._facts.get_batch_for_ticket(
+            request.parent_ticket_id,
+            verify_payload=True,
+        )
+        if (
+            batch is None
+            or batch.result.ticket_id != request.parent_ticket_id
+            or batch.result.request_id != request.request_id
+            or batch.result.run_id != request.run_id
+            or batch.result.generation != request.generation
+            or batch.result.status != "SUCCEEDED"
+            or batch.workspace_id != request.workspace_id
+            or not batch.facts
+            or tuple(item.fact_id for item in batch.facts)
+            != batch.result.fact_ids
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.parent_not_succeeded"
+            )
+        parent = self._store.get_effect(batch.result.effect_id)
+        if (
+            parent is None
+            or parent.state != "SUCCEEDED"
+            or parent.result is None
+            or parent.result.status != "SUCCEEDED"
+            or parent.claim.effect_kind != "execution"
+            or parent.claim.request_id != request.request_id
+            or parent.claim.run_id != request.run_id
+            or parent.claim.generation != request.generation
+            or parent.result.fact_id not in batch.result.fact_ids
+            or parent.result.result_object_id
+            != batch.result_payload_object_id
+            or parent.result.result_object_sha256
+            != batch.result_payload_sha256
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.parent_effect_mismatch"
+            )
+        return parent.claim.effect_id
+
+    def _preflight(self, record: Any, *, now_ms: int) -> dict[str, Any]:
+        request = record.request
+        if not record.has_valid_record_sha256():
+            raise CompositionStepExecutionError(
+                "composition.execution.authorization_invalid"
+            )
+        plan_record = self._store.get_active_executable_composition_plan(
+            request.registration_id, now_ms=now_ms
+        )
+        if plan_record is None:
+            raise CompositionStepExecutionError(
+                "composition.execution.plan_inactive"
+            )
+        plan = plan_record.executable_plan
+        try:
+            plan_workspace = Path(plan.workspace.workspace_root).resolve(
+                strict=True
+            )
+        except (OSError, ValueError) as exc:
+            raise CompositionStepExecutionError(
+                "composition.execution.plan_workspace_invalid"
+            ) from exc
+        if (
+            plan.executable_plan_id != request.executable_plan_id
+            or plan.executable_plan_sha256 != request.executable_plan_sha256
+            or plan.registration_id != request.registration_id
+            or plan.request_id != request.request_id
+            or plan.run_id != request.run_id
+            or plan.generation != request.generation
+            or plan.principal_scope_hash != request.principal_scope_hash
+            or plan.action_registry_sha256 != self._registry.registry_sha256
+            or plan.capability_manifest_sha256
+            != self._registry.source_manifest_sha256
+            or plan_workspace != self._workspace_root
+            or plan.workspace.workspace_id != request.workspace_id
+            or plan.workspace.workspace_scope_sha256
+            != request.workspace_scope_sha256
+            or len(plan.step_bindings) != 1
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.plan_mismatch"
+            )
+        try:
+            materialized = materialize_static_root_step(
+                plan, step_id=request.step_id
+            )
+        except CompositionActivationAdapterError as exc:
+            raise CompositionStepExecutionError(exc.code) from exc
+        # A non-empty target is not necessarily a host path (for example
+        # ``skill.get(target="word_delivery")``).  P7C's current
+        # object-grant-only path policy has already rejected raw host paths;
+        # P7D rechecks that immutable permission and the live target snapshot
+        # below instead of weakening the signed target to an empty-string
+        # special case.  STEP_OUTPUT materialization remains unavailable in
+        # this first slice because ``materialize_static_root_step`` rejects it.
+        permission = self._permission_for_step(self._registry, materialized.step)
+        try:
+            schema = self._schemas.resolve(
+                permission.action_id,
+                permission.action_version,
+                expected_sha256=materialized.step.argument_schema_sha256,
+                require_explicit=True,
+            )
+            validated = schema.validate_exact(
+                permission.action_id,
+                materialized.target,
+                materialized.arguments,
+                workspace=self._workspace_root,
+                available_actions=(
+                    item.action_id for item in self._registry.permissions
+                ),
+                user_roots=(),
+            )
+        except ActionRegistryError as exc:
+            raise CompositionStepExecutionError(
+                "composition.execution.schema_rejected"
+            ) from exc
+        if (
+            validated.get("action") != permission.action_id
+            or validated.get("target") != materialized.target
+            or validated.get("args") != materialized.arguments
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.arguments_normalized"
+            )
+
+        target_state = probe_target_state(
+            materialized.target, self._workspace_root
+        )
+        target_snapshot_sha256 = (
+            None if target_state is None else canonical_sha256(target_state)
+        )
+        if (
+            request.target_snapshot != target_state
+            or request.target_snapshot_sha256 != target_snapshot_sha256
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.target_changed"
+            )
+        try:
+            derived = derive_composition_execution_binding(
+                plan,
+                materialized,
+                parent_ticket_id=request.parent_ticket_id,
+                workspace_id=request.workspace_id,
+                workspace_scope_hash=request.workspace_scope_sha256,
+                target_snapshot_sha256=target_snapshot_sha256,
+            )
+            claim = rebuild_composition_effect_claim(
+                request,
+                run_sequence=derived.run_sequence,
+                ordinal=derived.ordinal,
+                lease_epoch=self._gateway_epoch,
+            )
+        except CompositionExecutionBindingError as exc:
+            raise CompositionStepExecutionError(exc.code) from exc
+        if (
+            request.prebound_effect_id != derived.effect_id
+            or request.prebound_effect_intent_sha256
+            != derived.effect_intent_sha256
+            or request.composition_binding_sha256
+            != derived.binding.binding_sha256
+            or request.materialized_arguments != materialized.arguments
+            or request.arguments_sha256
+            != canonical_sha256(
+                {
+                    "action": permission.action_id,
+                    "target": materialized.target,
+                    "args": materialized.arguments,
+                }
+            )
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.binding_mismatch"
+            )
+
+        try:
+            intent, impact, decision, ticket, grant = (
+                record.artifacts.restore_contracts()
+            )
+            record.artifacts.validate_for_request(request)
+        except Exception as exc:
+            raise CompositionStepExecutionError(
+                "composition.execution.signed_chain_invalid"
+            ) from exc
+        if (
+            ticket.payload.capability_manifest_hash != self._manifest.sha256
+            or ticket.payload.component_manifest_hash
+            != self._manifest.component_manifest_hash
+            or ticket.payload.claim_sha256 != claim.claim_sha256
+            or ticket.payload.claim_revision != claim.claim_revision
+            or ticket.payload.claim_lease_epoch != claim.lease_epoch
+            or ticket.payload.composition_execution_binding != derived.binding
+            or grant.payload.capability_manifest_hash != self._manifest.sha256
+            or grant.payload.action_registry_sha256
+            != self._registry.registry_sha256
+            or request.result_schema_sha256
+            != next(
+                (
+                    action.result_schema_sha256
+                    for action in self._manifest.actions
+                    if action.action_id == request.action_id
+                    and action.version == request.action_version
+                ),
+                None,
+            )
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.current_authority_mismatch"
+            )
+        current_fence = self._store.action_fence_status()
+        if (
+            int(current_fence.get("action_fence_epoch", -1))
+            != request.action_fence_epoch
+            or bool(current_fence.get("fenced"))
+            or bool(current_fence.get("draining"))
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.fence_closed"
+            )
+
+        self._verify_objects(request, ticket)
+        parent_effect_id = self._verify_parent_success(request)
+        trust_bundle = self._trust_bundle_provider(now_ms)
+        if (
+            not isinstance(trust_bundle, TrustBundle)
+            or not trust_bundle.has_valid_sha256()
+            or trust_bundle.gateway_epoch != self._gateway_epoch
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.trust_invalid"
+            )
+        try:
+            verify_omni_capability_grant(grant, trust_bundle, now_ms=now_ms)
+        except Exception as exc:
+            raise CompositionStepExecutionError(
+                "composition.execution.grant_invalid"
+            ) from exc
+
+        runtime_response = record.runtime_response
+        if (
+            set(runtime_response) != {"status", "grant", "runtime", "decision"}
+            or runtime_response.get("status") != "OK"
+            or runtime_response.get("grant")
+            != grant.model_dump(mode="json")
+            or not isinstance(runtime_response.get("runtime"), Mapping)
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.runtime_receipt_invalid"
+            )
+        runtime = deepcopy(dict(runtime_response["runtime"]))
+        runtime["trust_bundle"] = trust_bundle.model_dump(mode="json")
+        runtime["trust_bundle_sha256"] = trust_bundle.bundle_sha256
+        runtime["gateway_epoch"] = self._gateway_epoch
+        # Gateway FactLedger is the sole machine-fact writer.  The immutable
+        # authorization receipt remains untouched; only this detached runtime
+        # execution copy disables the BodyRuntime fact kernel.
+        runtime["fact_kernel_enabled"] = False
+        invocation = {
+            "action": permission.action_id,
+            "target": materialized.target,
+            "args": materialized.arguments,
+        }
+        return {
+            "record": record,
+            "plan": plan,
+            "permission": permission,
+            "binding": derived.binding,
+            "claim": claim,
+            "intent": intent,
+            "impact": impact,
+            "decision": decision,
+            "ticket": ticket,
+            "grant": grant,
+            "trust_bundle": trust_bundle,
+            "runtime": runtime,
+            "invocation": invocation,
+            "target_snapshot_sha256": target_snapshot_sha256,
+            "parent_effect_id": parent_effect_id,
+        }
+
+    @staticmethod
+    def _effect_result_from_batch(
+        batch: FactBatchRecord, *, observed_at_ms: int
+    ) -> EffectResult:
+        result = batch.result
+        if not batch.facts or tuple(item.fact_id for item in batch.facts) != result.fact_ids:
+            raise CompositionStepExecutionError(
+                "composition.execution.fact_batch_invalid"
+            )
+        status = (
+            "SUCCEEDED"
+            if result.status == "SUCCEEDED"
+            else "AMBIGUOUS"
+            if result.status == "AMBIGUOUS"
+            else "FAILED_FINAL"
+        )
+        return EffectResult(
+            result_id="effect-result-" + result.result_id[:120],
+            effect_id=result.effect_id,
+            status=status,
+            fact_id=result.fact_ids[0],
+            result_object_id=batch.result_payload_object_id,
+            result_object_sha256=batch.result_payload_sha256,
+            evidence_sha256=batch.batch_sha256,
+            error_code=(
+                None
+                if status == "SUCCEEDED"
+                else result.error_code or "composition.execution.failed"
+            ),
+            observed_at_ms=max(observed_at_ms, batch.observed_at_ms),
+            result_sha256="0" * 64,
+        ).with_computed_sha256()
+
+    def _terminal_event(self, record: Any, result: EffectResult) -> None:
+        event = (
+            "step.committed"
+            if result.status == "SUCCEEDED"
+            else "step.ambiguous"
+            if result.status == "AMBIGUOUS"
+            else "step.failed"
+        )
+        self._event(
+            event_type=event,
+            effect_id=result.effect_id,
+            request_id=record.request.request_id,
+            run_id=record.request.run_id,
+            generation=record.request.generation,
+            created_at_ms=result.observed_at_ms,
+            payload={
+                "authorization_id": record.authorization_id,
+                "effect_state": result.status,
+                "source": "composition_step_execution",
+            },
+        )
+
+    def _complete_without_backend_fact(
+        self,
+        record: Any,
+        *,
+        status: str,
+        code: str,
+        observed_at_ms: int,
+        expected_state: str | None = None,
+        release_dispatch_permit: bool = True,
+    ) -> EffectResult:
+        effect_id = record.request.prebound_effect_id
+        result = EffectResult(
+            result_id="effect-result-" + effect_id[4:20],
+            effect_id=effect_id,
+            status=status,
+            fact_id="fact-effect-" + effect_id[4:20],
+            evidence_sha256=canonical_sha256(
+                {
+                    "authorization_id": record.authorization_id,
+                    "code": code,
+                    "status": status,
+                }
+            ),
+            error_code=code,
+            observed_at_ms=observed_at_ms,
+            result_sha256="0" * 64,
+        ).with_computed_sha256()
+        self._store.complete_effect(
+            result,
+            expected_state=expected_state,
+            release_dispatch_permit=release_dispatch_permit,
+        )
+        self._terminal_event(record, result)
+        return result
+
+    def dispatch_record(
+        self, record: Any, *, now_ms: int
+    ) -> CompositionStepExecutionOutcome:
+        try:
+            prepared = self._preflight(record, now_ms=now_ms)
+        except Exception as exc:
+            current = self._store.get_effect(
+                record.request.prebound_effect_id
+            )
+            if current is None or current.state != "CLAIMED":
+                raise
+            code = str(
+                getattr(
+                    exc,
+                    "code",
+                    "composition.execution.preflight_failed",
+                )
+            )[:160]
+            completed = self._complete_without_backend_fact(
+                record,
+                status="FAILED_FINAL",
+                code=code,
+                observed_at_ms=max(
+                    now_ms,
+                    current.claim.claimed_at_ms,
+                ),
+                expected_state="CLAIMED",
+            )
+            return CompositionStepExecutionOutcome(
+                record.authorization_id,
+                record.request.executable_plan_id,
+                record.request.step_id,
+                record.request.prebound_effect_id,
+                completed.status,
+                (completed.fact_id,),
+            )
+        claim: EffectClaim = prepared["claim"]
+        current = self._store.get_effect(claim.effect_id)
+        if current is not None and current.result is not None:
+            return self._existing_outcome(record, current)
+        if current is not None and current.state == "SIDE_EFFECT_STARTED":
+            raise CompositionStepExecutionError(
+                "composition.execution.already_started", ambiguous=True
+            )
+
+        permit_crossed = False
+
+        def before_dispatch(crossed_at_ms: int) -> None:
+            nonlocal permit_crossed
+            effect, _created = self._store.claim_effect(claim)
+            if effect.state != "CLAIMED":
+                raise BackendClientError(
+                    "backend.composition.effect_not_claimable",
+                    ambiguous=effect.state == "SIDE_EFFECT_STARTED",
+                )
+            self._event(
+                event_type="step.prepared",
+                effect_id=claim.effect_id,
+                request_id=claim.request_id,
+                run_id=claim.run_id,
+                generation=claim.generation,
+                created_at_ms=crossed_at_ms,
+                payload={
+                    "authorization_id": record.authorization_id,
+                    "effect_state": "CLAIMED",
+                    "source": "composition_step_execution",
+                },
+            )
+            ticket = prepared["ticket"]
+            grant = prepared["grant"]
+            try:
+                self._store.acquire_dispatch_permit(
+                    effect_id=claim.effect_id,
+                    attempt=claim.attempt,
+                    expected_fence_epoch=record.request.action_fence_epoch,
+                    nonce_sha256=canonical_sha256(
+                        {
+                            "execution_ticket_nonce": ticket.payload.nonce,
+                            "omni_grant_nonce": grant.payload.nonce,
+                        }
+                    ),
+                    ticket_id=ticket.payload.ticket_id,
+                    ticket_sha256=canonical_sha256(
+                        ticket.model_dump(mode="json")
+                    ),
+                    grant_sha256=canonical_sha256(
+                        grant.model_dump(mode="json")
+                    ),
+                    expected_request_id=claim.request_id,
+                    expected_run_id=claim.run_id,
+                    expected_generation=claim.generation,
+                    expected_gateway_epoch=self._gateway_epoch,
+                    expected_owner_instance_id=self._instance_id,
+                    required_parent_effect_id=prepared[
+                        "parent_effect_id"
+                    ],
+                    now_ms=crossed_at_ms,
+                )
+                permit_crossed = True
+            except Exception as exc:
+                raise BackendClientError(
+                    "backend.composition.dispatch_permit_failed",
+                    ambiguous=permit_crossed,
+                ) from exc
+            self._event(
+                event_type="step.dispatched",
+                effect_id=claim.effect_id,
+                request_id=claim.request_id,
+                run_id=claim.run_id,
+                generation=claim.generation,
+                created_at_ms=crossed_at_ms,
+                payload={
+                    "authorization_id": record.authorization_id,
+                    "effect_state": "SIDE_EFFECT_STARTED",
+                    "source": "composition_step_execution",
+                },
+            )
+
+        transport = CompositionBackendExecutionTransport(
+            self._backend,
+            signed_grant=prepared["grant"].model_dump(mode="json"),
+            runtime_meta=prepared["runtime"],
+        )
+        client = BackendClient(
+            transport,
+            self._store,
+            ticket_consumer_instance_id=(
+                "composition-inprocess-" + self._instance_id
+            ),
+        )
+        try:
+            response = client.execute(
+                prepared["ticket"],
+                prepared["invocation"],
+                capability_manifest=self._manifest,
+                trust_bundle=prepared["trust_bundle"],
+                now_ms=now_ms,
+                expected_gateway_epoch=self._gateway_epoch,
+                minimum_generation=record.request.generation,
+                grant=prepared["grant"],
+                intent=prepared["intent"],
+                decision=prepared["decision"],
+                impact=prepared["impact"],
+                claim=claim,
+                expected_fence_epoch=prepared["ticket"].payload.fence_epoch,
+                active_lease_epoch=self._gateway_epoch,
+                expected_target_snapshot_sha256=prepared[
+                    "target_snapshot_sha256"
+                ],
+                expected_composition_binding=prepared["binding"],
+                actual_target_snapshot_sha256=prepared[
+                    "target_snapshot_sha256"
+                ],
+                before_dispatch=before_dispatch,
+                transport_runner=self._transport_runner,
+            )
+        except Exception as exc:
+            effect = self._store.get_effect(claim.effect_id)
+            if effect is None:
+                raise CompositionStepExecutionError(
+                    getattr(exc, "code", "composition.execution.preflight_failed")
+                ) from exc
+            status = (
+                "AMBIGUOUS"
+                if effect.state == "SIDE_EFFECT_STARTED"
+                else "FAILED_FINAL"
+            )
+            code = str(
+                getattr(exc, "code", "composition.execution.runtime_failed")
+            )[:160]
+            pending_transport = getattr(
+                exc,
+                "pending_transport_future",
+                None,
+            )
+            completed = self._complete_without_backend_fact(
+                record,
+                status=status,
+                code=code,
+                observed_at_ms=max(now_ms, time.time_ns() // 1_000_000),
+                release_dispatch_permit=pending_transport is None,
+            )
+            if pending_transport is not None:
+                def release_after_transport(_future: object) -> None:
+                    try:
+                        self._store.release_dispatch_permit(
+                            effect_id=claim.effect_id,
+                            attempt=claim.attempt,
+                            now_ms=max(
+                                completed.observed_at_ms,
+                                time.time_ns() // 1_000_000,
+                            ),
+                        )
+                    except Exception:
+                        # Fail closed: a release failure leaves inflight > 0;
+                        # startup recovery can reconcile the durable permit.
+                        return
+
+                pending_transport.add_done_callback(release_after_transport)
+            return CompositionStepExecutionOutcome(
+                record.authorization_id,
+                record.request.executable_plan_id,
+                record.request.step_id,
+                claim.effect_id,
+                completed.status,
+                (completed.fact_id,),
+            )
+
+        observed_at_ms = max(
+            now_ms,
+            response.result.finished_at_ms,
+            time.time_ns() // 1_000_000,
+        )
+        try:
+            registration = self._facts.record_execution(
+                response, observed_at_ms=observed_at_ms
+            )
+        except Exception as exc:
+            # The handler has returned but the canonical Fact commit is not
+            # proven.  Keep STARTED intact; recovery will either find the exact
+            # idempotent batch or close it AMBIGUOUS without replay.
+            raise CompositionStepExecutionError(
+                "composition.execution.fact_commit_unknown", ambiguous=True
+            ) from exc
+        effect_result = self._effect_result_from_batch(
+            registration.record, observed_at_ms=observed_at_ms
+        )
+        self._store.complete_effect(effect_result)
+        self._terminal_event(record, effect_result)
+        return CompositionStepExecutionOutcome(
+            record.authorization_id,
+            record.request.executable_plan_id,
+            record.request.step_id,
+            claim.effect_id,
+            effect_result.status,
+            tuple(item.fact_id for item in registration.record.facts),
+        )
+
+    def _existing_outcome(
+        self, record: Any, effect: Any
+    ) -> CompositionStepExecutionOutcome:
+        """Verify and project an already-terminal exact child Effect."""
+
+        request = record.request
+        if (
+            effect.claim.effect_id != request.prebound_effect_id
+            or effect.claim.request_id != request.request_id
+            or effect.claim.run_id != request.run_id
+            or effect.claim.generation != request.generation
+            or effect.claim.intent_sha256
+            != request.prebound_effect_intent_sha256
+            or effect.claim.pipeline_version
+            != COMPOSITION_STEP_PIPELINE_VERSION
+            or effect.claim.attempt != request.attempt
+            or effect.claim.effect_kind != "execution"
+            or effect.result is None
+            or effect.result.effect_id != request.prebound_effect_id
+            or effect.state != effect.result.status
+        ):
+            raise CompositionStepExecutionError(
+                "composition.execution.existing_effect_mismatch",
+                ambiguous=True,
+            )
+        fact_ids = (effect.result.fact_id,)
+        if effect.state == "SUCCEEDED":
+            batch = self._facts.get_batch_for_effect(
+                effect.claim.effect_id, verify_payload=True
+            )
+            try:
+                ticket = record.artifacts.restore_contracts()[3]
+            except Exception as exc:
+                raise CompositionStepExecutionError(
+                    "composition.execution.existing_authority_invalid",
+                    ambiguous=True,
+                ) from exc
+            if (
+                batch is None
+                or batch.result.effect_id != effect.claim.effect_id
+                or batch.result.ticket_id != ticket.payload.ticket_id
+                or batch.result.request_id != request.request_id
+                or batch.result.run_id != request.run_id
+                or batch.result.generation != request.generation
+                or batch.result.action_id != request.action_id
+                or batch.result.action_version != request.action_version
+                or batch.result.attempt != request.attempt
+                or batch.result.status != "SUCCEEDED"
+                or batch.workspace_id != request.workspace_id
+            ):
+                raise CompositionStepExecutionError(
+                    "composition.execution.existing_fact_mismatch",
+                    ambiguous=True,
+                )
+            expected = self._effect_result_from_batch(
+                batch, observed_at_ms=effect.result.observed_at_ms
+            )
+            if expected != effect.result:
+                raise CompositionStepExecutionError(
+                    "composition.execution.existing_fact_effect_mismatch",
+                    ambiguous=True,
+                )
+            fact_ids = tuple(item.fact_id for item in batch.facts)
+        return CompositionStepExecutionOutcome(
+            record.authorization_id,
+            request.executable_plan_id,
+            request.step_id,
+            request.prebound_effect_id,
+            effect.state,
+            fact_ids,
+            recovered=True,
+        )
+
+    def dispatch_next(
+        self,
+        *,
+        now_ms: int,
+        request_id: str | None = None,
+        run_id: str | None = None,
+        generation: int | None = None,
+    ) -> CompositionStepExecutionOutcome | None:
+        scoped = (request_id, run_id, generation)
+        if any(value is not None for value in scoped) and any(
+            value is None for value in scoped
+        ):
+            raise ValueError("composition dispatch scope is incomplete")
+        if all(value is not None for value in scoped):
+            plan_record = self._store.get_executable_composition_plan_for_request(
+                request_id,
+                run_id=run_id,
+                generation=generation,
+            )
+            if plan_record is None:
+                return None
+            plan = plan_record.executable_plan
+            if len(plan.step_bindings) != 1:
+                raise CompositionStepExecutionError(
+                    "composition.execution.p7d1_step_count_unsupported"
+                )
+            step_id = plan.step_bindings[0].step_id
+            record = self._store.get_composition_step_authorization(
+                plan.executable_plan_id,
+                step_id,
+            )
+            if record is None:
+                raise CompositionStepExecutionError(
+                    "composition.execution.authorization_missing"
+                )
+            effect = self._store.get_effect(record.request.prebound_effect_id)
+            if effect is not None and effect.result is not None:
+                return self._existing_outcome(record, effect)
+            if effect is not None and effect.state == "SIDE_EFFECT_STARTED":
+                raise CompositionStepExecutionError(
+                    "composition.execution.already_started", ambiguous=True
+                )
+            try:
+                live_record = self._store.get_composition_step_authorization(
+                    plan.executable_plan_id,
+                    step_id,
+                    now_ms=now_ms,
+                )
+            except Exception as exc:
+                if effect is not None and effect.state == "CLAIMED":
+                    completed = self._complete_without_backend_fact(
+                        record,
+                        status="FAILED_FINAL",
+                        code="composition.execution.authorization_not_live",
+                        observed_at_ms=max(
+                            now_ms,
+                            effect.claim.claimed_at_ms,
+                        ),
+                        expected_state="CLAIMED",
+                    )
+                    return CompositionStepExecutionOutcome(
+                        record.authorization_id,
+                        record.request.executable_plan_id,
+                        record.request.step_id,
+                        record.request.prebound_effect_id,
+                        completed.status,
+                        (completed.fact_id,),
+                    )
+                raise CompositionStepExecutionError(
+                    "composition.execution.authorization_not_live"
+                ) from exc
+            if live_record is None:
+                raise CompositionStepExecutionError(
+                    "composition.execution.authorization_missing"
+                )
+            return self.dispatch_record(live_record, now_ms=now_ms)
+
+        records = self._store.recover_live_composition_step_authorizations(
+            now_ms=now_ms
+        )
+        for record in records:
+            request = record.request
+            if request_id is not None and request.request_id != request_id:
+                continue
+            if run_id is not None and request.run_id != run_id:
+                continue
+            if generation is not None and request.generation != generation:
+                continue
+            effect = self._store.get_effect(request.prebound_effect_id)
+            if effect is not None and effect.result is not None:
+                continue
+            if effect is not None and effect.state == "SIDE_EFFECT_STARTED":
+                continue
+            return self.dispatch_record(record, now_ms=now_ms)
+        return None
+
+    def recover_started(
+        self, *, now_ms: int
+    ) -> tuple[CompositionStepExecutionOutcome, ...]:
+        # A previous process may have committed an AMBIGUOUS timeout while its
+        # unkillable in-process Future still owned the dispatch permit.  No
+        # such handler survives the single-instance process restart, so close
+        # that durable release gap before recovering STARTED Effects.
+        self._store.recover_terminal_dispatch_permits(
+            pipeline_version=COMPOSITION_STEP_PIPELINE_VERSION,
+            now_ms=now_ms,
+        )
+        outcomes: list[CompositionStepExecutionOutcome] = []
+        effects = self._store.list_effects_for_pipeline(
+            COMPOSITION_STEP_PIPELINE_VERSION,
+            states=("SIDE_EFFECT_STARTED",),
+        )
+        for effect in effects:
+            record = self._store.get_composition_step_authorization_for_effect(
+                effect.claim.effect_id
+            )
+            if record is None:
+                raise CompositionStepExecutionError(
+                    "composition.execution.recovery_receipt_missing",
+                    ambiguous=True,
+                )
+            batch = self._facts.get_batch_for_effect(
+                effect.claim.effect_id, verify_payload=True
+            )
+            if batch is None:
+                result = self._complete_without_backend_fact(
+                    record,
+                    status="AMBIGUOUS",
+                    code="composition.execution.result_missing_after_restart",
+                    observed_at_ms=max(
+                        now_ms,
+                        effect.side_effect_started_at_ms
+                        or effect.claim.claimed_at_ms,
+                    ),
+                )
+                fact_ids = (result.fact_id,)
+            else:
+                if (
+                    batch.result.effect_id != effect.claim.effect_id
+                    or batch.result.request_id != effect.claim.request_id
+                    or batch.result.run_id != effect.claim.run_id
+                    or batch.result.generation != effect.claim.generation
+                    or batch.result.ticket_id
+                    != record.artifacts.restore_contracts()[3].payload.ticket_id
+                    or batch.result.action_id != record.request.action_id
+                    or batch.result.action_version
+                    != record.request.action_version
+                    or batch.result.attempt != record.request.attempt
+                    or batch.workspace_id != record.request.workspace_id
+                ):
+                    raise CompositionStepExecutionError(
+                        "composition.execution.recovery_fact_mismatch",
+                        ambiguous=True,
+                    )
+                result = self._effect_result_from_batch(
+                    batch, observed_at_ms=now_ms
+                )
+                self._store.complete_effect(result)
+                self._terminal_event(record, result)
+                fact_ids = tuple(item.fact_id for item in batch.facts)
+            outcomes.append(
+                CompositionStepExecutionOutcome(
+                    record.authorization_id,
+                    record.request.executable_plan_id,
+                    record.request.step_id,
+                    effect.claim.effect_id,
+                    result.status,
+                    fact_ids,
+                    recovered=True,
+                )
+            )
+        return tuple(outcomes)
+
+
+__all__ = [
+    "CompositionStepExecutionCoordinator",
+    "CompositionStepExecutionError",
+    "CompositionStepExecutionOutcome",
+]

--- a/src/total_gateway/embedded_backend.py
+++ b/src/total_gateway/embedded_backend.py
@@ -109,6 +109,7 @@ class EmbeddedBackendRuntime:
         self._learning_ingest_provider: Any = None
         self._p15_memory_remember_provider: Any = None
         self._p15_memory_recall_provider: Any = None
+        self._composition_dispatch_authorizer: Any = None
         self._last_conversation_context: dict[str, Any] = {}
         self._last_user_name = ""
         self._last_user_text = ""
@@ -399,6 +400,25 @@ class EmbeddedBackendRuntime:
 
     def set_life_skill_overlay_provider(self, provider: Any) -> None:
         self._life_skill_overlay_provider = provider
+
+    def set_composition_dispatch_authorizer(self, provider: Any) -> None:
+        """Bind the private Omni composition route to the one Gateway Store.
+
+        The route is deliberately unusable until the owning orchestration
+        worker installs this current-trust/dispatch-permit callback.  Binding
+        is one-shot so another in-process subsystem cannot replace Gateway
+        authority after startup.
+        """
+
+        if not callable(provider):
+            raise TypeError("composition dispatch authorizer must be callable")
+        with self._lock:
+            existing = getattr(self, "_composition_dispatch_authorizer", None)
+            if existing is not None and existing is not provider:
+                raise EmbeddedBackendError(
+                    "embedded_backend.composition_authorizer_already_bound"
+                )
+            self._composition_dispatch_authorizer = provider
 
     def set_life_activity_query_provider(self, provider: Any) -> None:
         if not callable(provider):
@@ -1094,6 +1114,175 @@ class EmbeddedBackendRuntime:
             raise ValueError("share compose model output is invalid")
         return {"ok": True, "preview": value, "model_output_sha256": __import__("hashlib").sha256(raw.encode("utf-8")).hexdigest()}
 
+    def _execute_composition_action(
+        self, body: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Enter the existing Omni Body without chat/model or grant minting.
+
+        The Total Gateway has already verified the ExecutionTicket and crossed
+        its durable dispatch permit.  This private in-process route accepts
+        only the exact invocation plus the already-signed Omni grant/current
+        runtime trust metadata.  Omni remains the consumer-side grant verifier
+        and ``BodyRuntime`` remains the sole action runtime.
+        """
+
+        if set(body) != {
+            "schema",
+            "execute_ticket",
+            "capability_grant",
+            "runtime",
+        } or body.get("schema") != "tiangong.backend.composition-execute-ticket.v1":
+            raise ValueError("composition execution fields are invalid")
+        execute_ticket = body.get("execute_ticket")
+        grant_value = body.get("capability_grant")
+        runtime_value = body.get("runtime")
+        if (
+            not isinstance(execute_ticket, Mapping)
+            or set(execute_ticket) != {"schema", "ticket", "arguments"}
+            or execute_ticket.get("schema")
+            != "tiangong.backend.execute-ticket.v1"
+            or not isinstance(grant_value, Mapping)
+            or not isinstance(runtime_value, Mapping)
+        ):
+            raise ValueError("composition execution values are invalid")
+
+        # This private route is a second, independent consumer-side check.  It
+        # does not trust the transport's in-memory model objects and restores
+        # every signed contract from the exact wire payload before entering
+        # Omni Body.
+        from contracts import (
+            ExecutionTicket,
+            OmniCapabilityGrant,
+            TrustBundle,
+            canonical_json_bytes,
+            canonical_sha256,
+        )
+        from runtime_security import (
+            verify_execution_ticket,
+            verify_omni_capability_grant,
+        )
+
+        try:
+            ticket = ExecutionTicket.model_validate_json(
+                canonical_json_bytes(execute_ticket["ticket"]), strict=True
+            )
+            grant = OmniCapabilityGrant.model_validate_json(
+                canonical_json_bytes(grant_value), strict=True
+            )
+            runtime_meta = dict(runtime_value)
+            trust_bundle = TrustBundle.model_validate_json(
+                canonical_json_bytes(runtime_meta.get("trust_bundle")),
+                strict=True,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("composition signed authority is invalid") from exc
+
+        invocation = execute_ticket.get("arguments")
+        if (
+            not isinstance(invocation, Mapping)
+            or set(invocation) != {"action", "target", "args"}
+            or not isinstance(invocation.get("action"), str)
+            or not invocation.get("action")
+            or not isinstance(invocation.get("target"), str)
+            or not isinstance(invocation.get("args"), Mapping)
+        ):
+            raise ValueError("composition invocation is invalid")
+        action = str(invocation["action"])
+        target = str(invocation["target"])
+        arguments = dict(invocation["args"])
+        now_ms = time.time_ns() // 1_000_000
+        verify_execution_ticket(ticket, trust_bundle, now_ms=now_ms)
+        verify_omni_capability_grant(grant, trust_bundle, now_ms=now_ms)
+
+        ticket_payload = ticket.payload
+        grant_payload = grant.payload
+        ticket_binding = ticket_payload.composition_execution_binding
+        grant_binding = grant_payload.composition_execution_binding
+        required_runtime = {
+            "execution_ticket_id": ticket_payload.ticket_id,
+            "request_id": ticket_payload.request_id,
+            "run_id": ticket_payload.run_id,
+            "generation": ticket_payload.generation,
+            "effect_id": ticket_payload.effect_id,
+            "principal_scope_hash": ticket_payload.principal_scope_hash,
+            "workspace_id": ticket_payload.workspace_id,
+            "action_id": ticket_payload.action_id,
+            "action_version": ticket_payload.action_version,
+            "decision_sha256": ticket_payload.decision_sha256,
+            "impact_sha256": ticket_payload.impact_sha256,
+            "action_permission_sha256": ticket_payload.action_permission_sha256,
+            "action_registry_sha256": grant_payload.action_registry_sha256,
+            "capability_manifest_hash": ticket_payload.capability_manifest_hash,
+            "component_manifest_hash": ticket_payload.component_manifest_hash,
+            "gateway_epoch": ticket_payload.gateway_epoch,
+            "trust_bundle_sha256": trust_bundle.bundle_sha256,
+            "fact_kernel_enabled": False,
+        }
+        if (
+            ticket_binding is None
+            or grant_binding is None
+            or ticket_binding != grant_binding
+            or runtime_meta.get("composition_execution_binding")
+            != ticket_binding.model_dump(mode="json")
+            or runtime_meta.get("composition_binding_sha256")
+            != ticket_binding.binding_sha256
+            or any(runtime_meta.get(key) != expected for key, expected in required_runtime.items())
+            or ticket_payload.risk_class != "A0"
+            or grant_payload.risk_class != "A0"
+            or any(
+                item not in {"none", "read"}
+                for item in (*ticket_payload.allowed_side_effects, *grant_payload.allowed_side_effects)
+            )
+            or grant_payload.allow_shell
+            or grant_payload.allow_python
+            or action != ticket_payload.action_id
+            or action != grant_payload.action_id
+            or ticket_payload.action_version != grant_payload.action_version
+            or canonical_sha256(dict(invocation)) != ticket_payload.arguments_hash
+            or canonical_sha256(dict(invocation)) != grant_payload.arguments_sha256
+            or canonical_sha256(ticket_payload.model_dump(mode="json"))
+            != grant_payload.ticket_sha256
+            or canonical_sha256(arguments)
+            != ticket_binding.materialized_arguments_sha256
+            or canonical_sha256(target) != ticket_binding.target_sha256
+        ):
+            raise ValueError("composition execution authority mismatch")
+        authorizer = getattr(
+            self,
+            "_composition_dispatch_authorizer",
+            None,
+        )
+        if not callable(authorizer):
+            raise PermissionError("composition dispatch authority is unavailable")
+        try:
+            authorizer(
+                ticket=ticket,
+                grant=grant,
+                trust_bundle=trust_bundle,
+                runtime_meta=deepcopy(runtime_meta),
+                now_ms=now_ms,
+            )
+        except Exception as exc:
+            raise PermissionError(
+                "composition dispatch permit rejected"
+            ) from exc
+        muscle = importlib.import_module("v3.jineng.jirou_ceng")
+        runner = getattr(muscle, "_run_omni_body_tool", None)
+        if not callable(runner):
+            raise RuntimeError("omni_body_runner_missing")
+        result = runner(
+            {
+                "action": action,
+                "target": target,
+                "args": deepcopy(arguments),
+                "__capability_grant": deepcopy(dict(grant_value)),
+                "__runtime": deepcopy(runtime_meta),
+            }
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("omni_body_result_invalid")
+        return result
+
     def request(
         self,
         method: str,
@@ -1182,6 +1371,13 @@ class EmbeddedBackendRuntime:
             elif verb == "POST" and path == "/api/v1/internal/life-action/invoke":
                 with core_lock:
                     result = self._invoke_life_bound_action(body)
+            elif (
+                verb == "POST"
+                and target
+                == "/api/v1/internal/composition/execute-ticket"
+            ):
+                with core_lock:
+                    result = self._execute_composition_action(body)
             elif verb == "POST" and path == "/api/v1/internal/learning/synthesize":
                 result = self._learning_synthesis(body)
             elif verb == "POST" and path == "/api/v1/internal/capability/patch/decision":

--- a/src/total_gateway/fact_ledger.py
+++ b/src/total_gateway/fact_ledger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import hashlib
 import os
+import re
 import sqlite3
 import threading
 from contextlib import contextmanager
@@ -1104,6 +1105,63 @@ class FactLedger:
                 "SELECT * FROM execution_fact_batches WHERE result_id = ?", (result_id,)
             ).fetchone()
             return None if row is None else self._parse_batch(row, verify_payload=verify_payload)
+
+    def get_batch_for_effect(
+        self,
+        effect_id: str,
+        *,
+        verify_payload: bool = True,
+    ) -> FactBatchRecord | None:
+        """Return the unique immutable execution batch for one Effect.
+
+        ``execution_fact_batches.effect_id`` is UNIQUE, so this is the
+        authoritative crash-recovery lookup for a STARTED composition Effect;
+        callers never infer completion from a loose Fact search.
+        """
+
+        if not isinstance(effect_id, str) or re.fullmatch(
+            r"eff_[0-9a-f]{64}", effect_id
+        ) is None:
+            raise ValueError("fact effect identity is invalid")
+        with self._lock:
+            if self._closed:
+                raise FactLedgerError("fact ledger is closed")
+            row = self._connection.execute(
+                "SELECT * FROM execution_fact_batches WHERE effect_id = ?",
+                (effect_id,),
+            ).fetchone()
+            return (
+                None
+                if row is None
+                else self._parse_batch(row, verify_payload=verify_payload)
+            )
+
+    def get_batch_for_ticket(
+        self,
+        ticket_id: str,
+        *,
+        verify_payload: bool = True,
+    ) -> FactBatchRecord | None:
+        """Return the unique immutable execution batch for one ticket."""
+
+        if (
+            not isinstance(ticket_id, str)
+            or not ticket_id
+            or len(ticket_id) > 160
+        ):
+            raise ValueError("fact ticket identity is invalid")
+        with self._lock:
+            if self._closed:
+                raise FactLedgerError("fact ledger is closed")
+            row = self._connection.execute(
+                "SELECT * FROM execution_fact_batches WHERE ticket_id = ?",
+                (ticket_id,),
+            ).fetchone()
+            return (
+                None
+                if row is None
+                else self._parse_batch(row, verify_payload=verify_payload)
+            )
 
     def get_batch_for_fact(
         self,

--- a/src/total_gateway/omni_grant_authority.py
+++ b/src/total_gateway/omni_grant_authority.py
@@ -24,7 +24,6 @@ from contracts import (
     ActionImpact,
     ActionIntent,
     ActionRegistrySnapshot,
-    CompositionExecutionBindingV1,
     ExecutionTicket,
     ExecutionTicketPayload,
     OmniCapabilityGrant,
@@ -40,6 +39,11 @@ from .action_registry import ActionRegistryError, ActionSchemaCatalog
 from .composition_activation_adapter import (
     CompositionActivationAdapterError,
     materialize_static_root_step,
+)
+from .composition_execution_binding import (
+    COMPOSITION_STEP_PIPELINE_VERSION,
+    CompositionExecutionBindingError,
+    derive_composition_execution_binding,
 )
 from .composition_step_authorization import (
     CompositionStepAuthorizationArtifacts,
@@ -196,7 +200,6 @@ def _user_specified_roots_from_text(text: str) -> tuple[Path, ...]:
 # D-06 统一 admission：子 effect 与父级共用 effect 台账 + security_nonce_ledger。
 _OMNI_SUB_EFFECT_PIPELINE_VERSION = "tiangong.omni-grant-authority.v1"
 _OMNI_NONCE_CONSUMER_ID = "tiangong-total-gateway:omni-grant-authority"
-_COMPOSITION_STEP_PIPELINE_VERSION = "tiangong.composition-step-authorization.v1"
 # run_sequence 探测上限：run_id 由 derive_run_identity(request_id, seq) 派生，
 # 超过该上界的 run 视为合成/越界身份，fail-closed。
 _RUN_SEQUENCE_PROBE_LIMIT = 256
@@ -237,6 +240,8 @@ class OmniGrantAuthority:
         action_schema_catalog: ActionSchemaCatalog | None = None,
         object_store=None,
         capability_source_manifest_hash: str | None = None,
+        parent_capability_manifest_hash: str | None = None,
+        composition_capability_manifest_hash: str | None = None,
         gateway_url: str = DEFAULT_GATEWAY_URL,
     ) -> None:
         if not registry.has_valid_sha256():
@@ -273,8 +278,31 @@ class OmniGrantAuthority:
         )
         if re.fullmatch(r"[0-9a-f]{64}", source_manifest_hash) is None:
             raise ValueError("Omni capability source manifest binding is invalid")
+        parent_manifest_hash = (
+            capability_manifest_hash
+            if parent_capability_manifest_hash is None
+            else parent_capability_manifest_hash
+        )
+        composition_manifest_hash = (
+            capability_manifest_hash
+            if composition_capability_manifest_hash is None
+            else composition_capability_manifest_hash
+        )
+        if any(
+            re.fullmatch(r"[0-9a-f]{64}", value) is None
+            for value in (parent_manifest_hash, composition_manifest_hash)
+        ):
+            raise ValueError("Omni composition manifest binding is invalid")
         self.capability_manifest_hash = capability_manifest_hash
         self.capability_source_manifest_hash = source_manifest_hash
+        # These are deliberately distinct authorities.  The parent ticket is
+        # issued against the Gateway compatibility manifest, while a
+        # composition child executes one real registry Action under the
+        # compiled composition execution manifest.  The raw source-file hash
+        # remains drift evidence only and is never presented as a
+        # ``CapabilityManifest.sha256`` at the execution boundary.
+        self.parent_capability_manifest_hash = parent_manifest_hash
+        self.composition_capability_manifest_hash = composition_manifest_hash
         self.component_manifest_hash = component_manifest_hash
         self.skill_catalog_hash = skill_catalog_hash
         self.signer = signer
@@ -716,7 +744,8 @@ class OmniGrantAuthority:
             not signature_is_current
             or outer.ticket_id != parent_ticket_id
             or outer.gateway_epoch != self.gateway_epoch
-            or outer.capability_manifest_hash != self.capability_manifest_hash
+            or outer.capability_manifest_hash
+            != self.parent_capability_manifest_hash
             or outer.component_manifest_hash != self.component_manifest_hash
             or outer.request_id != plan.request_id
             or outer.run_id != plan.run_id
@@ -807,7 +836,7 @@ class OmniGrantAuthority:
                 or runtime["session_id"] != active.session_id
                 or runtime["gateway_epoch"] != self.gateway_epoch
                 or runtime["capability_manifest_hash"]
-                != self.capability_manifest_hash
+                != self.composition_capability_manifest_hash
                 or runtime["component_manifest_hash"]
                 != self.component_manifest_hash
             ):
@@ -999,74 +1028,22 @@ class OmniGrantAuthority:
         target_snapshot_sha256 = (
             None if target_state is None else canonical_sha256(target_state)
         )
-        canonical_invocation_sha256 = canonical_sha256(
-            {
-                "action_id": permission.action_id,
-                "action_version": permission.action_version,
-                "payload_sha256": materialized_arguments_sha256,
-                "target_ref": target_ref,
-                "workspace_id": self.workspace_id,
-            }
-        )
         try:
-            run_sequence = self._derive_run_sequence(plan.request_id, plan.run_id)
-        except OmniGrantAuthorityError:
-            raise
-        ordinal = next(
-            index + 1
-            for index, item in enumerate(plan.step_bindings)
-            if item.step_id == step_id
-        )
-        effect_intent_sha256 = canonical_sha256(
-            {
-                "domain": "tiangong.composition-step-effect-intent.v1",
-                "parent_ticket_id": parent_ticket_id,
-                "registration_id": registration_id,
-                "executable_plan_id": plan.executable_plan_id,
-                "executable_plan_sha256": plan.executable_plan_sha256,
-                "step_id": step_id,
-                "step_binding_sha256": materialized.step.sha256,
-                "action_id": permission.action_id,
-                "action_version": permission.action_version,
-                "arguments_sha256": arguments_sha256,
-                "materialized_arguments_sha256": materialized_arguments_sha256,
-                "target_sha256": materialized.target_sha256,
-                "target_snapshot_sha256": target_snapshot_sha256,
-                "workspace_id": self.workspace_id,
-                "workspace_scope_hash": self.workspace_scope_hash,
-                "request_id": plan.request_id,
-                "run_id": plan.run_id,
-                "generation": plan.generation,
-            }
-        )
-        effect_id = derive_effect_identity(
-            request_id=plan.request_id,
-            run_id=plan.run_id,
-            run_sequence=run_sequence,
-            generation=plan.generation,
-            effect_kind="execution",
-            ordinal=ordinal,
-            intent_sha256=effect_intent_sha256,
-        ).effect_id
-        binding = CompositionExecutionBindingV1(
-            executable_plan_id=plan.executable_plan_id,
-            executable_plan_sha256=plan.executable_plan_sha256,
-            step_id=step_id,
-            step_binding_sha256=materialized.step.sha256,
-            request_id=plan.request_id,
-            run_id=plan.run_id,
-            generation=plan.generation,
-            effect_id=effect_id,
-            action_id=permission.action_id,
-            action_version=permission.action_version,
-            materialized_arguments_sha256=materialized_arguments_sha256,
-            canonical_invocation_sha256=canonical_invocation_sha256,
-            target_sha256=materialized.target_sha256,
-            target_snapshot_sha256=target_snapshot_sha256,
-            workspace_id=self.workspace_id,
-            workspace_scope_hash=self.workspace_scope_hash,
-            binding_sha256="0" * 64,
-        ).with_computed_sha256()
+            derived_binding = derive_composition_execution_binding(
+                plan,
+                materialized,
+                parent_ticket_id=parent_ticket_id,
+                workspace_id=self.workspace_id,
+                workspace_scope_hash=self.workspace_scope_hash,
+                target_snapshot_sha256=target_snapshot_sha256,
+            )
+        except CompositionExecutionBindingError as exc:
+            raise OmniGrantAuthorityError(exc.code, status=409) from exc
+        run_sequence = derived_binding.run_sequence
+        ordinal = derived_binding.ordinal
+        effect_intent_sha256 = derived_binding.effect_intent_sha256
+        effect_id = derived_binding.effect_id
+        binding = derived_binding.binding
 
         fence_status = store.action_fence_status()
         raw_fence_epoch = int(fence_status.get("action_fence_epoch", -1))
@@ -1276,7 +1253,7 @@ class OmniGrantAuthority:
             self.registry,
             policy_snapshot_sha256=policy_snapshot_sha256,
             skill_catalog_hash=self.skill_catalog_hash,
-            capability_manifest_hash=self.capability_manifest_hash,
+            capability_manifest_hash=self.composition_capability_manifest_hash,
             component_manifest_hash=self.component_manifest_hash,
         ).evaluate(
             intent,
@@ -1298,7 +1275,7 @@ class OmniGrantAuthority:
             effect_kind="execution",
             ordinal=ordinal,
             intent_sha256=effect_intent_sha256,
-            pipeline_version=_COMPOSITION_STEP_PIPELINE_VERSION,
+            pipeline_version=COMPOSITION_STEP_PIPELINE_VERSION,
             attempt=1,
             claim_revision=1,
             lease_epoch=self.gateway_epoch,
@@ -1335,7 +1312,7 @@ class OmniGrantAuthority:
             link_account_id=outer.link_account_id,
             conversation_scope_hash=outer.conversation_scope_hash,
             principal_scope_hash=outer.principal_scope_hash,
-            capability_manifest_hash=self.capability_manifest_hash,
+            capability_manifest_hash=self.composition_capability_manifest_hash,
             policy_snapshot_hash=decision.policy_snapshot_sha256,
             policy_coverage_sha256=decision.policy_coverage_sha256,
             intent_id=intent.intent_id,
@@ -1407,7 +1384,7 @@ class OmniGrantAuthority:
             "impact_sha256": impact.impact_sha256,
             "action_permission_sha256": permission.permission_sha256,
             "action_registry_sha256": self.registry.registry_sha256,
-            "capability_manifest_hash": self.capability_manifest_hash,
+            "capability_manifest_hash": self.composition_capability_manifest_hash,
             "component_manifest_hash": self.component_manifest_hash,
             "confirmation_sha256": None,
             "skill_id": None,
@@ -1416,6 +1393,9 @@ class OmniGrantAuthority:
             "skill_activation_sha256": None,
             "gateway_url": self.gateway_url,
             "session_id": active.session_id,
+            # This is the immutable authorization receipt.  The P7D runtime
+            # coordinator derives a detached execution copy and forces that
+            # copy to False so Gateway FactLedger remains the sole fact writer.
             "fact_kernel_enabled": True,
             "gateway_epoch": self.gateway_epoch,
             "trust_bundle_sha256": trust_bundle.bundle_sha256,

--- a/src/total_gateway/orchestration.py
+++ b/src/total_gateway/orchestration.py
@@ -31,6 +31,7 @@ from contracts import (
     OutboundPart,
     OutboundPlan,
     OutboundScope,
+    TrustBundle,
     TransitionEvent,
     canonical_json_bytes,
     canonical_sha256,
@@ -40,10 +41,19 @@ from contracts import (
     new_state_snapshot,
     text_sha256,
 )
+from runtime_security import (
+    verify_execution_ticket,
+    verify_omni_capability_grant,
+)
 
 from .active_requests import ActiveRequestActivator
 from .action_registry import ActionSchemaCatalog
 from .composition_activation_adapter import CompositionActivationAdapter
+from .composition_execution_binding import COMPOSITION_STEP_PIPELINE_VERSION
+from .composition_step_execution import (
+    CompositionStepExecutionCoordinator,
+    CompositionStepExecutionError,
+)
 from .impact_evaluator import compute_action_impact, derive_impact_knobs, probe_target_state
 from .omni_grant_authority import OmniGrantAuthority
 from .policy_engine import PolicyEngine, SourceRef
@@ -57,6 +67,47 @@ _EXECUTION_WATCHDOG_POOL = concurrent.futures.ThreadPoolExecutor(
     max_workers=8,
     thread_name_prefix="execution-watchdog",
 )
+_COMPOSITION_WATCHDOG_SLOT = threading.BoundedSemaphore(value=1)
+
+
+def _run_backend_transport_with_watchdog(
+    call: Callable[[], dict[str, Any]], timeout_seconds: float
+) -> dict[str, Any]:
+    """Run only the already-authorized transport call in the existing pool.
+
+    The caller crosses the durable Effect permit and consumes the ticket nonce
+    before this helper is entered.  If the in-process handler ignores its
+    timeout, its late return is deliberately discarded: the canonical Effect
+    closes AMBIGUOUS and no late Fact can race that terminal head.
+    """
+
+    if not _COMPOSITION_WATCHDOG_SLOT.acquire(blocking=False):
+        raise BackendClientError(
+            "backend.composition.watchdog_capacity_exhausted",
+            ambiguous=True,
+        )
+    try:
+        future = _EXECUTION_WATCHDOG_POOL.submit(
+            contextvars.copy_context().run,
+            call,
+        )
+    except BaseException:
+        _COMPOSITION_WATCHDOG_SLOT.release()
+        raise
+    future.add_done_callback(lambda _future: _COMPOSITION_WATCHDOG_SLOT.release())
+    try:
+        return future.result(timeout=timeout_seconds)
+    except concurrent.futures.TimeoutError as exc:
+        # If the task has not begun, prevent a delayed handler invocation.  A
+        # running in-process call cannot be killed safely; this first batch is
+        # A0 read/verify only, so its unknown late return is ignored and never
+        # promoted to a machine Fact.
+        cancelled = future.cancel()
+        raise BackendClientError(
+            "backend.composition.execution_timeout",
+            ambiguous=True,
+            pending_transport_future=(None if cancelled else future),
+        ) from exc
 
 
 def _append_orchestration_effect_event(
@@ -153,6 +204,7 @@ from .release_manifest import (
 from .runtime_authority import RuntimeTicketAuthority
 from .skill_selection import (
     SkillSelectionService,
+    compile_composition_execution_manifest,
     load_filesystem_skill_catalog,
     load_model_capability_manifest,
 )
@@ -398,7 +450,19 @@ class GatewayOrchestrationWorker:
 
         if omni_registry is None or policy_evidence is None or skill_capabilities is None:
             raise ValueError("production orchestration requires Omni registry and policy evidence")
+        if omni_schema_catalog is None:
+            raise ValueError("production orchestration requires Omni schema authority")
         self._policy_evidence = policy_evidence
+        self._composition_capabilities = compile_composition_execution_manifest(
+            skill_capabilities,
+            omni_registry,
+            omni_schema_catalog,
+            generated_at_ms=self._components.generated_at_ms,
+        )
+        parent_capabilities = compatibility_capability_manifest(
+            self._components.manifest_sha256,
+            generated_at_ms=self._components.generated_at_ms,
+        )
         self._omni_grants = OmniGrantAuthority(
             registry=omni_registry,
             capability_manifest_hash=self._release_manifest.capability_manifest_sha256,
@@ -416,10 +480,51 @@ class GatewayOrchestrationWorker:
             action_schema_catalog=omni_schema_catalog,
             object_store=objects,
             capability_source_manifest_hash=omni_registry.source_manifest_sha256,
+            parent_capability_manifest_hash=parent_capabilities.sha256,
+            composition_capability_manifest_hash=(
+                self._composition_capabilities.sha256
+            ),
             gateway_url=self._gateway_url,
         )
+        composition_execution_available = False
+        if backend_compat_client is not None:
+            binder = getattr(
+                backend_compat_client,
+                "set_composition_dispatch_authorizer",
+                None,
+            )
+            if callable(binder) and callable(
+                getattr(store, "consume_composition_handler_permit", None)
+            ):
+                binder(self._authorize_composition_handler_entry)
+                composition_execution_available = True
         self._composition_activation_adapter = CompositionActivationAdapter(
-            self._omni_grants
+            self._omni_grants,
+            execution_available=composition_execution_available,
+        )
+        self._composition_steps = (
+            None
+            if not composition_execution_available
+            else CompositionStepExecutionCoordinator(
+                store=store,
+                objects=objects,
+                facts=facts,
+                registry=omni_registry,
+                schema_catalog=omni_schema_catalog,
+                capability_manifest=self._composition_capabilities,
+                trust_bundle_provider=lambda now_ms: (
+                    self._authority.execution_trust_bundle(
+                        gateway_epoch=self._epoch,
+                        now_ms=now_ms,
+                    )
+                ),
+                backend_compat_client=backend_compat_client,
+                workspace_root=self._workspace_root,
+                gateway_epoch=self._epoch,
+                gateway_instance_id=self._instance_id,
+                append_effect_event=_append_orchestration_effect_event,
+                transport_runner=_run_backend_transport_with_watchdog,
+            )
         )
         self._context_projector = SessionContextProjector(store, objects)
         self._poll_seconds = poll_interval_seconds
@@ -613,19 +718,76 @@ class GatewayOrchestrationWorker:
     def start(self) -> None:
         if self._thread is not None:
             return
-        # V14 草案 §3.2：启动时先把上次崩溃遗留的 STARTED attempt 收口为
-        # RECONCILE_REQUIRED（head 层 AMBIGUOUS），进入只读对账；
-        # 未完成提交不再悬挂（此前 recover_started_effects 无生产调用方）。
+        now_ms = time.time_ns() // 1_000_000
+        # Composition owns an exact Effect -> Fact recovery adapter.  It must
+        # run before the generic V14 recovery, otherwise a provable successful
+        # A0 read could be overwritten by the generic interrupted-wrapper rule.
+        if self._composition_steps is not None:
+            try:
+                recovered_composition = self._composition_steps.recover_started(
+                    now_ms=now_ms
+                )
+                if recovered_composition:
+                    diagnostic_log(
+                        "[ORCHESTRATION] recovered "
+                        f"{len(recovered_composition)} composition effects from exact Facts"
+                    )
+            except Exception as exc:  # noqa: BLE001 - fail closed; never replay STARTED
+                diagnostic_log(
+                    "[ORCHESTRATION] composition-effect recovery failed: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                raise OrchestrationError(
+                    "orchestration.composition.recovery_failed",
+                    ambiguous=True,
+                ) from exc
+        else:
+            stranded_composition = self._store.list_effects_for_pipeline(
+                COMPOSITION_STEP_PIPELINE_VERSION,
+                states=("SIDE_EFFECT_STARTED",),
+            )
+            if stranded_composition:
+                raise OrchestrationError(
+                    "orchestration.composition.executor_unavailable",
+                    ambiguous=True,
+                )
+        try:
+            recovered_parent = self._recover_parent_started_effects(
+                now_ms=now_ms
+            )
+            if recovered_parent:
+                diagnostic_log(
+                    "[ORCHESTRATION] recovered "
+                    f"{recovered_parent} parent effects from exact Facts"
+                )
+        except Exception as exc:  # noqa: BLE001 - corrupt recovery must block start
+            diagnostic_log(
+                "[ORCHESTRATION] parent-effect recovery failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            raise OrchestrationError(
+                "orchestration.parent.recovery_failed",
+                ambiguous=True,
+            ) from exc
+        # V14 草案 §3.2：其余 STARTED attempt 进入既有保守恢复。P7D
+        # pipeline is always excluded, including deployments without the
+        # embedded executor, so it can never be blindly replayed or mislabeled
+        # as an ordinary backend-wrapper interruption.
         try:
             recovered = self._store.recover_started_effects(
-                now_ms=time.time_ns() // 1_000_000
+                now_ms=now_ms,
+                exclude_pipeline_versions=(COMPOSITION_STEP_PIPELINE_VERSION,),
             )
             if recovered:
                 diagnostic_log(
                     f"[ORCHESTRATION] recovered {len(recovered)} started effects into reconcile-required"
                 )
-        except Exception as exc:  # noqa: BLE001 - 恢复失败不得阻止 worker 启动，但必须留痕
+        except Exception as exc:  # noqa: BLE001 - recovery corruption blocks new work
             diagnostic_log(f"[ORCHESTRATION] started-effect recovery failed: {type(exc).__name__}: {exc}")
+            raise OrchestrationError(
+                "orchestration.effect.recovery_failed",
+                ambiguous=True,
+            ) from exc
         self._thread = threading.Thread(
             target=self._run,
             name="tiangong-gateway-orchestration",
@@ -677,6 +839,335 @@ class GatewayOrchestrationWorker:
     @property
     def composition_activation_adapter(self) -> CompositionActivationAdapter:
         return self._composition_activation_adapter
+
+    @property
+    def composition_capability_manifest(self) -> CapabilityManifest:
+        """Current execution manifest for registry-versioned composition Actions."""
+
+        return self._composition_capabilities
+
+    @property
+    def composition_step_executor(
+        self,
+    ) -> CompositionStepExecutionCoordinator | None:
+        """The worker-owned P7D seam; absent outside embedded deployments."""
+
+        return self._composition_steps
+
+    def _authorize_composition_handler_entry(
+        self,
+        *,
+        ticket: Any,
+        grant: Any,
+        trust_bundle: Any,
+        runtime_meta: Mapping[str, Any],
+        now_ms: int,
+    ) -> None:
+        """Pin the private backend route to current Gateway authority.
+
+        This callback runs inside the embedded backend immediately before Omni
+        Body.  It does not mint authority: it independently rebuilds the
+        current trust bundle and atomically consumes the already-issued grant
+        nonce against the existing Effect dispatch permit.
+        """
+
+        if (
+            not isinstance(trust_bundle, TrustBundle)
+            or not trust_bundle.has_valid_sha256()
+            or trust_bundle.gateway_epoch != self._epoch
+            or trust_bundle.generated_at_ms > now_ms
+            or not isinstance(runtime_meta, Mapping)
+        ):
+            raise OrchestrationError(
+                "orchestration.composition.handler_trust_invalid"
+            )
+        current_trust = self._authority.execution_trust_bundle(
+            gateway_epoch=self._epoch,
+            now_ms=trust_bundle.generated_at_ms,
+        )
+        if current_trust != trust_bundle:
+            raise OrchestrationError(
+                "orchestration.composition.handler_trust_not_current"
+            )
+        try:
+            verify_execution_ticket(ticket, current_trust, now_ms=now_ms)
+            verify_omni_capability_grant(grant, current_trust, now_ms=now_ms)
+            ticket_payload = ticket.payload
+            grant_payload = grant.payload
+        except Exception as exc:
+            raise OrchestrationError(
+                "orchestration.composition.handler_signature_invalid"
+            ) from exc
+        if (
+            ticket_payload.composition_execution_binding is None
+            or grant_payload.composition_execution_binding
+            != ticket_payload.composition_execution_binding
+            or runtime_meta.get("trust_bundle_sha256")
+            != current_trust.bundle_sha256
+            or runtime_meta.get("gateway_epoch") != self._epoch
+        ):
+            raise OrchestrationError(
+                "orchestration.composition.handler_binding_invalid"
+            )
+        self._store.consume_composition_handler_permit(
+            effect_id=ticket_payload.effect_id,
+            ticket_id=ticket_payload.ticket_id,
+            ticket_nonce=ticket_payload.nonce,
+            ticket_sha256=canonical_sha256(ticket.model_dump(mode="json")),
+            grant_nonce=grant_payload.nonce,
+            grant_sha256=canonical_sha256(grant.model_dump(mode="json")),
+            gateway_epoch=self._epoch,
+            expected_ticket_consumer_instance_id=(
+                "composition-inprocess-" + self._instance_id
+            ),
+            handler_consumer_instance_id=(
+                "composition-runtime-" + self._instance_id
+            ),
+            now_ms=now_ms,
+        )
+
+    def _dispatch_next_composition_step(
+        self,
+        *,
+        now_ms: int,
+        request_id: str | None = None,
+        run_id: str | None = None,
+        generation: int | None = None,
+    ):
+        executor = self._composition_steps
+        if executor is None:
+            return None
+        outcome = executor.dispatch_next(
+            now_ms=now_ms,
+            request_id=request_id,
+            run_id=run_id,
+            generation=generation,
+        )
+        return outcome
+
+    def _recover_parent_started_effects(self, *, now_ms: int) -> int:
+        """Close the parent Fact-before-Effect crash window without replay.
+
+        The generic Store recovery cannot inspect the separate FactLedger and
+        therefore must not be allowed to overwrite an exact backend Fact with
+        an interruption failure.  This worker owns both authorities and first
+        promotes only an exact immutable parent batch.  A STARTED parent with
+        no batch is outcome-unknown (the handler may have returned before the
+        Fact commit), so this owner-aware layer closes it AMBIGUOUS instead of
+        letting the Store's legacy wrapper rule mislabel it FAILED_FINAL.
+        """
+
+        recovered = 0
+        for effect in self._store.list_effects_for_pipeline(
+            "unspecified",
+            states=("SIDE_EFFECT_STARTED",),
+        ):
+            claim = effect.claim
+            if (
+                claim.owner_component_id != "tiangong-backend"
+                or claim.effect_kind != "execution"
+                or claim.ordinal != 0
+            ):
+                continue
+            batch = self._facts.get_batch_for_effect(
+                claim.effect_id,
+                verify_payload=True,
+            )
+            if batch is None:
+                status = "AMBIGUOUS"
+                observed_at_ms = max(
+                    now_ms,
+                    effect.side_effect_started_at_ms
+                    or claim.claimed_at_ms,
+                )
+                evidence_sha256 = canonical_sha256(
+                    {
+                        "domain": "tiangong.gateway.parent-effect-recovery.v1",
+                        "effect_id": claim.effect_id,
+                        "reason": "result_missing_after_restart",
+                    }
+                )
+                effect_result = EffectResult(
+                    result_id=(
+                        "effect-result-parent-ambiguous-"
+                        + claim.effect_id[4:20]
+                    ),
+                    effect_id=claim.effect_id,
+                    status=status,
+                    fact_id="fact-parent-recovery-" + claim.effect_id[4:20],
+                    evidence_sha256=evidence_sha256,
+                    error_code="effect.result_missing_after_restart",
+                    observed_at_ms=observed_at_ms,
+                    result_sha256="0" * 64,
+                ).with_computed_sha256()
+            else:
+                result = batch.result
+                if (
+                    not batch.facts
+                    or tuple(item.fact_id for item in batch.facts)
+                    != result.fact_ids
+                    or result.effect_id != claim.effect_id
+                    or result.request_id != claim.request_id
+                    or result.run_id != claim.run_id
+                    or result.generation != claim.generation
+                    or result.attempt != claim.attempt
+                    or result.action_id != "gateway.model.run"
+                    or result.action_version != "1.0.0"
+                    or not result.side_effect_started
+                ):
+                    raise OrchestrationError(
+                        "orchestration.parent.recovery_fact_mismatch",
+                        ambiguous=True,
+                    )
+                status = (
+                    "SUCCEEDED"
+                    if result.status == "SUCCEEDED"
+                    else "AMBIGUOUS"
+                    if result.status == "AMBIGUOUS"
+                    else "FAILED_FINAL"
+                )
+                effect_result = EffectResult(
+                    result_id="effect-result-" + result.result_id[:120],
+                    effect_id=claim.effect_id,
+                    status=status,
+                    fact_id=result.fact_ids[0],
+                    result_object_id=batch.result_payload_object_id,
+                    result_object_sha256=batch.result_payload_sha256,
+                    evidence_sha256=batch.response_sha256,
+                    error_code=(
+                        None
+                        if status == "SUCCEEDED"
+                        else result.error_code or "execution.failed"
+                    ),
+                    observed_at_ms=max(
+                        batch.observed_at_ms,
+                        effect.side_effect_started_at_ms
+                        or claim.claimed_at_ms,
+                    ),
+                    result_sha256="0" * 64,
+                ).with_computed_sha256()
+            self._store.complete_effect(
+                effect_result,
+                expected_state="SIDE_EFFECT_STARTED",
+            )
+            _append_orchestration_effect_event(
+                self._store,
+                event_key=(
+                    "step.committed:"
+                    if status == "SUCCEEDED"
+                    else "step.ambiguous:"
+                    if status == "AMBIGUOUS"
+                    else "step.failed:"
+                )
+                + claim.effect_id,
+                event_type=(
+                    "step.committed"
+                    if status == "SUCCEEDED"
+                    else "step.ambiguous"
+                    if status == "AMBIGUOUS"
+                    else "step.failed"
+                ),
+                payload={
+                    "effect_state": status,
+                    "source": "gateway_orchestration_parent_recovery",
+                },
+                request_id=claim.request_id,
+                run_id=claim.run_id,
+                generation=claim.generation,
+                effect_id=claim.effect_id,
+                created_at_ms=effect_result.observed_at_ms,
+            )
+            recovered += 1
+        return recovered
+
+    def _terminalize_composition_failure(
+        self,
+        activation: ActiveRequestActivation,
+        *,
+        execution_entity: str,
+        delivery_entity: str,
+        code: str,
+        ambiguous: bool,
+        observed_at_ms: int,
+        fact_id: str | None = None,
+        evidence_sha256: str | None = None,
+    ) -> None:
+        """Stop the parent request before artifact, Life or delivery commits."""
+
+        request_id = activation.entry.request_id
+        run_id = activation.generation.run_id
+        generation = activation.generation.generation
+        evidence = evidence_sha256 or canonical_sha256(
+            {
+                "code": code,
+                "domain": "tiangong.gateway.composition-execution-failure.v1",
+                "generation": generation,
+                "request_id": request_id,
+                "run_id": run_id,
+            }
+        )
+        transition_fact_id = fact_id or (
+            "fact-composition-" + evidence[:32]
+        )
+        execution = self._store.get_snapshot("execution", execution_entity)
+        if execution is not None and not execution.is_terminal:
+            if ambiguous:
+                if execution.state not in {"AMBIGUOUS", "RECONCILE_REQUIRED"}:
+                    self._advance(
+                        "execution",
+                        execution_entity,
+                        "AMBIGUOUS",
+                        now_ms=observed_at_ms,
+                        fact_id=transition_fact_id,
+                        evidence_sha256=evidence,
+                    )
+                self._advance(
+                    "execution",
+                    execution_entity,
+                    "RECONCILE_REQUIRED",
+                    now_ms=observed_at_ms,
+                    fact_id=transition_fact_id,
+                    evidence_sha256=evidence,
+                )
+            else:
+                self._advance(
+                    "execution",
+                    execution_entity,
+                    "FAILED_FINAL",
+                    now_ms=observed_at_ms,
+                    fact_id=transition_fact_id,
+                    evidence_sha256=evidence,
+                )
+        delivery = self._store.get_snapshot("delivery", delivery_entity)
+        if delivery is not None and not delivery.is_terminal:
+            self._advance(
+                "delivery",
+                delivery_entity,
+                "CANCELLED",
+                now_ms=observed_at_ms,
+            )
+        request = self._store.get_snapshot("request", request_id)
+        if request is not None and not request.is_terminal:
+            self._advance(
+                "request",
+                request_id,
+                "FAILED",
+                now_ms=observed_at_ms,
+                fact_id=transition_fact_id,
+                evidence_sha256=evidence,
+            )
+        self._persist_interruption(
+            activation,
+            reason_code=code,
+            observed_at_ms=observed_at_ms,
+            fact_id=transition_fact_id,
+        )
+        self._store.complete_session_request(
+            activation.entry.session_scope_hash,
+            request_id,
+            completed_at_ms=observed_at_ms,
+            release_generation=True,
+        )
 
     # ------------------------------------------------------------------
     # D-14 澄清不是确认（最小集）
@@ -1418,6 +1909,14 @@ class GatewayOrchestrationWorker:
         ):
             effect = self._store.get_effect(effect_id)
             if effect is None or effect.state not in {"CLAIMED", "SIDE_EFFECT_STARTED"}:
+                continue
+            # Composition STARTED effects have a dedicated exact-Fact recovery
+            # path.  The generic timeout watchdog must not race that path or
+            # convert a provable success into an arbitrary AMBIGUOUS head.
+            if (
+                getattr(getattr(effect, "claim", None), "pipeline_version", None)
+                == COMPOSITION_STEP_PIPELINE_VERSION
+            ):
                 continue
             result = EffectResult(
                 result_id="effect-result-" + effect_id[4:20],
@@ -3093,6 +3592,7 @@ class GatewayOrchestrationWorker:
             try:
                 response = execution_future.result(timeout=watchdog_ms / 1000.0)
             except concurrent.futures.TimeoutError:
+                execution_future.cancel()
                 effect_record = self._store.get_effect(effect.effect_id)
                 raise BackendClientError(
                     "effect_execution_timeout",
@@ -3200,15 +3700,20 @@ class GatewayOrchestrationWorker:
             effect_id=effect.effect_id,
             created_at_ms=observed_at,
         )
-        self._advance(
-            "execution",
-            execution_entity,
-            response.result.status if response.result.status in {"SUCCEEDED", "AMBIGUOUS", "FAILED_FINAL"} else "FAILED_FINAL",
-            now_ms=observed_at,
-            fact_id=response.result.fact_ids[0],
-            evidence_sha256=response.response_sha256,
-        )
         if response.result.status != "SUCCEEDED":
+            self._advance(
+                "execution",
+                execution_entity,
+                (
+                    response.result.status
+                    if response.result.status
+                    in {"AMBIGUOUS", "FAILED_FINAL"}
+                    else "FAILED_FINAL"
+                ),
+                now_ms=observed_at,
+                fact_id=response.result.fact_ids[0],
+                evidence_sha256=response.response_sha256,
+            )
             if response.result.status == "AMBIGUOUS":
                 self._advance(
                     "execution",
@@ -3240,6 +3745,118 @@ class GatewayOrchestrationWorker:
                 completed_at_ms=observed_at,
             )
             raise OrchestrationError(response.result.error_code or "orchestration.execution.failed")
+
+        # P7D.1 executes only a persisted, single A0 root authorization and
+        # does so after the parent response has both an immutable Gateway Fact
+        # and a successful Effect head.  This point is also after parent Omni
+        # authority unregister/core-lock release, but before aggregate success,
+        # artifact/Life commits or any delivery intent.
+        composition_outcome = None
+        try:
+            if self._composition_steps is None:
+                required_plan = (
+                    self._store.get_executable_composition_plan_for_request(
+                        request_id,
+                        run_id=run_id,
+                        generation=generation.generation,
+                    )
+                )
+                if required_plan is not None:
+                    raise CompositionStepExecutionError(
+                        "composition.execution.executor_unavailable"
+                    )
+            else:
+                composition_outcome = self._dispatch_next_composition_step(
+                    now_ms=observed_at,
+                    request_id=request_id,
+                    run_id=run_id,
+                    generation=generation.generation,
+                )
+                if (
+                    composition_outcome is not None
+                    and composition_outcome.status != "SUCCEEDED"
+                ):
+                    child = self._store.get_effect(
+                        composition_outcome.effect_id
+                    )
+                    child_result = None if child is None else child.result
+                    raise CompositionStepExecutionError(
+                        (
+                            "composition.execution.failed"
+                            if child_result is None
+                            or child_result.error_code is None
+                            else child_result.error_code
+                        ),
+                        ambiguous=(
+                            composition_outcome.status == "AMBIGUOUS"
+                        ),
+                    )
+        except Exception as exc:
+            composition_effects = tuple(
+                item
+                for item in self._store.list_effects_for_request(
+                    request_id,
+                    run_id=run_id,
+                    generation=generation.generation,
+                )
+                if item.claim.pipeline_version
+                == COMPOSITION_STEP_PIPELINE_VERSION
+            )
+            child = composition_effects[-1] if composition_effects else None
+            child_result = None if child is None else child.result
+            ambiguous = bool(getattr(exc, "ambiguous", False)) or any(
+                item.state in {"SIDE_EFFECT_STARTED", "AMBIGUOUS"}
+                for item in composition_effects
+            )
+            code = str(
+                getattr(exc, "code", None)
+                or (
+                    None
+                    if child_result is None
+                    else child_result.error_code
+                )
+                or "composition.execution.failed"
+            )[:160]
+            failed_at_ms = max(
+                observed_at,
+                time.time_ns() // 1_000_000,
+                0
+                if child_result is None
+                else child_result.observed_at_ms,
+            )
+            self._terminalize_composition_failure(
+                activation,
+                execution_entity=execution_entity,
+                delivery_entity=delivery_entity,
+                code=code,
+                ambiguous=ambiguous,
+                observed_at_ms=failed_at_ms,
+                fact_id=(
+                    None if child_result is None else child_result.fact_id
+                ),
+                evidence_sha256=(
+                    None
+                    if child_result is None
+                    else child_result.evidence_sha256
+                ),
+            )
+            raise OrchestrationError(code, ambiguous=ambiguous) from exc
+
+        self._advance(
+            "execution",
+            execution_entity,
+            "SUCCEEDED",
+            now_ms=max(
+                observed_at,
+                (
+                    0
+                    if composition_outcome is None
+                    else time.time_ns() // 1_000_000
+                ),
+            ),
+            fact_id=response.result.fact_ids[0],
+            evidence_sha256=response.response_sha256,
+        )
 
         result_payload = response.result_payload if isinstance(response.result_payload, dict) else {}
         reply = str(result_payload.get("reply_text") or "").strip()

--- a/src/total_gateway/policy_evidence.py
+++ b/src/total_gateway/policy_evidence.py
@@ -88,7 +88,27 @@ class PolicyEvidenceLedger:
                         stream.write(body)
                         stream.flush()
                         os.fsync(stream.fileno())
-                    os.replace(temp, path)
+                    # Publish without replacing an existing content address.
+                    # ``self._lock`` only coordinates one ledger instance;
+                    # separate workers can therefore reach this point at the
+                    # same time.  ``os.replace`` lets both writers overwrite
+                    # the destination and Windows can reject that race with
+                    # ``PermissionError``.  A hard link is an atomic
+                    # create-if-absent operation because the staging file is
+                    # in the same directory.  The losing writer may accept the
+                    # winner only after verifying the authoritative bytes.
+                    try:
+                        os.link(temp, path)
+                    except FileExistsError:
+                        pass
+                    if (
+                        path.is_symlink()
+                        or not path.is_file()
+                        or path.read_bytes() != body
+                    ):
+                        raise PolicyEvidenceError(
+                            "policy evidence content-address conflict"
+                        )
                 finally:
                     temp.unlink(missing_ok=True)
         return {"kind": kind, "object_id": object_id, "sha256": digest, "path": str(path)}

--- a/src/total_gateway/service_ports.py
+++ b/src/total_gateway/service_ports.py
@@ -75,5 +75,17 @@ class CompatibilityJsonClient:
         ).encode("utf-8")
         return status, value, hashlib.sha256(raw).hexdigest()
 
+    def set_composition_dispatch_authorizer(self, provider: Any) -> None:
+        setter = getattr(
+            self._service,
+            "set_composition_dispatch_authorizer",
+            None,
+        )
+        if not callable(setter):
+            raise TypeError(
+                "service does not expose composition dispatch authority binding"
+            )
+        setter(provider)
+
 
 __all__.append("CompatibilityJsonClient")

--- a/src/total_gateway/skill_selection.py
+++ b/src/total_gateway/skill_selection.py
@@ -13,13 +13,19 @@ from typing import Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from contracts import (
+    ActionRegistrySnapshot,
     CapabilityAction,
     CapabilityManifest,
     SkillCandidate,
     SkillSelectionRecord,
     canonical_sha256,
 )
-from .action_registry import LoadedActionAuthority, compile_action_authority
+from .action_registry import (
+    ActionSchemaCatalog,
+    LoadedActionAuthority,
+    ResolvedActionSchema,
+    compile_action_authority,
+)
 
 
 SkillOperation = Literal["skill.route", "skill.list", "skill.get", "skill.read"]
@@ -436,6 +442,211 @@ def load_model_capability_manifest(
     )
 
 
+def compile_composition_execution_manifest(
+    model_manifest: CapabilityManifest,
+    registry: ActionRegistrySnapshot,
+    schema_catalog: ActionSchemaCatalog,
+    *,
+    generated_at_ms: int | None = None,
+) -> CapabilityManifest:
+    """Join the model, permission, and schema views into an execution manifest.
+
+    ``load_model_capability_manifest`` intentionally exposes model-facing
+    action versions. Composition tickets, however, carry the current Action
+    Registry permission version. Passing the model-facing projection directly
+    to ``BackendClient`` therefore cannot authorize a real composition action.
+
+    This compiler does not treat the raw source-manifest digest as a
+    ``CapabilityManifest`` digest. It validates the contract digest on the
+    supplied model view, joins every registry permission to exactly one model
+    action and one current schema entry, then computes a new contract digest
+    over the resulting execution view.
+    """
+
+    if not isinstance(model_manifest, CapabilityManifest):
+        raise SkillSelectionError(
+            "composition execution model capability manifest is invalid"
+        )
+    if not isinstance(registry, ActionRegistrySnapshot):
+        raise SkillSelectionError(
+            "composition execution action registry is invalid"
+        )
+    if not isinstance(schema_catalog, ActionSchemaCatalog):
+        raise SkillSelectionError(
+            "composition execution action schema catalog is invalid"
+        )
+    if generated_at_ms is not None and (
+        type(generated_at_ms) is not int or generated_at_ms < 0
+    ):
+        raise ValueError("composition execution manifest generation time is invalid")
+
+    # model_copy/model_construct can bypass Pydantic validators. Re-parse the
+    # supplied contracts before trusting their ordering and nested invariants,
+    # and independently verify their content-addressed digests.
+    try:
+        checked_model = CapabilityManifest.model_validate(
+            model_manifest.model_dump(mode="python"), strict=True
+        )
+    except (TypeError, ValueError) as exc:
+        raise SkillSelectionError(
+            "composition execution model capability manifest is invalid"
+        ) from exc
+    if not checked_model.has_valid_sha256():
+        raise SkillSelectionError(
+            "composition execution model capability manifest digest is invalid"
+        )
+
+    try:
+        checked_registry = ActionRegistrySnapshot.model_validate(
+            registry.model_dump(mode="python"), strict=True
+        )
+    except (TypeError, ValueError) as exc:
+        raise SkillSelectionError(
+            "composition execution action registry is invalid"
+        ) from exc
+    if not checked_registry.has_valid_sha256():
+        raise SkillSelectionError(
+            "composition execution action registry digest is invalid"
+        )
+
+    try:
+        catalog_valid = schema_catalog.has_valid_sha256()
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise SkillSelectionError(
+            "composition execution action schema catalog is invalid"
+        ) from exc
+    if not catalog_valid:
+        raise SkillSelectionError(
+            "composition execution action schema catalog digest is invalid"
+        )
+    if (
+        not isinstance(schema_catalog.source_manifest_sha256, str)
+        or not re.fullmatch(
+            r"[0-9a-f]{64}", schema_catalog.source_manifest_sha256
+        )
+        or schema_catalog.source_manifest_sha256
+        != checked_registry.source_manifest_sha256
+    ):
+        raise SkillSelectionError(
+            "composition execution authority source manifest mismatch"
+        )
+
+    permissions = checked_registry.permissions
+    permission_ids = tuple(item.action_id for item in permissions)
+    if permission_ids != tuple(sorted(set(permission_ids))):
+        raise SkillSelectionError(
+            "composition execution action permissions are unordered or ambiguous"
+        )
+
+    model_actions: dict[str, CapabilityAction] = {}
+    for action in checked_model.actions:
+        if action.action_id in model_actions:
+            raise SkillSelectionError(
+                "composition execution model action identity is ambiguous"
+            )
+        model_actions[action.action_id] = action
+    if set(model_actions) != set(permission_ids):
+        raise SkillSelectionError(
+            "composition execution model and permission coverage mismatch"
+        )
+
+    entries = schema_catalog.entries
+    if not isinstance(entries, tuple) or not entries:
+        raise SkillSelectionError(
+            "composition execution action schema catalog is invalid"
+        )
+    if any(not isinstance(entry, ResolvedActionSchema) for entry in entries):
+        raise SkillSelectionError(
+            "composition execution action schema entry is invalid"
+        )
+    entry_ids = tuple(entry.action_id for entry in entries)
+    if entry_ids != permission_ids:
+        raise SkillSelectionError(
+            "composition execution permission and schema coverage mismatch"
+        )
+
+    compiled_actions: list[CapabilityAction] = []
+    for permission, entry in zip(permissions, entries, strict=True):
+        if (
+            entry.action_id != permission.action_id
+            or entry.action_version != permission.action_version
+            or entry.source_manifest_sha256
+            != schema_catalog.source_manifest_sha256
+            or entry.kind not in {"EXPLICIT", "OPAQUE"}
+            or not isinstance(entry.argument_schema_sha256, str)
+            or not re.fullmatch(
+                r"[0-9a-f]{64}", entry.argument_schema_sha256
+            )
+            or not isinstance(entry.validator_source_sha256, str)
+            or not re.fullmatch(
+                r"[0-9a-f]{64}", entry.validator_source_sha256
+            )
+        ):
+            raise SkillSelectionError(
+                "composition execution permission and schema binding mismatch"
+            )
+        try:
+            schema_body = entry.body()
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise SkillSelectionError(
+                "composition execution action schema entry is invalid"
+            ) from exc
+        if (
+            canonical_sha256(schema_body) != entry.argument_schema_sha256
+            or schema_body.get("action") != entry.canonical_action_id
+        ):
+            raise SkillSelectionError(
+                "composition execution action schema body is invalid"
+            )
+
+        model_action = model_actions[permission.action_id]
+        if model_action.argument_schema_sha256 != entry.argument_schema_sha256:
+            raise SkillSelectionError(
+                "composition execution model and current schema mismatch"
+            )
+        compiled_actions.append(
+            CapabilityAction(
+                action_id=permission.action_id,
+                version=permission.action_version,
+                provider_component_id=model_action.provider_component_id,
+                argument_schema_sha256=entry.argument_schema_sha256,
+                result_schema_sha256=model_action.result_schema_sha256,
+                risk_class=permission.effective_risk,
+                allowed_side_effects=permission.allowed_side_effects,
+                idempotency_mode=model_action.idempotency_mode,
+                max_runtime_ms=model_action.max_runtime_ms,
+                max_output_bytes=model_action.max_output_bytes,
+                max_tool_calls=model_action.max_tool_calls,
+                available=model_action.available,
+                unavailable_reason=model_action.unavailable_reason,
+                model_visible=model_action.model_visible,
+            )
+        )
+
+    draft = CapabilityManifest(
+        manifest_id="omni-body-composition-execution-capabilities-v1",
+        revision=checked_model.revision,
+        generated_at_ms=(
+            checked_model.generated_at_ms
+            if generated_at_ms is None
+            else generated_at_ms
+        ),
+        component_manifest_hash=checked_model.component_manifest_hash,
+        actions=tuple(
+            sorted(
+                compiled_actions,
+                key=lambda item: (item.action_id, item.version),
+            )
+        ),
+        sha256="0" * 64,
+    ).with_computed_sha256()
+    if not draft.has_valid_sha256():  # defensive: never return unhashed authority
+        raise SkillSelectionError(
+            "composition execution capability manifest digest is invalid"
+        )
+    return draft
+
+
 class SkillResolution(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
@@ -781,6 +992,7 @@ __all__ = [
     "SkillResolution",
     "SkillSelectionError",
     "SkillSelectionService",
+    "compile_composition_execution_manifest",
     "load_filesystem_skill_catalog",
     "load_model_capability_manifest",
 ]

--- a/src/total_gateway/store.py
+++ b/src/total_gateway/store.py
@@ -6,6 +6,7 @@ from .diagnostics import diagnostic_log
 
 import os
 import json
+import re
 import sqlite3
 
 from .store_unit_of_work import gateway_store_write_transaction
@@ -6247,14 +6248,24 @@ class GatewayStateStore:
                     effect_id, attempt, claim_revision, lease_epoch, pipeline_version,
                     state, ticket_id, ticket_sha256, grant_sha256, nonce_sha256,
                     claimed_at_ms, side_effect_started_at_ms, terminal_at_ms, terminal_kind
-                ) VALUES (?, 1, 1, NULL, NULL, 'CLAIMED', NULL, NULL, NULL, NULL, ?, NULL, NULL, NULL)
+                ) VALUES (?, ?, ?, ?, ?, 'CLAIMED', NULL, NULL, NULL, NULL, ?, NULL, NULL, NULL)
                 """,
-                (claim.effect_id, claim.claimed_at_ms),
+                (
+                    claim.effect_id,
+                    claim.attempt,
+                    claim.claim_revision,
+                    claim.lease_epoch,
+                    claim.pipeline_version,
+                    claim.claimed_at_ms,
+                ),
             )
             claim_payload = json.loads(claim_json)
             claim_payload["action_fence_epoch"] = int(self._action_fence_row_locked()["action_fence_epoch"])
             self._append_effect_fact_locked(
-                effect_id=claim.effect_id, attempt=1, fact_kind="CLAIM", verdict=None,
+                effect_id=claim.effect_id,
+                attempt=claim.attempt,
+                fact_kind="CLAIM",
+                verdict=None,
                 payload=claim_payload, created_at_ms=claim.claimed_at_ms,
             )
             return _effect_record_from_row(row), True
@@ -6314,6 +6325,53 @@ class GatewayStateStore:
             ).fetchall()
             return tuple(_effect_record_from_row(row) for row in rows)
 
+    def list_effects_for_pipeline(
+        self,
+        pipeline_version: str,
+        *,
+        states: tuple[str, ...] = (
+            "CLAIMED",
+            "SIDE_EFFECT_STARTED",
+            "SUCCEEDED",
+            "FAILED_FINAL",
+            "AMBIGUOUS",
+            "RECONCILED",
+        ),
+    ) -> tuple[EffectLedgerRecord, ...]:
+        """Read Effect heads whose immutable claim belongs to one pipeline."""
+
+        valid_states = {
+            "CLAIMED",
+            "SIDE_EFFECT_STARTED",
+            "SUCCEEDED",
+            "FAILED_FINAL",
+            "AMBIGUOUS",
+            "RECONCILED",
+        }
+        if (
+            not isinstance(pipeline_version, str)
+            or not pipeline_version
+            or len(pipeline_version) > 160
+            or not states
+            or set(states) - valid_states
+        ):
+            raise ValueError("effect pipeline query is invalid")
+        with self._lock:
+            if self._closed:
+                raise StoreError("gateway store is closed")
+            placeholders = ",".join("?" for _ in states)
+            rows = self._connection.execute(
+                f"SELECT * FROM effect_ledger WHERE state IN ({placeholders}) "
+                "ORDER BY claimed_at_ms, effect_id",
+                states,
+            ).fetchall()
+            records = tuple(_effect_record_from_row(row) for row in rows)
+            return tuple(
+                record
+                for record in records
+                if record.claim.pipeline_version == pipeline_version
+            )
+
     def list_started_execution_effects_for_request(
         self,
         request_id: str,
@@ -6366,20 +6424,33 @@ class GatewayStateStore:
                 """,
                 (effect_id,),
             ).fetchone()
-            anchor_epoch = 0
-            if claim_fact is not None:
-                try:
-                    anchor_epoch = int(json.loads(claim_fact["payload_json"]).get("action_fence_epoch") or 0)
-                except Exception as exc:
-                    # 读损坏 fail-closed：CLAIM fact 半写/损坏时静默当作
-                    # epoch 0 放行，等于把 fence 锚点校验整体架空。
-                    raise StoreCorruptionError(
-                        f"effect claim fact payload is corrupt: {effect_id}"
-                    ) from exc
-            current_epoch = int(self._action_fence_row_locked()["action_fence_epoch"])
-            if current_epoch != anchor_epoch:
+            if claim_fact is None:
+                raise StoreCorruptionError(
+                    f"effect claim fact is missing: {effect_id}"
+                )
+            try:
+                anchor_epoch = int(
+                    json.loads(claim_fact["payload_json"]).get(
+                        "action_fence_epoch"
+                    )
+                    or 0
+                )
+            except Exception as exc:
+                # 读损坏 fail-closed：CLAIM fact 半写/损坏时静默当作
+                # epoch 0 放行，等于把 fence 锚点校验整体架空。
+                raise StoreCorruptionError(
+                    f"effect claim fact payload is corrupt: {effect_id}"
+                ) from exc
+            action_fence = self._action_fence_row_locked()
+            current_epoch = int(action_fence["action_fence_epoch"])
+            if (
+                current_epoch != anchor_epoch
+                or current_epoch != 0
+                or bool(action_fence["draining"])
+            ):
                 raise StoreConflictError(
-                    f"action fence epoch advanced since claim: {anchor_epoch} -> {current_epoch}"
+                    "action fence is closed for effect start: "
+                    f"claim epoch {anchor_epoch}, current {current_epoch}"
                 )
             updated = self._connection.execute(
                 """
@@ -6413,9 +6484,23 @@ class GatewayStateStore:
                 ).fetchone()
             )
 
-    def complete_effect(self, result: EffectResult) -> EffectLedgerRecord:
+    def complete_effect(
+        self,
+        result: EffectResult,
+        *,
+        expected_state: Literal["CLAIMED", "SIDE_EFFECT_STARTED"] | None = None,
+        release_dispatch_permit: bool = True,
+    ) -> EffectLedgerRecord:
         if not result.has_valid_sha256():
             raise ValueError("effect result digest is invalid")
+        if expected_state not in {None, "CLAIMED", "SIDE_EFFECT_STARTED"}:
+            raise ValueError("effect expected state is invalid")
+        if type(release_dispatch_permit) is not bool:
+            raise ValueError("effect dispatch permit release flag is invalid")
+        if not release_dispatch_permit and result.status != "AMBIGUOUS":
+            raise ValueError(
+                "retaining an effect dispatch permit requires an ambiguous result"
+            )
         result_json, result_digest = _effect_model_payload(result)
         with self._lock, self._write_transaction():
             row = self._connection.execute(
@@ -6428,6 +6513,8 @@ class GatewayStateStore:
                 if record.result != result:
                     raise StoreConflictError("effect already has a different first result")
                 return record
+            if expected_state is not None and record.state != expected_state:
+                raise StoreConflictError("effect crossed its expected completion state")
             if result.observed_at_ms < (record.side_effect_started_at_ms or record.claim.claimed_at_ms):
                 raise ValueError("effect result predates its durable boundary")
             if result.status in {"SUCCEEDED", "AMBIGUOUS", "RECONCILED"} and record.state != "SIDE_EFFECT_STARTED":
@@ -6477,7 +6564,7 @@ class GatewayStateStore:
                 """,
                 (result.effect_id,),
             ).fetchone()
-            if open_permit is not None:
+            if open_permit is not None and release_dispatch_permit:
                 self._connection.execute(
                     """
                     UPDATE action_fence
@@ -6501,16 +6588,32 @@ class GatewayStateStore:
                 ).fetchone()
             )
 
-    def recover_started_effects(self, *, now_ms: int) -> tuple[EffectLedgerRecord, ...]:
+    def recover_started_effects(
+        self,
+        *,
+        now_ms: int,
+        exclude_pipeline_versions: tuple[str, ...] = (),
+    ) -> tuple[EffectLedgerRecord, ...]:
         # V14：先把 attempt 层 STARTED 标记为 RECONCILE_REQUIRED + INCONCLUSIVE
-        self.recover_started_attempts(now_ms=now_ms)
+        self.recover_started_attempts(
+            now_ms=now_ms,
+            exclude_pipeline_versions=exclude_pipeline_versions,
+        )
         with self._lock:
             rows = self._connection.execute(
                 "SELECT * FROM effect_ledger WHERE state = 'SIDE_EFFECT_STARTED' ORDER BY effect_id"
             ).fetchall()
         recovered = []
         for row in rows:
-            claim = _effect_record_from_row(row).claim
+            record = _effect_record_from_row(row)
+            claim = record.claim
+            if claim.pipeline_version in exclude_pipeline_versions:
+                continue
+            recovered_at_ms = max(
+                now_ms,
+                record.side_effect_started_at_ms
+                or record.claim.claimed_at_ms,
+            )
             if str(claim.owner_component_id) == "tiangong-backend":
                 # The gateway's own execution wrapper never recorded a terminal
                 # result, which is provable: no terminal fact exists.  Finalize
@@ -6531,7 +6634,7 @@ class GatewayStateStore:
                     fact_id="fact_effect_interrupted_" + claim.effect_id[4:20],
                     evidence_sha256=evidence,
                     error_code="effect.execution_interrupted_by_restart",
-                    observed_at_ms=now_ms,
+                    observed_at_ms=recovered_at_ms,
                     result_sha256="0" * 64,
                 ).with_computed_sha256()
             else:
@@ -6549,7 +6652,7 @@ class GatewayStateStore:
                     fact_id="fact_effect_recovery_" + claim.effect_id[4:20],
                     evidence_sha256=evidence,
                     error_code="effect.result_missing_after_restart",
-                    observed_at_ms=now_ms,
+                    observed_at_ms=recovered_at_ms,
                     result_sha256="0" * 64,
                 ).with_computed_sha256()
             recovered.append(self.complete_effect(result))
@@ -8029,6 +8132,12 @@ class GatewayStateStore:
         ticket_id: str | None = None,
         ticket_sha256: str | None = None,
         grant_sha256: str | None = None,
+        expected_request_id: str | None = None,
+        expected_run_id: str | None = None,
+        expected_generation: int | None = None,
+        expected_gateway_epoch: int | None = None,
+        expected_owner_instance_id: str | None = None,
+        required_parent_effect_id: str | None = None,
         now_ms: int,
     ) -> dict:
         """dispatch CAS（与 action_fence_epoch 同一事务、同一 store 行）。
@@ -8036,18 +8145,91 @@ class GatewayStateStore:
         stop 先提交则 epoch 已变 → 拒绝（handler=0）；dispatch 先提交则该 attempt
         按"可能已施加"对账。STARTED 与 dispatch fact 在此同事务持久化（先发前记）。
         """
+        scoped_values = (
+            expected_request_id,
+            expected_run_id,
+            expected_generation,
+            expected_gateway_epoch,
+            expected_owner_instance_id,
+            required_parent_effect_id,
+        )
+        if any(value is not None for value in scoped_values) and any(
+            value is None for value in scoped_values
+        ):
+            raise ValueError("dispatch generation scope is incomplete")
         with self._lock, self._write_transaction():
             fence = self._action_fence_row_locked()
             epoch = int(fence["action_fence_epoch"])
-            if epoch != expected_fence_epoch:
+            if (
+                epoch != expected_fence_epoch
+                or epoch != 0
+                or bool(fence["draining"])
+            ):
                 raise StoreConflictError(
-                    f"action fence epoch advanced: ticket epoch {expected_fence_epoch} < current {epoch}"
+                    "action fence is closed for dispatch: "
+                    f"ticket epoch {expected_fence_epoch}, current {epoch}"
                 )
             row = self._get_effect_attempt_locked(effect_id, attempt)
             if row is None:
                 raise StoreNotFoundError("dispatch target attempt is missing")
             if row["state"] != "CLAIMED":
                 raise StoreConflictError("dispatch permit requires a pre-start claim")
+            if expected_request_id is not None:
+                generation_row = self._connection.execute(
+                    "SELECT * FROM request_generation WHERE request_id = ?",
+                    (expected_request_id,),
+                ).fetchone()
+                if generation_row is None:
+                    raise StoreConflictError(
+                        "dispatch request generation is missing"
+                    )
+                generation_view = _generation_view(
+                    self._connection, generation_row
+                )
+                fence_row = self._connection.execute(
+                    "SELECT state FROM generation_fences WHERE fence_id = ?",
+                    (generation_row["current_fence_id"],),
+                ).fetchone()
+                if fence_row is None:
+                    raise StoreCorruptionError(
+                        "request generation references a missing fence"
+                    )
+                if (
+                    generation_view.run_id != expected_run_id
+                    or generation_view.generation != expected_generation
+                    or generation_view.gateway_epoch != expected_gateway_epoch
+                    or generation_view.owner_instance_id
+                    != expected_owner_instance_id
+                    or generation_view.status != "ACTIVE"
+                    or generation_view.lease_id is None
+                    or fence_row["state"] != "ACTIVE"
+                    or now_ms > generation_view.fence.expires_at_ms
+                    or row["lease_epoch"] != expected_gateway_epoch
+                ):
+                    raise StoreConflictError(
+                        "dispatch request generation is no longer active"
+                    )
+                parent_row = self._connection.execute(
+                    "SELECT * FROM effect_ledger WHERE effect_id = ?",
+                    (required_parent_effect_id,),
+                ).fetchone()
+                if parent_row is None:
+                    raise StoreConflictError(
+                        "dispatch parent effect is missing"
+                    )
+                parent = _effect_record_from_row(parent_row)
+                if (
+                    parent.state != "SUCCEEDED"
+                    or parent.result is None
+                    or parent.result.status != "SUCCEEDED"
+                    or parent.claim.effect_kind != "execution"
+                    or parent.claim.request_id != expected_request_id
+                    or parent.claim.run_id != expected_run_id
+                    or parent.claim.generation != expected_generation
+                ):
+                    raise StoreConflictError(
+                        "dispatch parent effect is not successful"
+                    )
             updated = self._connection.execute(
                 """
                 UPDATE effect_attempts
@@ -8100,6 +8282,200 @@ class GatewayStateStore:
             )
             return {"fence_epoch": epoch, "started_fact": started}
 
+    def consume_composition_handler_permit(
+        self,
+        *,
+        effect_id: str,
+        ticket_id: str,
+        ticket_nonce: str,
+        ticket_sha256: str,
+        grant_nonce: str,
+        grant_sha256: str,
+        gateway_epoch: int,
+        expected_ticket_consumer_instance_id: str,
+        handler_consumer_instance_id: str,
+        now_ms: int,
+    ) -> dict:
+        """Admit the private composition handler exactly once.
+
+        ``acquire_dispatch_permit`` durably crosses the Effect boundary and
+        ``BackendClient`` consumes the execution-ticket nonce before transport.
+        The embedded runtime calls this method immediately before Omni Body.
+        It rebinds both facts to the immutable P7C receipt and consumes the
+        grant nonce in the same transaction, so the generic in-process service
+        port cannot replay or self-authorize the private route.
+        """
+
+        identities = (
+            effect_id,
+            ticket_id,
+            ticket_nonce,
+            grant_nonce,
+            expected_ticket_consumer_instance_id,
+            handler_consumer_instance_id,
+        )
+        if (
+            any(not isinstance(value, str) or not value for value in identities)
+            or re.fullmatch(r"eff_[0-9a-f]{64}", effect_id) is None
+            or any(len(value) > 240 for value in identities)
+            or any(
+                re.fullmatch(r"[0-9a-f]{64}", value or "") is None
+                for value in (ticket_sha256, grant_sha256)
+            )
+            or type(gateway_epoch) is not int
+            or gateway_epoch < 1
+            or type(now_ms) is not int
+            or now_ms < 0
+        ):
+            raise ValueError("composition handler permit arguments are invalid")
+
+        with self._lock, self._write_transaction():
+            authorization_row = self._connection.execute(
+                "SELECT * FROM composition_step_authorization "
+                "WHERE prebound_effect_id = ?",
+                (effect_id,),
+            ).fetchone()
+            if authorization_row is None:
+                raise StoreConflictError(
+                    "composition handler authorization is missing"
+                )
+            try:
+                authorization = authorization_record_from_row(
+                    authorization_row
+                )
+                _verify_composition_step_authorization_authorities(
+                    self._connection,
+                    authorization,
+                )
+                restored = authorization.artifacts.restore_contracts()
+                stored_ticket = restored[3]
+                stored_grant = restored[4]
+            except (TypeError, ValueError) as exc:
+                raise StoreCorruptionError(
+                    "stored composition handler authorization is invalid"
+                ) from exc
+
+            request = authorization.request
+            expected_ticket_sha256 = canonical_sha256(
+                stored_ticket.model_dump(mode="json")
+            )
+            expected_grant_sha256 = canonical_sha256(
+                stored_grant.model_dump(mode="json")
+            )
+            if (
+                stored_ticket.payload.ticket_id != ticket_id
+                or stored_ticket.payload.nonce != ticket_nonce
+                or stored_ticket.payload.effect_id != effect_id
+                or stored_ticket.payload.gateway_epoch != gateway_epoch
+                or stored_grant.payload.ticket_id != ticket_id
+                or stored_grant.payload.nonce != grant_nonce
+                or stored_grant.payload.effect_id != effect_id
+                or stored_grant.payload.gateway_epoch != gateway_epoch
+                or ticket_sha256 != expected_ticket_sha256
+                or grant_sha256 != expected_grant_sha256
+                or now_ms > stored_grant.payload.expires_at_ms
+            ):
+                raise StoreConflictError(
+                    "composition handler authority does not match its receipt"
+                )
+
+            attempt_row = self._get_effect_attempt_locked(
+                effect_id,
+                request.attempt,
+            )
+            head_row = self._connection.execute(
+                "SELECT * FROM effect_ledger WHERE effect_id = ?",
+                (effect_id,),
+            ).fetchone()
+            if attempt_row is None or head_row is None:
+                raise StoreConflictError(
+                    "composition handler Effect permit is missing"
+                )
+            head = _effect_record_from_row(head_row)
+            expected_nonce_sha256 = canonical_sha256(
+                {
+                    "execution_ticket_nonce": ticket_nonce,
+                    "omni_grant_nonce": grant_nonce,
+                }
+            )
+            if (
+                attempt_row["state"] != "SIDE_EFFECT_STARTED"
+                or head.state != "SIDE_EFFECT_STARTED"
+                or head.claim.pipeline_version
+                != "tiangong.composition-step-authorization.v1"
+                or head.claim.attempt != request.attempt
+                or head.claim.claim_revision != attempt_row["claim_revision"]
+                or head.claim.lease_epoch != gateway_epoch
+                or head.claim.request_id != request.request_id
+                or head.claim.run_id != request.run_id
+                or head.claim.generation != request.generation
+                or attempt_row["ticket_id"] != ticket_id
+                or attempt_row["ticket_sha256"] != ticket_sha256
+                or attempt_row["grant_sha256"] != grant_sha256
+                or attempt_row["nonce_sha256"] != expected_nonce_sha256
+            ):
+                raise StoreConflictError(
+                    "composition handler Effect permit is not current"
+                )
+
+            consumed_ticket = self._connection.execute(
+                """
+                SELECT * FROM security_nonce_ledger
+                WHERE issuer = 'tiangong-total-gateway'
+                  AND audience = 'tiangong-backend'
+                  AND purpose = 'execution_ticket'
+                  AND nonce = ?
+                """,
+                (ticket_nonce,),
+            ).fetchone()
+            if (
+                consumed_ticket is None
+                or consumed_ticket["payload_sha256"] != ticket_sha256
+                or consumed_ticket["gateway_epoch"] != gateway_epoch
+                or consumed_ticket["consumer_instance_id"]
+                != expected_ticket_consumer_instance_id
+                or consumed_ticket["consumed_at_ms"]
+                < int(attempt_row["side_effect_started_at_ms"] or 0)
+                or consumed_ticket["consumed_at_ms"] > now_ms
+                or consumed_ticket["expires_at_ms"]
+                != stored_ticket.payload.expires_at_ms
+                or now_ms > stored_ticket.payload.expires_at_ms
+            ):
+                raise StoreConflictError(
+                    "composition execution ticket was not consumed by this dispatch"
+                )
+
+            try:
+                self._connection.execute(
+                    """
+                    INSERT INTO security_nonce_ledger(
+                        issuer, audience, purpose, nonce, payload_sha256,
+                        gateway_epoch, consumer_instance_id, consumed_at_ms,
+                        expires_at_ms
+                    ) VALUES (
+                        'tiangong-total-gateway', 'tiangong-backend',
+                        'omni_capability_grant', ?, ?, ?, ?, ?, ?
+                    )
+                    """,
+                    (
+                        grant_nonce,
+                        grant_sha256,
+                        gateway_epoch,
+                        handler_consumer_instance_id,
+                        now_ms,
+                        stored_grant.payload.expires_at_ms,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise StoreConflictError(
+                    "composition handler grant nonce was already consumed"
+                ) from exc
+            return {
+                "effect_id": effect_id,
+                "attempt": request.attempt,
+                "handler_consumer_instance_id": handler_consumer_instance_id,
+            }
+
     def release_dispatch_permit(self, *, effect_id: str, attempt: int, now_ms: int) -> None:
         """attempt 收尾：inflight 归还（receipt 落地后调用）。
 
@@ -8150,7 +8526,79 @@ class GatewayStateStore:
                 (effect_id, attempt, now_ms),
             )
 
-    def recover_started_attempts(self, *, now_ms: int) -> tuple[dict, ...]:
+    def recover_terminal_dispatch_permits(
+        self,
+        *,
+        pipeline_version: str,
+        now_ms: int,
+    ) -> tuple[dict[str, object], ...]:
+        """Release terminal permits whose in-process handler died with its process.
+
+        A composition timeout may terminalize its Effect as ``AMBIGUOUS`` while
+        retaining the permit until the still-running Future exits.  If the
+        process dies first, no handler survives the single-instance restart;
+        the missing release row is therefore safe to reconcile at startup.
+        """
+
+        if (
+            not isinstance(pipeline_version, str)
+            or not pipeline_version
+            or len(pipeline_version) > 160
+            or type(now_ms) is not int
+            or now_ms < 0
+        ):
+            raise ValueError("terminal dispatch permit recovery scope is invalid")
+        with self._lock:
+            if self._closed:
+                raise StoreError("gateway store is closed")
+            rows = self._connection.execute(
+                """
+                SELECT a.effect_id, a.attempt, a.side_effect_started_at_ms,
+                       a.terminal_at_ms
+                FROM effect_attempts a
+                WHERE a.pipeline_version = ?
+                  AND a.state IN ('SUCCEEDED','FAILED_FINAL','AMBIGUOUS','RECONCILED')
+                  AND EXISTS (
+                      SELECT 1 FROM effect_facts f
+                      WHERE f.effect_id = a.effect_id
+                        AND f.attempt = a.attempt
+                        AND f.fact_kind = 'DISPATCH_PERMIT'
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM dispatch_permit_release r
+                      WHERE r.effect_id = a.effect_id
+                        AND r.attempt = a.attempt
+                  )
+                ORDER BY a.effect_id, a.attempt
+                """,
+                (pipeline_version,),
+            ).fetchall()
+        recovered: list[dict[str, object]] = []
+        for row in rows:
+            released_at_ms = max(
+                now_ms,
+                int(row["side_effect_started_at_ms"] or 0),
+                int(row["terminal_at_ms"] or 0),
+            )
+            self.release_dispatch_permit(
+                effect_id=str(row["effect_id"]),
+                attempt=int(row["attempt"]),
+                now_ms=released_at_ms,
+            )
+            recovered.append(
+                {
+                    "effect_id": str(row["effect_id"]),
+                    "attempt": int(row["attempt"]),
+                }
+            )
+        return tuple(recovered)
+
+    def recover_started_attempts(
+        self,
+        *,
+        now_ms: int,
+        exclude_pipeline_versions: tuple[str, ...] = (),
+    ) -> tuple[dict, ...]:
         """启动恢复：SIDE_EFFECT_STARTED 的 attempt 标记 RECONCILE_REQUIRED 并落 INCONCLUSIVE。
 
         只读对账由协调方随后用 record_effect_reconciliation 推进；
@@ -8158,10 +8606,18 @@ class GatewayStateStore:
         """
         with self._lock:
             rows = self._connection.execute(
-                "SELECT effect_id, attempt FROM effect_attempts WHERE state = 'SIDE_EFFECT_STARTED' ORDER BY effect_id, attempt"
+                "SELECT effect_id, attempt, pipeline_version, claimed_at_ms, "
+                "side_effect_started_at_ms FROM effect_attempts "
+                "WHERE state = 'SIDE_EFFECT_STARTED' ORDER BY effect_id, attempt"
             ).fetchall()
         recovered = []
         for row in rows:
+            if row["pipeline_version"] in exclude_pipeline_versions:
+                continue
+            recovered_at_ms = max(
+                now_ms,
+                int(row["side_effect_started_at_ms"] or row["claimed_at_ms"]),
+            )
             with self._lock, self._write_transaction():
                 self._connection.execute(
                     """
@@ -8178,7 +8634,7 @@ class GatewayStateStore:
                         "reason": "started_attempt_missing_terminal_fact_after_restart",
                         "note": "进入只读对账；APPLIED/PROVEN_NOT_APPLIED 结论须由动作专属证据适配器给出",
                     },
-                    created_at_ms=now_ms,
+                    created_at_ms=recovered_at_ms,
                 )
                 recovered.append({"effect_id": row["effect_id"], "attempt": row["attempt"]})
         return tuple(recovered)
@@ -8188,7 +8644,12 @@ class GatewayStateStore:
         *,
         issuer: str,
         audience: str,
-        purpose: Literal["execution_ticket", "delivery_ticket", "service_auth"],
+        purpose: Literal[
+            "execution_ticket",
+            "delivery_ticket",
+            "service_auth",
+            "omni_capability_grant",
+        ],
         nonce: str,
         payload_sha256: str,
         gateway_epoch: int,
@@ -15011,6 +15472,53 @@ class GatewayStateStore:
             )
             return record
 
+    def get_executable_composition_plan_for_request(
+        self,
+        request_id: str,
+        *,
+        run_id: str,
+        generation: int,
+    ) -> ExecutableCompositionPlanStoreRecord | None:
+        """Return an immutable plan obligation for one exact request lineage.
+
+        Unlike ``get_active_executable_composition_plan``, this read does not
+        hide an expired plan.  Once a request has a durable executable-plan
+        companion, an expired or otherwise non-dispatchable authorization is
+        still an obligation that must fail closed before delivery; it must not
+        be mistaken for a request that never had composition work.
+        """
+
+        if (
+            not isinstance(request_id, str)
+            or not request_id
+            or not isinstance(run_id, str)
+            or not run_id
+            or type(generation) is not int
+            or generation < 0
+        ):
+            raise ValueError("composition request lineage is invalid")
+        with self._lock:
+            if self._closed:
+                raise StoreError("gateway store is closed")
+            row = self._connection.execute(
+                "SELECT * FROM composition_executable_plan "
+                "WHERE request_id = ? AND run_id = ? AND generation = ?",
+                (request_id, run_id, generation),
+            ).fetchone()
+            if row is None:
+                _assert_no_required_executable_plan_missing(self._connection)
+                return None
+            try:
+                record = executable_plan_record_from_row(row)
+            except ValueError as exc:
+                raise StoreCorruptionError(
+                    "stored executable composition plan is invalid"
+                ) from exc
+            _verify_executable_composition_plan_authorities(
+                self._connection, record
+            )
+            return record
+
     def get_active_executable_composition_plan(
         self, registration_id: str, *, now_ms: int
     ) -> ExecutableCompositionPlanStoreRecord | None:
@@ -15632,6 +16140,44 @@ class GatewayStateStore:
                 "SELECT * FROM composition_step_authorization "
                 "WHERE executable_plan_id = ? AND step_id = ? AND attempt = ?",
                 (executable_plan_id, step_id, attempt),
+            ).fetchone()
+            if row is None:
+                return None
+            try:
+                record = authorization_record_from_row(row)
+            except ValueError as exc:
+                raise StoreCorruptionError(
+                    "stored composition step authorization is invalid"
+                ) from exc
+            _verify_composition_step_authorization_authorities(
+                self._connection, record
+            )
+            if now_ms is not None:
+                _assert_live_composition_step_authorization_locked(
+                    self._connection, record, now_ms=now_ms
+                )
+            return record
+
+    def get_composition_step_authorization_for_effect(
+        self,
+        effect_id: str,
+        *,
+        now_ms: int | None = None,
+    ) -> CompositionStepAuthorizationStoreRecord | None:
+        """Resolve the unique persisted composition receipt for an Effect."""
+
+        if (
+            not isinstance(effect_id, str)
+            or re.fullmatch(r"eff_[0-9a-f]{64}", effect_id) is None
+        ):
+            raise ValueError("composition authorization effect identity is invalid")
+        with self._lock:
+            if self._closed:
+                raise StoreError("gateway store is closed")
+            row = self._connection.execute(
+                "SELECT * FROM composition_step_authorization "
+                "WHERE prebound_effect_id = ?",
+                (effect_id,),
             ).fetchone()
             if row is None:
                 return None

--- a/src/total_gateway/verification_plane.py
+++ b/src/total_gateway/verification_plane.py
@@ -10,6 +10,6 @@ fails with VERIFICATION_PLANE_FREEZE_CHANGED otherwise).
 
 from __future__ import annotations
 
-VERIFICATION_PLANE_VERSION = "1.3"
+VERIFICATION_PLANE_VERSION = "1.4"
 
 __all__ = ["VERIFICATION_PLANE_VERSION"]

--- a/tests/golden/p19_r2/test_freeze_and_guards.py
+++ b/tests/golden/p19_r2/test_freeze_and_guards.py
@@ -7,7 +7,7 @@ Guards (M6 §7/§8) — enforced with AST/contract scans:
 - exactly ONE store schema authority constant
 - CompletionDecision construction lives ONLY in completion_gate.py
 - no standalone repair runtime/daemon entry point
-- the single Verification Plane version source exists and is "1.3"
+- the single Verification Plane version source exists and is "1.4"
 
 Freeze guard (M6 §23/§24): the freeze manifest records the authority
 surface hashes; any change fails with VERIFICATION_PLANE_FREEZE_CHANGED
@@ -149,12 +149,12 @@ class ArchitectureGuardTests(unittest.TestCase):
             VERIFICATION_PLANE_VERSION,
         )
 
-        self.assertEqual(VERIFICATION_PLANE_VERSION, "1.3")
+        self.assertEqual(VERIFICATION_PLANE_VERSION, "1.4")
         # the literal must appear in exactly ONE src module
         holders = [
             path.relative_to(ROOT)
             for path in _iter_py_files()
-            if '"1.3"' in (
+            if '"1.4"' in (
                 path.read_text(encoding="utf-8")
             )
             and path.name == "verification_plane.py"
@@ -182,7 +182,7 @@ class VerificationPlaneFreezeGuardTests(unittest.TestCase):
         )
         return {
             "verification_plane_version": VERIFICATION_PLANE_VERSION,
-            "baseline_sha": "b75d0c8aec926e18bebbf92938ded423b44a8016",
+            "baseline_sha": "acb39a63bd267b5db1b9c0b7076110c5391704c8",
             "store_schema_version": STORE_SCHEMA_VERSION,
             "contract_schema_versions": {
                 "verification": sha(
@@ -211,7 +211,7 @@ class VerificationPlaneFreezeGuardTests(unittest.TestCase):
             "authority_surface_sha256": self._authority_surface(),
         }
 
-    #: The authority surface frozen at 1.3.
+    #: The authority surface frozen at 1.4.
     AUTHORITY_SURFACE_FILES = (
         "src/total_gateway/store.py",
         "src/total_gateway/store_unit_of_work.py",

--- a/tests/golden/p19_r2/test_golden_trace.py
+++ b/tests/golden/p19_r2/test_golden_trace.py
@@ -447,9 +447,17 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
         self.assertEqual(len(bindings), 2)
 
     def test_g11_crash_before_boundary(self) -> None:
+        import time as _time
+
+        # Keep the pre-crash disposition observably earlier than the resumed
+        # loop.  A wall-clock millisecond collision otherwise makes the two
+        # deterministic disposition identities collapse on fast runners.
+        crash_snapshot_ms = _time.time_ns() // 1_000_000 - 1_000
         readiness = self._reverify()
         dispositions = self.coordinator.process_readiness(
-            plan=self.plan, readiness=readiness
+            plan=self.plan,
+            readiness=readiness,
+            now_ms=crash_snapshot_ms,
         )
         evidence = (
             self.gateway_store.get_verification_failure_evidence_by_id(
@@ -460,6 +468,7 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
             disposition=dispositions[0],
             failure_evidence=evidence,
             plan=self.plan,
+            now_ms=crash_snapshot_ms,
         )
         # CRASH: directive persisted, no binding, runtime never entered.
 
@@ -1324,9 +1333,17 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
         self.assertEqual(len(bindings), 2)
 
     def test_g11_crash_before_boundary(self) -> None:
+        import time as _time
+
+        # Keep the pre-crash disposition observably earlier than the resumed
+        # loop.  A wall-clock millisecond collision otherwise makes the two
+        # deterministic disposition identities collapse on fast runners.
+        crash_snapshot_ms = _time.time_ns() // 1_000_000 - 1_000
         readiness = self._reverify()
         dispositions = self.coordinator.process_readiness(
-            plan=self.plan, readiness=readiness
+            plan=self.plan,
+            readiness=readiness,
+            now_ms=crash_snapshot_ms,
         )
         evidence = (
             self.gateway_store.get_verification_failure_evidence_by_id(
@@ -1337,6 +1354,7 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
             disposition=dispositions[0],
             failure_evidence=evidence,
             plan=self.plan,
+            now_ms=crash_snapshot_ms,
         )
         # CRASH: directive persisted, no binding, runtime never entered.
 
@@ -2157,9 +2175,17 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
         self.assertEqual(len(bindings), 2)
 
     def test_g11_crash_before_boundary(self) -> None:
+        import time as _time
+
+        # Keep the pre-crash disposition observably earlier than the resumed
+        # loop.  A wall-clock millisecond collision otherwise makes the two
+        # deterministic disposition identities collapse on fast runners.
+        crash_snapshot_ms = _time.time_ns() // 1_000_000 - 1_000
         readiness = self._reverify()
         dispositions = self.coordinator.process_readiness(
-            plan=self.plan, readiness=readiness
+            plan=self.plan,
+            readiness=readiness,
+            now_ms=crash_snapshot_ms,
         )
         evidence = (
             self.gateway_store.get_verification_failure_evidence_by_id(
@@ -2170,6 +2196,7 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
             disposition=dispositions[0],
             failure_evidence=evidence,
             plan=self.plan,
+            now_ms=crash_snapshot_ms,
         )
         # CRASH: directive persisted, no binding, runtime never entered.
 
@@ -2994,9 +3021,17 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
         self.assertEqual(len(bindings), 2)
 
     def test_g11_crash_before_boundary(self) -> None:
+        import time as _time
+
+        # Keep the pre-crash disposition observably earlier than the resumed
+        # loop.  A wall-clock millisecond collision otherwise makes the two
+        # deterministic disposition identities collapse on fast runners.
+        crash_snapshot_ms = _time.time_ns() // 1_000_000 - 1_000
         readiness = self._reverify()
         dispositions = self.coordinator.process_readiness(
-            plan=self.plan, readiness=readiness
+            plan=self.plan,
+            readiness=readiness,
+            now_ms=crash_snapshot_ms,
         )
         evidence = (
             self.gateway_store.get_verification_failure_evidence_by_id(
@@ -3007,6 +3042,7 @@ class GoldenArtifactCase(_GoldenArtifactFixture):
             disposition=dispositions[0],
             failure_evidence=evidence,
             plan=self.plan,
+            now_ms=crash_snapshot_ms,
         )
         # CRASH: directive persisted, no binding, runtime never entered.
 

--- a/tests/test_avatar_p2b_transport.test.mjs
+++ b/tests/test_avatar_p2b_transport.test.mjs
@@ -58,12 +58,13 @@ async function drainGateFully(gate, { isSettled = null, timeoutMs = 2_000 } = {}
 
 // 等待 gate 积累至少 count 条消息（宿主的 open/stat/read 是异步 I/O，
 // 全量运行时事件轮时序不可假设，禁止用固定 flush 轮数赌时序）。
-async function waitForGate(gate, count, rounds = 200) {
-  for (let i = 0; i < rounds; i += 1) {
+async function waitForGate(gate, count, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
     if (gate.pending >= count) return;
     await new Promise((resolve) => setImmediate(resolve));
   }
-  throw new Error(`gate 未在预期内积累 ${count} 条消息（当前 ${gate.pending}）`);
+  throw new Error(`gate 未在 ${timeoutMs}ms 内积累 ${count} 条消息（当前 ${gate.pending}）`);
 }
 
 // 错误一律按 code 断言（message 是诊断文本，不是契约）。

--- a/tests/test_composition_activation_store_p7b2.py
+++ b/tests/test_composition_activation_store_p7b2.py
@@ -181,7 +181,7 @@ def test_p7b2_explicitly_advances_store_and_p19_compatibility() -> None:
     # P7C.1 adds the current v32 authorization receipt.  Neither later layer
     # changes P7B eligibility semantics.
     assert STORE_SCHEMA_VERSION == 32
-    assert VERIFICATION_PLANE_VERSION == "1.3"
+    assert VERIFICATION_PLANE_VERSION == "1.4"
 
 
 def test_v29_store_migrates_additively_through_v30_to_current() -> None:

--- a/tests/test_composition_backend_transport_p7d1.py
+++ b/tests/test_composition_backend_transport_p7d1.py
@@ -1,0 +1,1052 @@
+"""P7D.1 composition execution boundary and embedded transport tests.
+
+These tests deliberately stop at the one-step execution boundary.  They do
+not assume a composition scheduler/coordinator API: the already-persisted P7C
+authorization artifacts are restored, rebound to a normal CapabilityManifest,
+and presented directly to BackendClient and the private embedded route.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+from typing import Any, Callable
+from unittest import mock
+
+import pytest
+
+import test_composition_grant_authority_p7c1 as p7c1
+from contracts import (
+    CapabilityAction,
+    CapabilityManifest,
+    CompositionExecutionBindingV1,
+    ExecutionAuthorizationError,
+    ExecutionTicket,
+    OmniCapabilityGrant,
+    canonical_json_bytes,
+    canonical_sha256,
+)
+from tests.test_backend_client import backend_response
+from total_gateway.backend_client import BackendClient, BackendClientError
+from total_gateway.composition_backend_transport import (
+    COMPOSITION_BACKEND_PATH,
+    COMPOSITION_BACKEND_REQUEST_SCHEMA,
+    COMPOSITION_RESULT_PAYLOAD_SCHEMA,
+    CompositionBackendExecutionTransport,
+)
+from total_gateway.embedded_backend import EmbeddedBackendRuntime
+from total_gateway.service_ports import CompatibilityJsonClient
+from total_gateway.store import GatewayStateStore
+
+
+ZERO_SHA256 = "0" * 64
+
+
+@dataclass(frozen=True)
+class AuthorizedComposition:
+    invocation: dict[str, Any]
+    ticket: ExecutionTicket
+    manifest: CapabilityManifest
+    trust: Any
+    grant: OmniCapabilityGrant
+    intent: Any
+    impact: Any
+    decision: Any
+    binding: CompositionExecutionBindingV1
+    runtime: dict[str, Any]
+    signer: Any
+
+
+def _canonical_legacy_json(value: Any) -> bytes:
+    """The strict JSON bytes used to content-address a raw Omni response."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@pytest.fixture(scope="module")
+def authorized_composition(tmp_path_factory: pytest.TempPathFactory) -> AuthorizedComposition:
+    root = tmp_path_factory.mktemp("p7d1-authority")
+    # Use a real, explicitly-schema'd A0 composition action with a non-empty
+    # target.  This makes target and target-snapshot enforcement substantive;
+    # the private route must not special-case only targetless actions.
+    with p7c1._harness(
+        root,
+        action_id="skill.get",
+        target="word_delivery",
+        arguments={},
+    ) as harness:
+        response = p7c1._authorize(harness)
+        persisted = harness.store.get_composition_step_authorization(
+            harness.plan.executable_plan_id,
+            "step.01",
+            now_ms=1_700,
+        )
+        assert persisted is not None
+        intent, impact, decision, ticket, grant = (
+            persisted.artifacts.restore_contracts()
+        )
+        original_binding = ticket.payload.composition_execution_binding
+        assert original_binding is not None
+
+        # The non-empty target is probed by the real P7C authority, so all four
+        # runtime hash inputs include a genuine non-null optimistic snapshot.
+        binding = original_binding
+        assert binding.target_snapshot_sha256 is not None
+
+        action = CapabilityAction(
+            action_id=ticket.payload.action_id,
+            version=ticket.payload.action_version,
+            provider_component_id="tiangong-backend",
+            argument_schema_sha256=ticket.payload.argument_schema_sha256,
+            result_schema_sha256="e" * 64,
+            risk_class=ticket.payload.risk_class,
+            allowed_side_effects=ticket.payload.allowed_side_effects,
+            idempotency_mode="pure",
+            max_runtime_ms=ticket.payload.max_runtime_ms,
+            max_output_bytes=ticket.payload.max_output_bytes,
+            max_tool_calls=ticket.payload.max_tool_calls,
+            available=True,
+        )
+        manifest = CapabilityManifest(
+            manifest_id="composition_execution_manifest_p7d1",
+            revision=1,
+            generated_at_ms=1_700,
+            component_manifest_hash=ticket.payload.component_manifest_hash,
+            actions=(action,),
+            sha256=ZERO_SHA256,
+        ).with_computed_sha256()
+        decision = decision.model_copy(
+            update={
+                "capability_manifest_hash": manifest.sha256,
+                "decision_sha256": ZERO_SHA256,
+            }
+        ).with_computed_sha256()
+        ticket_payload = ticket.payload.model_copy(
+            update={
+                "capability_manifest_hash": manifest.sha256,
+                "decision_sha256": decision.decision_sha256,
+            }
+        )
+        ticket = harness.signer.sign_execution(ticket_payload)
+        grant_payload = grant.payload.model_copy(
+            update={
+                "ticket_sha256": canonical_sha256(
+                    ticket.payload.model_dump(mode="json")
+                ),
+                "decision_sha256": decision.decision_sha256,
+                "capability_manifest_hash": manifest.sha256,
+            }
+        )
+        grant = harness.signer.sign_omni_capability(grant_payload)
+        invocation = {
+            "action": ticket.payload.action_id,
+            "target": "word_delivery",
+            "args": {},
+        }
+        assert canonical_sha256(invocation) == ticket.payload.arguments_hash
+
+        # P7C persists the fact-kernel-enabled authorization response.  P7D
+        # must dispatch a detached copy with the duplicate fact writer off.
+        assert response["runtime"]["fact_kernel_enabled"] is True
+        runtime = deepcopy(response["runtime"])
+        runtime.update(
+            {
+                "composition_binding_sha256": binding.binding_sha256,
+                "composition_execution_binding": binding.model_dump(mode="json"),
+                "decision_sha256": decision.decision_sha256,
+                "impact_sha256": impact.impact_sha256,
+                "capability_manifest_hash": manifest.sha256,
+                "trust_bundle": harness.trust.model_dump(mode="json"),
+                "trust_bundle_sha256": harness.trust.bundle_sha256,
+                "fact_kernel_enabled": False,
+            }
+        )
+        material = AuthorizedComposition(
+            invocation=invocation,
+            ticket=ticket,
+            manifest=manifest,
+            trust=harness.trust,
+            grant=grant,
+            intent=intent,
+            impact=impact,
+            decision=decision,
+            binding=binding,
+            runtime=runtime,
+            signer=harness.signer,
+        )
+    return material
+
+
+class RecordingTransport:
+    def __init__(
+        self,
+        response: dict[str, object] | None = None,
+        *,
+        error: Exception | None = None,
+        on_execute: Callable[[], None] | None = None,
+    ) -> None:
+        self.response = response
+        self.error = error
+        self.on_execute = on_execute
+        self.calls: list[tuple[bytes, float]] = []
+
+    def execute(self, body: bytes, *, timeout_seconds: float) -> dict[str, object]:
+        self.calls.append((body, timeout_seconds))
+        if self.on_execute is not None:
+            self.on_execute()
+        if self.error is not None:
+            raise self.error
+        assert self.response is not None
+        return self.response
+
+
+class FakeCompatibilityClient:
+    def __init__(
+        self,
+        *,
+        status: int,
+        payload: dict[str, Any],
+        digest: str | None = None,
+    ) -> None:
+        self.status = status
+        self.payload = payload
+        self.digest = digest or hashlib.sha256(
+            _canonical_legacy_json(payload)
+        ).hexdigest()
+        self.calls: list[tuple[str, str, dict[str, Any], dict[str, Any]]] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None,
+        **kwargs: Any,
+    ) -> tuple[int, dict[str, Any], str]:
+        assert payload is not None
+        self.calls.append((method, path, deepcopy(payload), dict(kwargs)))
+        return self.status, deepcopy(self.payload), self.digest
+
+
+def _wire(material: AuthorizedComposition, *, ticket: ExecutionTicket | None = None, invocation=None) -> bytes:
+    selected_ticket = ticket or material.ticket
+    return canonical_json_bytes(
+        {
+            "schema": "tiangong.backend.execute-ticket.v1",
+            "ticket": selected_ticket.model_dump(mode="json"),
+            "arguments": material.invocation if invocation is None else invocation,
+        }
+    )
+
+
+def _private_request(material: AuthorizedComposition) -> dict[str, Any]:
+    return {
+        "schema": COMPOSITION_BACKEND_REQUEST_SCHEMA,
+        "execute_ticket": json.loads(_wire(material)),
+        "capability_grant": material.grant.model_dump(mode="json"),
+        "runtime": deepcopy(material.runtime),
+    }
+
+
+def _nonce_count(store: GatewayStateStore) -> int:
+    return int(
+        store._connection.execute(
+            "SELECT count(*) FROM security_nonce_ledger"
+        ).fetchone()[0]
+    )
+
+
+def _client_execute(
+    client: BackendClient,
+    material: AuthorizedComposition,
+    invocation: dict[str, Any],
+    *,
+    ticket: ExecutionTicket | None = None,
+    grant: OmniCapabilityGrant | None = None,
+    expected_binding: CompositionExecutionBindingV1 | None = None,
+    actual_target_snapshot_sha256: str | None = None,
+    before_dispatch: Callable[[int], None] | None = None,
+    transport_runner: Any = None,
+):
+    return client.execute(
+        ticket or material.ticket,
+        invocation,
+        capability_manifest=material.manifest,
+        trust_bundle=material.trust,
+        now_ms=1_800,
+        expected_gateway_epoch=1,
+        minimum_generation=1,
+        grant=grant or material.grant,
+        intent=material.intent,
+        decision=material.decision,
+        impact=material.impact,
+        expected_composition_binding=expected_binding or material.binding,
+        actual_target_snapshot_sha256=(
+            material.binding.target_snapshot_sha256
+            if actual_target_snapshot_sha256 is None
+            else actual_target_snapshot_sha256
+        ),
+        before_dispatch=before_dispatch,
+        transport_runner=transport_runner,
+    )
+
+
+def _ticket_and_grant_for_invocation(
+    material: AuthorizedComposition,
+    invocation: dict[str, Any],
+) -> tuple[ExecutionTicket, OmniCapabilityGrant]:
+    invocation_sha256 = canonical_sha256(invocation)
+    payload = material.ticket.payload.model_copy(
+        update={"arguments_hash": invocation_sha256}
+    )
+    ticket = material.signer.sign_execution(payload)
+    grant_payload = material.grant.payload.model_copy(
+        update={
+            "arguments_sha256": invocation_sha256,
+            "ticket_sha256": canonical_sha256(payload.model_dump(mode="json")),
+        }
+    )
+    return ticket, material.signer.sign_omni_capability(grant_payload)
+
+
+def _ticket_and_grant_for_output_limit(
+    material: AuthorizedComposition,
+    max_output_bytes: int,
+) -> tuple[ExecutionTicket, OmniCapabilityGrant]:
+    resource_envelope_sha256 = canonical_sha256(
+        {
+            "max_output_bytes": max_output_bytes,
+            "max_runtime_ms": material.ticket.payload.max_runtime_ms,
+            "max_tool_calls": material.ticket.payload.max_tool_calls,
+        }
+    )
+    payload = material.ticket.payload.model_copy(
+        update={
+            "max_output_bytes": max_output_bytes,
+            "resource_envelope_sha256": resource_envelope_sha256,
+        }
+    )
+    ticket = material.signer.sign_execution(payload)
+    grant_payload = material.grant.payload.model_copy(
+        update={
+            "ticket_sha256": canonical_sha256(payload.model_dump(mode="json")),
+        }
+    )
+    return ticket, material.signer.sign_omni_capability(grant_payload)
+
+
+def _alternate_signed_authority(
+    material: AuthorizedComposition,
+) -> tuple[ExecutionTicket, OmniCapabilityGrant, dict[str, Any]]:
+    """Build a valid second ticket/grant/runtime binding for swap attacks."""
+
+    effect_id = "eff_" + "7" * 64
+    binding = material.binding.model_copy(
+        update={
+            "effect_id": effect_id,
+            "binding_sha256": ZERO_SHA256,
+        }
+    ).with_computed_sha256()
+    ticket_payload = material.ticket.payload.model_copy(
+        update={
+            "ticket_id": "execution-ticket-p7d1-alternate",
+            "nonce": "execution-nonce-p7d1-alternate",
+            "effect_id": effect_id,
+            "composition_execution_binding": binding,
+        }
+    )
+    ticket = material.signer.sign_execution(ticket_payload)
+    grant_payload = material.grant.payload.model_copy(
+        update={
+            "grant_id": "omni-grant-p7d1-alternate",
+            "ticket_id": ticket.payload.ticket_id,
+            "ticket_sha256": canonical_sha256(
+                ticket.payload.model_dump(mode="json")
+            ),
+            "effect_id": effect_id,
+            "nonce": "omni-nonce-p7d1-alternate",
+            "composition_execution_binding": binding,
+        }
+    )
+    grant = material.signer.sign_omni_capability(grant_payload)
+    runtime = deepcopy(material.runtime)
+    runtime.update(
+        {
+            "execution_ticket_id": ticket.payload.ticket_id,
+            "effect_id": effect_id,
+            "composition_binding_sha256": binding.binding_sha256,
+            "composition_execution_binding": binding.model_dump(mode="json"),
+        }
+    )
+    return ticket, grant, runtime
+
+
+def test_backend_client_binds_complete_invocation_and_all_four_runtime_hashes(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    store = GatewayStateStore.open(tmp_path / "gateway.sqlite3", now_ms=1_000)
+    callback_events: list[int] = []
+    try:
+        transport = RecordingTransport(
+            backend_response(material.ticket, {"state": "observed"}),
+            on_execute=lambda: (
+                callback_events == [1_800]
+                and _nonce_count(store) == 1
+            )
+            or pytest.fail("transport ran before callback and nonce consumption"),
+        )
+        client = BackendClient(
+            transport,
+            store,
+            ticket_consumer_instance_id="p7d1-composition-consumer",
+        )
+
+        def before_dispatch(now_ms: int) -> None:
+            # Full structural authorization has returned, while neither the
+            # nonce nor the handler/transport boundary has been crossed.
+            assert now_ms == 1_800
+            assert _nonce_count(store) == 0
+            assert transport.calls == []
+            callback_events.append(now_ms)
+
+        response = _client_execute(
+            client,
+            material,
+            material.invocation,
+            before_dispatch=before_dispatch,
+        )
+
+        assert response.result.status == "SUCCEEDED"
+        assert callback_events == [1_800]
+        assert len(transport.calls) == 1
+        wire = json.loads(transport.calls[0][0])
+        assert wire["arguments"] == material.invocation
+        assert set(wire["arguments"]) == {"action", "target", "args"}
+
+        # Four independent execution-time values are bound: the complete
+        # invocation plus its args, target, and optimistic target snapshot.
+        assert canonical_sha256(wire["arguments"]) == material.ticket.payload.arguments_hash
+        assert canonical_sha256(wire["arguments"]["args"]) == material.binding.materialized_arguments_sha256
+        assert canonical_sha256(wire["arguments"]["target"]) == material.binding.target_sha256
+        assert material.binding.target_snapshot_sha256 is not None
+        assert wire["arguments"]["action"] == material.binding.action_id
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize(
+    "drift",
+    ("overall", "shape", "action", "arguments", "target", "target_snapshot", "binding"),
+)
+def test_composition_preflight_drift_has_zero_callback_nonce_and_transport(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+    drift: str,
+) -> None:
+    material = authorized_composition
+    invocation = deepcopy(material.invocation)
+    ticket = material.ticket
+    grant = material.grant
+    expected_binding = material.binding
+    actual_snapshot = material.binding.target_snapshot_sha256
+
+    if drift == "overall":
+        invocation["args"]["skill_id"] = "substituted-skill"
+    elif drift == "shape":
+        invocation["unexpected"] = "caller authority injection"
+        ticket, grant = _ticket_and_grant_for_invocation(material, invocation)
+    elif drift == "action":
+        invocation["action"] = "skill.read"
+        ticket, grant = _ticket_and_grant_for_invocation(material, invocation)
+    elif drift == "arguments":
+        invocation["args"] = {"skill_id": "substituted-skill"}
+        ticket, grant = _ticket_and_grant_for_invocation(material, invocation)
+    elif drift == "target":
+        invocation["target"] = "substituted-target"
+        ticket, grant = _ticket_and_grant_for_invocation(material, invocation)
+    elif drift == "target_snapshot":
+        actual_snapshot = "9" * 64
+    else:
+        expected_binding = material.binding.model_copy(
+            update={
+                "step_id": "step.substituted",
+                "binding_sha256": ZERO_SHA256,
+            }
+        ).with_computed_sha256()
+
+    store = GatewayStateStore.open(tmp_path / f"{drift}.sqlite3", now_ms=1_000)
+    transport = RecordingTransport(backend_response(ticket, {"unexpected": True}))
+    client = BackendClient(
+        transport,
+        store,
+        ticket_consumer_instance_id=f"p7d1-drift-{drift}",
+    )
+    callback_calls: list[int] = []
+    try:
+        with pytest.raises((BackendClientError, ExecutionAuthorizationError)):
+            _client_execute(
+                client,
+                material,
+                invocation,
+                ticket=ticket,
+                grant=grant,
+                expected_binding=expected_binding,
+                actual_target_snapshot_sha256=actual_snapshot,
+                before_dispatch=callback_calls.append,
+            )
+        assert callback_calls == []
+        assert _nonce_count(store) == 0
+        assert transport.calls == []
+    finally:
+        store.close()
+
+
+def test_before_dispatch_failure_leaves_nonce_and_transport_untouched(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    store = GatewayStateStore.open(tmp_path / "callback.sqlite3", now_ms=1_000)
+    transport = RecordingTransport(backend_response(material.ticket, {"unexpected": True}))
+    client = BackendClient(
+        transport,
+        store,
+        ticket_consumer_instance_id="p7d1-callback-failure",
+    )
+    try:
+        def fail_dispatch(_now_ms: int) -> None:
+            raise RuntimeError("durable dispatch permit failed")
+
+        with pytest.raises(RuntimeError, match="durable dispatch permit failed"):
+            _client_execute(
+                client,
+                material,
+                material.invocation,
+                before_dispatch=fail_dispatch,
+            )
+        assert _nonce_count(store) == 0
+        assert transport.calls == []
+    finally:
+        store.close()
+
+
+def test_transport_runner_receives_exact_timeout_and_invokes_transport_once(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    store = GatewayStateStore.open(tmp_path / "runner-success.sqlite3", now_ms=1_000)
+    transport = RecordingTransport(
+        backend_response(material.ticket, {"state": "runner-observed"})
+    )
+    client = BackendClient(
+        transport,
+        store,
+        ticket_consumer_instance_id="p7d1-transport-runner-success",
+    )
+    runner_calls: list[float] = []
+    callback_calls: list[int] = []
+
+    def runner(run_transport: Callable[[], dict[str, Any]], timeout_seconds: float):
+        assert callback_calls == [1_800]
+        assert _nonce_count(store) == 1
+        assert transport.calls == []
+        runner_calls.append(timeout_seconds)
+        return run_transport()
+
+    try:
+        response = _client_execute(
+            client,
+            material,
+            material.invocation,
+            before_dispatch=callback_calls.append,
+            transport_runner=runner,
+        )
+        expected_timeout = material.ticket.payload.max_runtime_ms / 1_000
+        assert response.result.status == "SUCCEEDED"
+        assert runner_calls == [expected_timeout]
+        assert callback_calls == [1_800]
+        assert len(transport.calls) == 1
+        assert transport.calls[0][1] == expected_timeout
+    finally:
+        store.close()
+
+
+def test_invalid_transport_runner_fails_before_callback_nonce_or_transport(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    store = GatewayStateStore.open(tmp_path / "runner-invalid.sqlite3", now_ms=1_000)
+    transport = RecordingTransport(
+        backend_response(material.ticket, {"unexpected": True})
+    )
+    client = BackendClient(
+        transport,
+        store,
+        ticket_consumer_instance_id="p7d1-transport-runner-invalid",
+    )
+    callback_calls: list[int] = []
+    try:
+        with pytest.raises(ValueError, match="transport runner is invalid"):
+            _client_execute(
+                client,
+                material,
+                material.invocation,
+                before_dispatch=callback_calls.append,
+                transport_runner=object(),
+            )
+        assert callback_calls == []
+        assert _nonce_count(store) == 0
+        assert transport.calls == []
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("runner_error", (TimeoutError("deadline"), RuntimeError("pool failed")))
+def test_transport_runner_timeout_or_exception_after_dispatch_is_ambiguous_without_transport(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+    runner_error: Exception,
+) -> None:
+    material = authorized_composition
+    store = GatewayStateStore.open(
+        tmp_path / f"runner-{type(runner_error).__name__}.sqlite3",
+        now_ms=1_000,
+    )
+    transport = RecordingTransport(
+        backend_response(material.ticket, {"unexpected": True})
+    )
+    client = BackendClient(
+        transport,
+        store,
+        ticket_consumer_instance_id=(
+            f"p7d1-transport-runner-{type(runner_error).__name__}"
+        ),
+    )
+    callback_calls: list[int] = []
+    runner_calls: list[float] = []
+
+    def runner(
+        _run_transport: Callable[[], dict[str, Any]], timeout_seconds: float
+    ) -> dict[str, Any]:
+        runner_calls.append(timeout_seconds)
+        raise runner_error
+
+    try:
+        with pytest.raises(BackendClientError) as caught:
+            _client_execute(
+                client,
+                material,
+                material.invocation,
+                before_dispatch=callback_calls.append,
+                transport_runner=runner,
+            )
+        assert caught.value.code == "backend.transport.failed"
+        assert caught.value.ambiguous is True
+        assert callback_calls == [1_800]
+        assert runner_calls == [material.ticket.payload.max_runtime_ms / 1_000]
+        assert _nonce_count(store) == 1
+        assert transport.calls == []
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("failure_kind", ("transport", "response"))
+def test_every_failure_after_dispatch_callback_is_ambiguous(
+    tmp_path: Path,
+    authorized_composition: AuthorizedComposition,
+    failure_kind: str,
+) -> None:
+    material = authorized_composition
+    store = GatewayStateStore.open(tmp_path / f"{failure_kind}.sqlite3", now_ms=1_000)
+    if failure_kind == "transport":
+        transport = RecordingTransport(
+            error=BackendClientError("backend.composition.route_failed", status=400)
+        )
+    else:
+        transport = RecordingTransport({"ok": True})
+    client = BackendClient(
+        transport,
+        store,
+        ticket_consumer_instance_id=f"p7d1-post-dispatch-{failure_kind}",
+    )
+    callback_calls: list[int] = []
+    try:
+        with pytest.raises(BackendClientError) as caught:
+            _client_execute(
+                client,
+                material,
+                material.invocation,
+                before_dispatch=callback_calls.append,
+            )
+        assert caught.value.ambiguous is True
+        assert callback_calls == [1_800]
+        assert _nonce_count(store) == 1
+        assert len(transport.calls) == 1
+    finally:
+        store.close()
+
+
+def test_composition_transport_uses_only_exact_private_route_and_body_and_wraps_float(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    raw_omni = {
+        "ok": True,
+        "action": material.ticket.payload.action_id,
+        "elapsed_seconds": 0.125,
+        "metrics": {"ratio": 0.75},
+    }
+    client = FakeCompatibilityClient(status=200, payload=raw_omni)
+    grant_value = material.grant.model_dump(mode="json")
+    runtime_value = deepcopy(material.runtime)
+    transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=grant_value,
+        runtime_meta=runtime_value,
+    )
+
+    # Constructor-bound authority is detached from mutable caller dictionaries.
+    grant_value["payload"]["ticket_id"] = "ticket_substituted_after_bind"
+    runtime_value["effect_id"] = "eff_" + "9" * 64
+    envelope = transport.execute(_wire(material), timeout_seconds=30.0)
+
+    assert len(client.calls) == 1
+    method, path, request, kwargs = client.calls[0]
+    assert (method, path) == ("POST", COMPOSITION_BACKEND_PATH)
+    assert set(request) == {
+        "schema",
+        "execute_ticket",
+        "capability_grant",
+        "runtime",
+    }
+    assert request["schema"] == COMPOSITION_BACKEND_REQUEST_SCHEMA
+    assert request["execute_ticket"] == json.loads(_wire(material))
+    assert request["capability_grant"] == material.grant.model_dump(mode="json")
+    assert request["runtime"] == material.runtime
+    assert request["runtime"]["fact_kernel_enabled"] is False
+    assert kwargs == {"timeout_seconds": 30.0, "backend_started": True}
+
+    result = envelope["execution_result"]
+    payload = envelope["result_payload"]
+    raw_bytes = _canonical_legacy_json(raw_omni)
+    assert result["status"] == "SUCCEEDED"
+    assert payload == {
+        "schema": COMPOSITION_RESULT_PAYLOAD_SCHEMA,
+        "backend_http_status": 200,
+        "backend_response_sha256": hashlib.sha256(raw_bytes).hexdigest(),
+        "execution_boundary": "embedded-omni-body-composition-v1",
+        "omni_ok": True,
+        "omni_result_json": raw_bytes.decode("utf-8"),
+        "omni_result_sha256": hashlib.sha256(raw_bytes).hexdigest(),
+        "omni_result_size_bytes": len(raw_bytes),
+    }
+    assert json.loads(payload["omni_result_json"])["elapsed_seconds"] == 0.125
+    assert canonical_sha256(payload) == result["result_payload_sha256"]
+
+
+def test_composition_transport_returns_final_failure_for_non_5xx_omni_failure(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    raw_omni = {"ok": False, "cuowu": "action rejected", "progress": 0.5}
+    client = FakeCompatibilityClient(status=400, payload=raw_omni)
+    transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=material.grant.model_dump(mode="json"),
+        runtime_meta=material.runtime,
+    )
+
+    envelope = transport.execute(_wire(material), timeout_seconds=30.0)
+
+    result = envelope["execution_result"]
+    assert result["status"] == "FAILED_FINAL"
+    assert result["error_code"] == "composition.runtime.action_failed"
+    assert result["error_message"] == "action rejected"
+    assert envelope["result_payload"]["omni_ok"] is False
+    assert json.loads(envelope["result_payload"]["omni_result_json"])["progress"] == 0.5
+
+
+def test_composition_transport_treats_5xx_as_unknown_after_started(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    client = FakeCompatibilityClient(
+        status=503,
+        payload={"ok": False, "error": "backend unavailable"},
+    )
+    transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=material.grant.model_dump(mode="json"),
+        runtime_meta=material.runtime,
+    )
+
+    with pytest.raises(BackendClientError) as caught:
+        transport.execute(_wire(material), timeout_seconds=30.0)
+    assert caught.value.code == "backend.composition.outcome_unknown"
+    assert caught.value.status == 503
+    assert caught.value.ambiguous is True
+    assert len(client.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    ("wire_authority", "bound_pair", "grant", "runtime", "fact_kernel"),
+)
+def test_composition_transport_rejects_authority_or_binding_replacement_before_route(
+    authorized_composition: AuthorizedComposition,
+    replacement: str,
+) -> None:
+    material = authorized_composition
+    invocation = deepcopy(material.invocation)
+    grant = material.grant.model_dump(mode="json")
+    runtime = deepcopy(material.runtime)
+    if replacement == "wire_authority":
+        invocation["__runtime"] = runtime
+        ticket, _ = _ticket_and_grant_for_invocation(material, invocation)
+    elif replacement == "bound_pair":
+        ticket = material.ticket
+        _alternate_ticket, alternate_grant, alternate_runtime = (
+            _alternate_signed_authority(material)
+        )
+        grant = alternate_grant.model_dump(mode="json")
+        runtime = alternate_runtime
+    else:
+        ticket = material.ticket
+        if replacement == "grant":
+            grant["payload"]["effect_id"] = "eff_" + "8" * 64
+        elif replacement == "runtime":
+            runtime["composition_binding_sha256"] = "8" * 64
+        else:
+            runtime["fact_kernel_enabled"] = True
+
+    client = FakeCompatibilityClient(status=200, payload={"ok": True})
+    transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=grant,
+        runtime_meta=runtime,
+    )
+    with pytest.raises(BackendClientError):
+        transport.execute(
+            _wire(material, ticket=ticket, invocation=invocation),
+            timeout_seconds=30.0,
+        )
+    assert client.calls == []
+
+
+def test_composition_transport_bounds_oversized_output_and_rejects_impossible_envelope(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    raw_omni = {"ok": True, "content": "x" * 2_000}
+    client = FakeCompatibilityClient(status=200, payload=raw_omni)
+
+    bounded_ticket, bounded_grant = _ticket_and_grant_for_output_limit(
+        material, 256
+    )
+    transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=bounded_grant.model_dump(mode="json"),
+        runtime_meta=material.runtime,
+    )
+    envelope = transport.execute(
+        _wire(material, ticket=bounded_ticket), timeout_seconds=30.0
+    )
+    assert envelope["execution_result"]["status"] == "FAILED_FINAL"
+    assert (
+        envelope["execution_result"]["error_code"]
+        == "composition.runtime.output_too_large"
+    )
+    assert envelope["result_payload"]["error_code"] == "composition.runtime.output_too_large"
+    assert "omni_result_json" not in envelope["result_payload"]
+
+    impossible_ticket, impossible_grant = _ticket_and_grant_for_output_limit(
+        material, 8
+    )
+    impossible_transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=impossible_grant.model_dump(mode="json"),
+        runtime_meta=material.runtime,
+    )
+    with pytest.raises(BackendClientError) as caught:
+        impossible_transport.execute(
+            _wire(material, ticket=impossible_ticket), timeout_seconds=30.0
+        )
+    assert caught.value.code == "backend.composition.output_envelope_impossible"
+    assert caught.value.ambiguous is True
+
+
+def test_embedded_private_route_verifies_authority_and_runs_omni_exactly_once_without_model(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    runner_calls: list[dict[str, Any]] = []
+    model_calls: list[tuple[Any, ...]] = []
+    authorization_calls: list[dict[str, Any]] = []
+
+    def runner(payload: dict[str, Any]) -> dict[str, Any]:
+        runner_calls.append(deepcopy(payload))
+        return {"ok": True, "elapsed_seconds": 0.25}
+
+    backend = EmbeddedBackendRuntime.__new__(EmbeddedBackendRuntime)
+    backend._lock = threading.RLock()
+    backend._closed = False
+    backend._closing = False
+    backend.qiaojie = SimpleNamespace(_core_execution_lock=threading.RLock())
+    backend.scheduler = SimpleNamespace(
+        _zhiming_llm=lambda *args: model_calls.append(args)
+    )
+    backend.set_composition_dispatch_authorizer(
+        lambda **kwargs: authorization_calls.append(kwargs)
+    )
+    request = _private_request(material)
+
+    def import_module(name: str):
+        assert name == "v3.jineng.jirou_ceng"
+        return SimpleNamespace(_run_omni_body_tool=runner)
+
+    with mock.patch(
+        "total_gateway.embedded_backend.time.time_ns",
+        return_value=1_800_000_000,
+    ), mock.patch(
+        "total_gateway.embedded_backend.importlib.import_module",
+        side_effect=import_module,
+    ):
+        status, payload, media_type = backend.request(
+            "POST",
+            COMPOSITION_BACKEND_PATH,
+            request,
+        )
+
+    assert status == 200
+    assert payload == {"ok": True, "elapsed_seconds": 0.25}
+    assert media_type == "application/json; charset=utf-8"
+    assert model_calls == []
+    assert len(authorization_calls) == 1
+    assert authorization_calls[0]["ticket"] == material.ticket
+    assert authorization_calls[0]["grant"] == material.grant
+    assert runner_calls == [
+        {
+            **material.invocation,
+            "__capability_grant": material.grant.model_dump(mode="json"),
+            "__runtime": material.runtime,
+        }
+    ]
+    assert runner_calls[0]["__runtime"]["fact_kernel_enabled"] is False
+
+
+def test_transport_and_real_embedded_request_contract_execute_end_to_end(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    material = authorized_composition
+    runner_calls: list[dict[str, Any]] = []
+
+    def runner(payload: dict[str, Any]) -> dict[str, Any]:
+        runner_calls.append(deepcopy(payload))
+        return {"ok": True, "elapsed_seconds": 0.125}
+
+    backend = EmbeddedBackendRuntime.__new__(EmbeddedBackendRuntime)
+    backend._lock = threading.RLock()
+    backend._closed = False
+    backend._closing = False
+    backend.qiaojie = SimpleNamespace(_core_execution_lock=threading.RLock())
+    backend.scheduler = SimpleNamespace()
+    authorization_calls: list[dict[str, Any]] = []
+    client = CompatibilityJsonClient(backend)
+    client.set_composition_dispatch_authorizer(
+        lambda **kwargs: authorization_calls.append(kwargs)
+    )
+    transport = CompositionBackendExecutionTransport(
+        client,
+        signed_grant=material.grant.model_dump(mode="json"),
+        runtime_meta=material.runtime,
+    )
+
+    def import_module(name: str):
+        assert name == "v3.jineng.jirou_ceng"
+        return SimpleNamespace(_run_omni_body_tool=runner)
+
+    with mock.patch(
+        "total_gateway.embedded_backend.time.time_ns",
+        return_value=1_800_000_000,
+    ), mock.patch(
+        "total_gateway.embedded_backend.importlib.import_module",
+        side_effect=import_module,
+    ):
+        envelope = transport.execute(_wire(material), timeout_seconds=30.0)
+
+    assert envelope["execution_result"]["status"] == "SUCCEEDED"
+    assert envelope["result_payload"]["omni_ok"] is True
+    assert len(authorization_calls) == 1
+    assert runner_calls == [
+        {
+            **material.invocation,
+            "__capability_grant": material.grant.model_dump(mode="json"),
+            "__runtime": material.runtime,
+        }
+    ]
+
+
+def test_embedded_private_route_without_gateway_authorizer_is_handler_zero(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    backend = EmbeddedBackendRuntime.__new__(EmbeddedBackendRuntime)
+    backend._lock = threading.RLock()
+    backend._closed = False
+    backend._closing = False
+    backend.qiaojie = SimpleNamespace(_core_execution_lock=threading.RLock())
+    backend.scheduler = SimpleNamespace()
+
+    with mock.patch(
+        "total_gateway.embedded_backend.time.time_ns",
+        return_value=1_800_000_000,
+    ), mock.patch(
+        "total_gateway.embedded_backend.importlib.import_module"
+    ) as import_module:
+        status, payload, media_type = backend.request(
+            "POST",
+            COMPOSITION_BACKEND_PATH,
+            _private_request(authorized_composition),
+        )
+
+    assert status == 500
+    assert payload["ok"] is False
+    assert payload["error_type"] == "PermissionError"
+    assert media_type == "application/problem+json"
+    import_module.assert_not_called()
+
+
+def test_embedded_composition_route_is_private_and_has_no_legacy_alias(
+    authorized_composition: AuthorizedComposition,
+) -> None:
+    backend = EmbeddedBackendRuntime.__new__(EmbeddedBackendRuntime)
+    backend._lock = threading.RLock()
+    backend._closed = False
+    backend._closing = False
+    backend.qiaojie = SimpleNamespace(_core_execution_lock=threading.RLock())
+
+    with mock.patch(
+        "total_gateway.embedded_backend.importlib.import_module"
+    ) as import_module:
+        status, payload, media_type = backend.request(
+            "POST",
+            "/api/v1/internal/composition/execute",
+            _private_request(authorized_composition),
+        )
+    assert status == 404
+    assert payload == {"ok": False, "error": "not_found"}
+    assert media_type == "application/problem+json"
+    import_module.assert_not_called()

--- a/tests/test_composition_execution_manifest_p7d1.py
+++ b/tests/test_composition_execution_manifest_p7d1.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from contracts import CapabilityManifest, canonical_json_bytes, canonical_sha256
+from total_gateway.action_registry import ActionSchemaCatalog
+from total_gateway.skill_selection import (
+    LoadedModelCapabilityManifest,
+    SkillSelectionError,
+    compile_composition_execution_manifest,
+    load_model_capability_manifest,
+)
+
+
+ZERO = "0" * 64
+OTHER = "f" * 64
+COMPONENT_MANIFEST_SHA256 = "c" * 64
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_MANIFEST_PATH = (
+    ROOT
+    / "src"
+    / "omni_body_skill"
+    / "registry"
+    / "capability_manifest.generated.json"
+).resolve()
+
+
+@pytest.fixture(scope="module")
+def loaded() -> LoadedModelCapabilityManifest:
+    raw = MODEL_MANIFEST_PATH.read_bytes()
+    return load_model_capability_manifest(
+        MODEL_MANIFEST_PATH,
+        expected_sha256=hashlib.sha256(raw).hexdigest(),
+        component_manifest_hash=COMPONENT_MANIFEST_SHA256,
+        generated_at_ms=1_000,
+    )
+
+
+def _rehash_catalog(
+    catalog: ActionSchemaCatalog,
+    *,
+    entries=None,
+    source_manifest_sha256: str | None = None,
+) -> ActionSchemaCatalog:
+    draft = replace(
+        catalog,
+        entries=catalog.entries if entries is None else entries,
+        source_manifest_sha256=(
+            catalog.source_manifest_sha256
+            if source_manifest_sha256 is None
+            else source_manifest_sha256
+        ),
+        catalog_sha256=ZERO,
+    )
+    return replace(draft, catalog_sha256=canonical_sha256(draft.payload()))
+
+
+def _rehash_manifest(
+    manifest: CapabilityManifest,
+    *,
+    actions,
+) -> CapabilityManifest:
+    return manifest.model_copy(
+        update={"actions": tuple(actions), "sha256": ZERO}
+    ).with_computed_sha256()
+
+
+def test_compiles_real_execution_manifest_from_all_three_authorities(
+    loaded: LoadedModelCapabilityManifest,
+) -> None:
+    model_manifest = loaded.manifest
+    registry = loaded.action_authority.registry
+    catalog = loaded.action_authority.schema_catalog
+
+    execution_manifest = compile_composition_execution_manifest(
+        model_manifest,
+        registry,
+        catalog,
+        generated_at_ms=1_001,
+    )
+
+    assert execution_manifest.has_valid_sha256()
+    assert execution_manifest.generated_at_ms == 1_001
+    assert execution_manifest.component_manifest_hash == COMPONENT_MANIFEST_SHA256
+    assert len(execution_manifest.actions) == registry.executable_count == 290
+    assert tuple(
+        (item.action_id, item.version) for item in execution_manifest.actions
+    ) == tuple(
+        (permission.action_id, permission.action_version)
+        for permission in registry.permissions
+    )
+
+    model_by_id = {item.action_id: item for item in model_manifest.actions}
+    permission_by_id = {
+        item.action_id: item for item in registry.permissions
+    }
+    schema_by_id = {item.action_id: item for item in catalog.entries}
+    for action in execution_manifest.actions:
+        model_action = model_by_id[action.action_id]
+        permission = permission_by_id[action.action_id]
+        schema = schema_by_id[action.action_id]
+        assert action.version == permission.action_version
+        assert action.argument_schema_sha256 == schema.argument_schema_sha256
+        assert action.result_schema_sha256 == model_action.result_schema_sha256
+        assert action.max_runtime_ms == model_action.max_runtime_ms
+        assert action.max_output_bytes == model_action.max_output_bytes
+        assert action.max_tool_calls == model_action.max_tool_calls
+        assert action.available == model_action.available
+        assert action.unavailable_reason == model_action.unavailable_reason
+        assert action.risk_class == permission.effective_risk
+        assert action.allowed_side_effects == permission.allowed_side_effects
+
+    # This action proves the join does not accidentally retain the model-view
+    # risk and broad routing side effects when it constructs execution policy.
+    photoshop = next(
+        item
+        for item in execution_manifest.actions
+        if item.action_id == "adobe.photoshop.document.open"
+    )
+    assert model_by_id[photoshop.action_id].risk_class == "A0"
+    assert photoshop.risk_class == "A3"
+    assert (
+        model_by_id[photoshop.action_id].allowed_side_effects
+        != photoshop.allowed_side_effects
+    )
+
+
+def test_default_generation_time_is_the_verified_model_time(
+    loaded: LoadedModelCapabilityManifest,
+) -> None:
+    execution_manifest = compile_composition_execution_manifest(
+        loaded.manifest,
+        loaded.action_authority.registry,
+        loaded.action_authority.schema_catalog,
+    )
+    assert execution_manifest.generated_at_ms == loaded.manifest.generated_at_ms
+
+
+def test_raw_source_hash_cannot_masquerade_as_capability_manifest_digest(
+    loaded: LoadedModelCapabilityManifest,
+) -> None:
+    raw_source_sha256 = loaded.action_authority.manifest_sha256
+    assert raw_source_sha256 != loaded.manifest.sha256
+    forged_model = loaded.manifest.model_copy(
+        update={"sha256": raw_source_sha256}
+    )
+
+    with pytest.raises(SkillSelectionError, match="manifest digest"):
+        compile_composition_execution_manifest(
+            forged_model,
+            loaded.action_authority.registry,
+            loaded.action_authority.schema_catalog,
+        )
+
+    execution_manifest = compile_composition_execution_manifest(
+        loaded.manifest,
+        loaded.action_authority.registry,
+        loaded.action_authority.schema_catalog,
+    )
+    assert execution_manifest.sha256 == execution_manifest.computed_sha256()
+    assert execution_manifest.sha256 != raw_source_sha256
+
+
+def test_missing_or_ambiguous_model_action_fails_closed(
+    loaded: LoadedModelCapabilityManifest,
+) -> None:
+    missing = _rehash_manifest(
+        loaded.manifest,
+        actions=loaded.manifest.actions[:-1],
+    )
+    with pytest.raises(SkillSelectionError, match="coverage mismatch"):
+        compile_composition_execution_manifest(
+            missing,
+            loaded.action_authority.registry,
+            loaded.action_authority.schema_catalog,
+        )
+
+    first = loaded.manifest.actions[0]
+    duplicate_version = first.model_copy(update={"version": "second-version"})
+    ambiguous = _rehash_manifest(
+        loaded.manifest,
+        actions=tuple(
+            sorted(
+                (*loaded.manifest.actions, duplicate_version),
+                key=lambda item: (item.action_id, item.version),
+            )
+        ),
+    )
+    with pytest.raises(SkillSelectionError, match="identity is ambiguous"):
+        compile_composition_execution_manifest(
+            ambiguous,
+            loaded.action_authority.registry,
+            loaded.action_authority.schema_catalog,
+        )
+
+
+def test_current_schema_mismatch_and_rehashed_body_drift_fail_closed(
+    loaded: LoadedModelCapabilityManifest,
+) -> None:
+    first = loaded.manifest.actions[0]
+    changed = first.model_copy(update={"argument_schema_sha256": OTHER})
+    drifted_model = _rehash_manifest(
+        loaded.manifest,
+        actions=tuple(
+            changed if item.action_id == first.action_id else item
+            for item in loaded.manifest.actions
+        ),
+    )
+    with pytest.raises(SkillSelectionError, match="current schema mismatch"):
+        compile_composition_execution_manifest(
+            drifted_model,
+            loaded.action_authority.registry,
+            loaded.action_authority.schema_catalog,
+        )
+
+    catalog = loaded.action_authority.schema_catalog
+    schema = catalog.entries[0]
+    drifted_schema = replace(
+        schema,
+        _body_json=canonical_json_bytes(
+            {"action": schema.canonical_action_id, "drifted": True}
+        ),
+    )
+    drifted_catalog = _rehash_catalog(
+        catalog,
+        entries=(drifted_schema, *catalog.entries[1:]),
+    )
+    assert drifted_catalog.has_valid_sha256()
+    with pytest.raises(SkillSelectionError, match="schema body"):
+        compile_composition_execution_manifest(
+            loaded.manifest,
+            loaded.action_authority.registry,
+            drifted_catalog,
+        )
+
+
+def test_registry_catalog_digests_source_and_exact_coverage_fail_closed(
+    loaded: LoadedModelCapabilityManifest,
+) -> None:
+    registry = loaded.action_authority.registry
+    catalog = loaded.action_authority.schema_catalog
+
+    invalid_registry = registry.model_copy(update={"registry_sha256": ZERO})
+    with pytest.raises(SkillSelectionError, match="registry digest"):
+        compile_composition_execution_manifest(
+            loaded.manifest,
+            invalid_registry,
+            catalog,
+        )
+
+    invalid_catalog = replace(catalog, catalog_sha256=ZERO)
+    with pytest.raises(SkillSelectionError, match="catalog digest"):
+        compile_composition_execution_manifest(
+            loaded.manifest,
+            registry,
+            invalid_catalog,
+        )
+
+    changed_entries = tuple(
+        replace(item, source_manifest_sha256=OTHER) for item in catalog.entries
+    )
+    other_source_catalog = _rehash_catalog(
+        catalog,
+        entries=changed_entries,
+        source_manifest_sha256=OTHER,
+    )
+    assert other_source_catalog.has_valid_sha256()
+    with pytest.raises(SkillSelectionError, match="source manifest mismatch"):
+        compile_composition_execution_manifest(
+            loaded.manifest,
+            registry,
+            other_source_catalog,
+        )
+
+    missing_schema_catalog = _rehash_catalog(
+        catalog,
+        entries=catalog.entries[:-1],
+    )
+    assert missing_schema_catalog.has_valid_sha256()
+    with pytest.raises(SkillSelectionError, match="schema coverage mismatch"):
+        compile_composition_execution_manifest(
+            loaded.manifest,
+            registry,
+            missing_schema_catalog,
+        )

--- a/tests/test_composition_step_execution_p7d1.py
+++ b/tests/test_composition_step_execution_p7d1.py
@@ -1,0 +1,1439 @@
+"""P7D.1 coordinator state-machine and restart-safety tests.
+
+These tests deliberately reuse the production P7C plan/authorization fixture,
+the real Gateway Store, and the real FactLedger.  Only the embedded backend
+call is replaced with a deterministic in-process response so the assertions
+can observe the exact durable boundary ordering.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+import hashlib
+import json
+from pathlib import Path
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, Iterator
+from unittest import mock
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+import pytest
+
+from contracts import (
+    ExecutionResult,
+    ObjectGrant,
+    canonical_sha256,
+    derive_effect_identity,
+    derive_run_identity,
+)
+from tests import test_composition_grant_authority_p7c1 as p7c1
+from tests.test_execution_contracts import capability_manifest
+from total_gateway.backend_client import BackendClient, BackendClientError
+from total_gateway.composition_step_execution import (
+    CompositionStepExecutionCoordinator,
+    CompositionStepExecutionError,
+)
+from total_gateway.composition_execution_binding import (
+    COMPOSITION_STEP_PIPELINE_VERSION,
+)
+import total_gateway.composition_step_execution as execution_module
+import total_gateway.orchestration as orchestration_module
+from total_gateway.fact_ledger import FactLedger
+from total_gateway.effects import EffectClaim, EffectResult
+from total_gateway.embedded_backend import EmbeddedBackendRuntime
+from total_gateway.object_store import ContentAddressedObjectStore
+from total_gateway.orchestration import GatewayOrchestrationWorker
+from total_gateway.service_ports import CompatibilityJsonClient
+from total_gateway.skill_selection import (
+    compile_composition_execution_manifest,
+    load_model_capability_manifest,
+)
+from total_gateway.store import GatewayStateStore, StoreConflictError
+
+
+class _BackendProbe:
+    def __init__(self, store, facts, effect_id: str) -> None:
+        self._store = store
+        self._facts = facts
+        self._effect_id = effect_id
+        self.calls = 0
+        self.states_at_call: list[tuple[str, bool]] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None,
+        *,
+        timeout_seconds: float,
+        backend_started: bool = False,
+        before_request=None,
+    ) -> tuple[int, dict[str, Any], str]:
+        del method, path, payload, timeout_seconds, backend_started, before_request
+        self.calls += 1
+        effect = self._store.get_effect(self._effect_id)
+        batch = self._facts.get_batch_for_effect(self._effect_id)
+        self.states_at_call.append((effect.state, batch is not None))
+        value = {"ok": True, "result": {"source": "p7d1-test"}}
+        raw = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return 200, value, hashlib.sha256(raw).hexdigest()
+
+
+class _ParentTransport:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def execute(self, body: bytes, *, timeout_seconds: float) -> dict[str, Any]:
+        del body, timeout_seconds
+        return self._payload
+
+
+class _FactCrashProxy:
+    """Optionally persist the Fact batch, then emulate process death."""
+
+    def __init__(self, delegate: FactLedger, *, commit_first: bool) -> None:
+        self._delegate = delegate
+        self._commit_first = commit_first
+
+    def record_execution(self, response, *, observed_at_ms: int):
+        if self._commit_first:
+            self._delegate.record_execution(response, observed_at_ms=observed_at_ms)
+        raise OSError("injected crash at Fact commit boundary")
+
+    def get_batch_for_effect(self, effect_id: str, *, verify_payload: bool = True):
+        return self._delegate.get_batch_for_effect(
+            effect_id, verify_payload=verify_payload
+        )
+
+    def get_batch_for_ticket(self, ticket_id: str, *, verify_payload: bool = True):
+        return self._delegate.get_batch_for_ticket(
+            ticket_id, verify_payload=verify_payload
+        )
+
+
+@dataclass
+class _RuntimeFixture:
+    p7c: Any
+    manifest: Any
+    record: Any
+    facts: FactLedger
+    backend: _BackendProbe
+    coordinator: CompositionStepExecutionCoordinator
+    events: list[tuple[str, str, bool]]
+    baseline_nonce_count: int
+
+
+def _seed_successful_parent(
+    harness: Any,
+    facts: FactLedger,
+    *,
+    parent_manifest: Any,
+    parent_ticket: Any,
+    parent_claim: EffectClaim,
+) -> None:
+    """Persist the real Fact batch and terminal parent Effect required by P7D."""
+
+    parent_args = {"parent": "composition-authority"}
+    result_payload = {"parent": "succeeded"}
+    result = ExecutionResult(
+        result_id="execution_result_parent_p7d1",
+        ticket_id=parent_ticket.payload.ticket_id,
+        request_id=parent_ticket.payload.request_id,
+        run_id=parent_ticket.payload.run_id,
+        generation=parent_ticket.payload.generation,
+        effect_id=parent_ticket.payload.effect_id,
+        action_id=parent_ticket.payload.action_id,
+        action_version=parent_ticket.payload.action_version,
+        status="SUCCEEDED",
+        attempt=1,
+        started_at_ms=1_640,
+        finished_at_ms=1_660,
+        side_effect_started=True,
+        result_payload_sha256=canonical_sha256(result_payload),
+        receipt_sha256="1" * 64,
+        output_object_refs=(),
+        fact_ids=("fact_parent_p7d1",),
+    )
+    transport = _ParentTransport(
+        {
+            "ok": True,
+            "api_contract": "tiangong.desktop.backend.v3",
+            "execution_result": result.model_dump(mode="json"),
+            "result_payload": result_payload,
+        }
+    )
+    harness.store.claim_effect(parent_claim)
+    harness.store.mark_effect_started(
+        parent_claim.effect_id, started_at_ms=result.started_at_ms
+    )
+    response = BackendClient(
+        transport,
+        harness.store,
+        ticket_consumer_instance_id="gateway-parent-p7d1-test",
+    ).execute(
+        parent_ticket,
+        parent_args,
+        capability_manifest=parent_manifest,
+        trust_bundle=harness.trust,
+        now_ms=1_650,
+        expected_gateway_epoch=1,
+        minimum_generation=parent_ticket.payload.generation,
+    )
+    batch = facts.record_execution(response, observed_at_ms=1_660).record
+    # Match GatewayOrchestrationWorker's production parent projection exactly:
+    # parent Effect evidence is the verified backend response digest, while the
+    # Fact batch independently binds the content-addressed result payload.
+    effect_result = EffectResult(
+        result_id="effect-result-" + response.result.result_id[:120],
+        effect_id=response.result.effect_id,
+        status="SUCCEEDED",
+        fact_id=response.result.fact_ids[0],
+        result_object_id=batch.result_payload_object_id,
+        result_object_sha256=batch.result_payload_sha256,
+        evidence_sha256=response.response_sha256,
+        observed_at_ms=1_660,
+        result_sha256="0" * 64,
+    ).with_computed_sha256()
+    harness.store.complete_effect(effect_result)
+
+
+@contextmanager
+def _runtime_fixture(root: Path, **harness_kwargs: Any) -> Iterator[_RuntimeFixture]:
+    root.mkdir(parents=True, exist_ok=True)
+    harness = p7c1._open_harness(root, **harness_kwargs)
+    facts = FactLedger.open(root / "facts.sqlite3", harness.objects, now_ms=1_000)
+    runtime: _RuntimeFixture | None = None
+    try:
+        model = load_model_capability_manifest(
+            p7c1.CAPABILITY_MANIFEST,
+            expected_sha256=hashlib.sha256(
+                p7c1.CAPABILITY_MANIFEST.read_bytes()
+            ).hexdigest(),
+            component_manifest_hash=p7c1.COMPONENT_MANIFEST_SHA256,
+            generated_at_ms=1_250,
+        ).manifest
+        manifest = compile_composition_execution_manifest(
+            model,
+            harness.loaded.registry,
+            harness.loaded.schema_catalog,
+            generated_at_ms=1_250,
+        )
+        # P7C's reusable test world intentionally uses a sentinel result-schema
+        # hash instead of the model-manifest hash.  Align that one test action
+        # so this fixture can exercise the runtime state machine; compiler
+        # cross-authority drift remains covered by the dedicated P7D manifest
+        # tests.
+        sealed_result_schema = harness.plan.step_bindings[0].result_schema_sha256
+        manifest = manifest.model_copy(
+            update={
+                "actions": tuple(
+                    action.model_copy(
+                        update={"result_schema_sha256": sealed_result_schema}
+                    )
+                    if action.action_id == harness.plan.step_bindings[0].action_id
+                    else action
+                    for action in manifest.actions
+                ),
+                "sha256": "0" * 64,
+            }
+        ).with_computed_sha256()
+
+        parent_args = {"parent": "composition-authority"}
+        parent_manifest = capability_manifest()
+        parent_intent_sha256 = canonical_sha256(
+            {
+                "domain": "tiangong.test.composition-parent.v1",
+                "request_id": harness.plan.request_id,
+                "run_id": harness.plan.run_id,
+                "generation": harness.plan.generation,
+            }
+        )
+        parent_identity = derive_effect_identity(
+            request_id=harness.plan.request_id,
+            run_id=harness.plan.run_id,
+            run_sequence=1,
+            generation=harness.plan.generation,
+            effect_kind="execution",
+            ordinal=0,
+            intent_sha256=parent_intent_sha256,
+        )
+        parent_claim = EffectClaim(
+            effect_id=parent_identity.effect_id,
+            request_id=harness.plan.request_id,
+            run_id=harness.plan.run_id,
+            run_sequence=1,
+            generation=harness.plan.generation,
+            effect_kind="execution",
+            ordinal=0,
+            intent_sha256=parent_intent_sha256,
+            owner_component_id="tiangong-total-gateway",
+            claimed_at_ms=1_600,
+            claim_sha256="0" * 64,
+        ).with_computed_sha256()
+        outer = harness.outer.payload
+        parent_ticket = p7c1.execution_ticket(
+            manifest=parent_manifest,
+            ticket_id="ticket_parent_p7d1",
+            nonce="nonce_parent_p7d1",
+            issued_at_ms=outer.issued_at_ms,
+            not_before_ms=outer.not_before_ms,
+            expires_at_ms=outer.expires_at_ms,
+            gateway_epoch=outer.gateway_epoch,
+            request_id=outer.request_id,
+            run_id=outer.run_id,
+            generation=outer.generation,
+            effect_id=parent_identity.effect_id,
+            channel=outer.channel,
+            tenant_id=outer.tenant_id,
+            link_account_id=outer.link_account_id,
+            conversation_scope_hash=outer.conversation_scope_hash,
+            principal_scope_hash=outer.principal_scope_hash,
+            arguments_hash=canonical_sha256(parent_args),
+            workspace_id=outer.workspace_id,
+            input_objects=outer.input_objects,
+            max_output_bytes=1_000_000,
+            max_runtime_ms=30_000,
+            max_tool_calls=1,
+        )
+        parent_ticket = harness.signer.sign_execution(parent_ticket.payload)
+
+        # The shared P7C fixture predates the split between the outer
+        # compatibility manifest and the child execution manifest.  Mutating
+        # this test-only authority before issuance exercises the new split
+        # without weakening any signed contract.
+        authority = p7c1._authority(
+            harness,
+            capability_manifest_hash=parent_manifest.sha256,
+            outer=parent_ticket,
+        )
+        authority.composition_capability_manifest_hash = manifest.sha256
+        p7c1._authorize(
+            harness,
+            authority=authority,
+            parent_ticket_id=parent_ticket.payload.ticket_id,
+        )
+        record = harness.store.get_composition_step_authorization(
+            harness.plan.executable_plan_id,
+            "step.01",
+            now_ms=1_700,
+        )
+        assert record is not None
+
+        _seed_successful_parent(
+            harness,
+            facts,
+            parent_manifest=parent_manifest,
+            parent_ticket=parent_ticket,
+            parent_claim=parent_claim,
+        )
+        baseline_nonce_count = _nonce_count(harness.store)
+
+        backend = _BackendProbe(
+            harness.store, facts, record.request.prebound_effect_id
+        )
+        events: list[tuple[str, str, bool]] = []
+
+        def append_event(store, **kwargs) -> bool:
+            effect = store.get_effect(kwargs["effect_id"])
+            batch = facts.get_batch_for_effect(kwargs["effect_id"])
+            events.append((kwargs["event_type"], effect.state, batch is not None))
+            return True
+
+        generation = harness.store.get_generation(record.request.request_id)
+        assert generation is not None
+        assert generation.owner_instance_id is not None
+        coordinator = CompositionStepExecutionCoordinator(
+            store=harness.store,
+            objects=harness.objects,
+            facts=facts,
+            registry=harness.loaded.registry,
+            schema_catalog=harness.loaded.schema_catalog,
+            capability_manifest=manifest,
+            trust_bundle_provider=lambda _now_ms: harness.trust,
+            backend_compat_client=backend,
+            workspace_root=root.resolve(strict=True),
+            gateway_epoch=1,
+            gateway_instance_id=generation.owner_instance_id,
+            append_effect_event=append_event,
+        )
+        runtime = _RuntimeFixture(
+            harness,
+            manifest,
+            record,
+            facts,
+            backend,
+            coordinator,
+            events,
+            baseline_nonce_count,
+        )
+        yield runtime
+    finally:
+        if runtime is not None and runtime.facts is not facts:
+            runtime.facts.close()
+        facts.close()
+        harness.close()
+
+
+def _nonce_count(store) -> int:
+    return int(
+        store._connection.execute(  # noqa: SLF001 - boundary assertion
+            "SELECT count(*) FROM security_nonce_ledger"
+        ).fetchone()[0]
+    )
+
+
+def _exact_scope(fixture: _RuntimeFixture) -> dict[str, Any]:
+    request = fixture.record.request
+    return {
+        "request_id": request.request_id,
+        "run_id": request.run_id,
+        "generation": request.generation,
+    }
+
+
+def _reopen_runtime(
+    fixture: _RuntimeFixture,
+    *,
+    now_ms: int,
+    gateway_epoch: int = 1,
+    trust_bundle: Any | None = None,
+) -> None:
+    """Emulate a process restart with fresh SQLite/Object authority handles."""
+
+    harness = fixture.p7c
+    fixture.facts.close()
+    harness.objects.close()
+    harness.store.close()
+
+    store = GatewayStateStore.open(harness.database_path, now_ms=now_ms)
+    objects = ContentAddressedObjectStore.open(
+        harness.root / "objects", now_ms=now_ms
+    )
+    facts = FactLedger.open(
+        harness.root / "facts.sqlite3", objects, now_ms=now_ms
+    )
+    backend = _BackendProbe(
+        store, facts, fixture.record.request.prebound_effect_id
+    )
+    events: list[tuple[str, str, bool]] = []
+
+    def append_event(event_store, **kwargs) -> bool:
+        effect = event_store.get_effect(kwargs["effect_id"])
+        batch = facts.get_batch_for_effect(kwargs["effect_id"])
+        events.append((kwargs["event_type"], effect.state, batch is not None))
+        return True
+
+    generation = store.get_generation(fixture.record.request.request_id)
+    assert generation is not None
+    coordinator = CompositionStepExecutionCoordinator(
+        store=store,
+        objects=objects,
+        facts=facts,
+        registry=harness.loaded.registry,
+        schema_catalog=harness.loaded.schema_catalog,
+        capability_manifest=fixture.manifest,
+        trust_bundle_provider=lambda _now_ms: (
+            harness.trust if trust_bundle is None else trust_bundle
+        ),
+        backend_compat_client=backend,
+        workspace_root=harness.root.resolve(strict=True),
+        gateway_epoch=gateway_epoch,
+        gateway_instance_id=generation.owner_instance_id,
+        append_effect_event=append_event,
+    )
+    harness.store = store
+    harness.objects = objects
+    fixture.facts = facts
+    fixture.backend = backend
+    fixture.coordinator = coordinator
+    fixture.events = events
+
+
+def test_dispatch_orders_started_handler_fact_effect_and_terminal_event(
+    tmp_path: Path,
+) -> None:
+    # Unicode makes the test cover the Windows path representation used by the
+    # real repository, while the plan compiler still supplies its canonical
+    # resolved spelling.
+    with _runtime_fixture(tmp_path / "天工造物-路径") as fixture:
+        outcome = fixture.coordinator.dispatch_record(
+            fixture.record, now_ms=1_700
+        )
+
+        assert outcome.status == "SUCCEEDED"
+        assert fixture.backend.calls == 1
+        assert fixture.backend.states_at_call == [("SIDE_EFFECT_STARTED", False)]
+        assert fixture.events == [
+            ("step.prepared", "CLAIMED", False),
+            ("step.dispatched", "SIDE_EFFECT_STARTED", False),
+            ("step.committed", "SUCCEEDED", True),
+        ]
+        assert (
+            _nonce_count(fixture.p7c.store)
+            == fixture.baseline_nonce_count + 1
+        )
+        attempt = fixture.p7c.store.get_effect_attempt(outcome.effect_id, 1)
+        assert attempt["state"] == "SUCCEEDED"
+        assert attempt["pipeline_version"] == COMPOSITION_STEP_PIPELINE_VERSION
+        assert fixture.facts.get_batch_for_effect(outcome.effect_id) is not None
+
+
+def test_timeout_retains_store_permit_until_running_handler_really_exits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="p7d1-store-permit-test",
+    )
+    slot = threading.BoundedSemaphore(value=1)
+    monkeypatch.setattr(orchestration_module, "_EXECUTION_WATCHDOG_POOL", executor)
+    monkeypatch.setattr(orchestration_module, "_COMPOSITION_WATCHDOG_SLOT", slot)
+    started = threading.Event()
+    release = threading.Event()
+    exited = threading.Event()
+
+    try:
+        with _runtime_fixture(tmp_path / "timeout-store-permit") as fixture:
+            class BlockingBackend(_BackendProbe):
+                def request(self, *args, **kwargs):
+                    started.set()
+                    if not release.wait(timeout=2):  # pragma: no cover - cleanup guard
+                        raise AssertionError("test did not release the handler")
+                    try:
+                        return super().request(*args, **kwargs)
+                    finally:
+                        exited.set()
+
+            backend = BlockingBackend(
+                fixture.p7c.store,
+                fixture.facts,
+                fixture.record.request.prebound_effect_id,
+            )
+            fixture.coordinator._backend = backend  # noqa: SLF001
+            fixture.coordinator._transport_runner = (  # noqa: SLF001
+                lambda call, _signed_timeout: (
+                    orchestration_module._run_backend_transport_with_watchdog(
+                        call,
+                        timeout_seconds=0.05,
+                    )
+                )
+            )
+
+            outcome = fixture.coordinator.dispatch_record(
+                fixture.record,
+                now_ms=1_700,
+            )
+
+            assert started.is_set()
+            assert outcome.status == "AMBIGUOUS"
+            assert fixture.p7c.store.get_effect(outcome.effect_id).state == "AMBIGUOUS"
+            assert fixture.p7c.store.action_fence_status()["inflight_count"] == 1
+            assert fixture.facts.get_batch_for_effect(outcome.effect_id) is None
+
+            release.set()
+            assert exited.wait(timeout=1)
+            deadline = time.monotonic() + 1
+            while (
+                fixture.p7c.store.action_fence_status()["inflight_count"] != 0
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+            assert fixture.p7c.store.action_fence_status()["inflight_count"] == 0
+            # Explicit release is idempotent after the Future callback.
+            fixture.p7c.store.release_dispatch_permit(
+                effect_id=outcome.effect_id,
+                attempt=1,
+                now_ms=2_000,
+            )
+            assert fixture.p7c.store.action_fence_status()["inflight_count"] == 0
+    finally:
+        release.set()
+        executor.shutdown(wait=True, cancel_futures=True)
+
+
+def test_restart_releases_terminal_permit_left_by_timed_out_process(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "timeout-terminal-restart") as fixture:
+        callbacks: list[Any] = []
+
+        class PendingTransport:
+            def add_done_callback(self, callback) -> None:
+                callbacks.append(callback)
+
+        pending = PendingTransport()
+
+        def timed_out_runner(_call, _timeout_seconds):
+            raise BackendClientError(
+                "backend.composition.execution_timeout",
+                ambiguous=True,
+                pending_transport_future=pending,
+            )
+
+        fixture.coordinator._transport_runner = timed_out_runner  # noqa: SLF001
+        outcome = fixture.coordinator.dispatch_record(
+            fixture.record,
+            now_ms=1_700,
+        )
+        assert outcome.status == "AMBIGUOUS"
+        assert len(callbacks) == 1
+        assert fixture.p7c.store.action_fence_status()["inflight_count"] == 1
+
+        # Emulate process loss before the pending Future invokes its callback.
+        _reopen_runtime(fixture, now_ms=2_000)
+        assert fixture.p7c.store.action_fence_status()["inflight_count"] == 1
+        assert fixture.coordinator.recover_started(now_ms=2_000) == ()
+        assert fixture.p7c.store.get_effect(outcome.effect_id).state == "AMBIGUOUS"
+        assert fixture.p7c.store.action_fence_status()["inflight_count"] == 0
+
+
+@pytest.mark.parametrize("status", ("SUCCEEDED", "FAILED_FINAL", "RECONCILED"))
+def test_store_rejects_retaining_permit_for_nonambiguous_terminal(
+    tmp_path: Path,
+    status: str,
+) -> None:
+    with _runtime_fixture(tmp_path / f"retain-permit-{status.casefold()}") as fixture:
+        prepared = fixture.coordinator._preflight(  # noqa: SLF001
+            fixture.record,
+            now_ms=1_700,
+        )
+        claim = prepared["claim"]
+        fixture.p7c.store.claim_effect(claim)
+        fixture.p7c.store.mark_effect_started(
+            claim.effect_id,
+            started_at_ms=1_700,
+        )
+        result = EffectResult(
+            result_id="effect-result-invalid-retention-" + status.casefold(),
+            effect_id=claim.effect_id,
+            status=status,
+            fact_id="fact-invalid-retention-" + status.casefold(),
+            evidence_sha256=canonical_sha256(
+                {"effect_id": claim.effect_id, "status": status}
+            ),
+            error_code=(
+                "p7d1.test.invalid_retention" if status == "FAILED_FINAL" else None
+            ),
+            observed_at_ms=1_701,
+            result_sha256="0" * 64,
+        ).with_computed_sha256()
+
+        with pytest.raises(
+            ValueError,
+            match="retaining an effect dispatch permit requires an ambiguous result",
+        ):
+            fixture.p7c.store.complete_effect(
+                result,
+                release_dispatch_permit=False,
+            )
+
+        assert fixture.p7c.store.get_effect(claim.effect_id).state == "SIDE_EFFECT_STARTED"
+
+
+def test_private_handler_requires_dispatch_permit_and_consumes_grant_once(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "handler-permit") as fixture:
+        prepared = fixture.coordinator._preflight(  # noqa: SLF001
+            fixture.record,
+            now_ms=1_700,
+        )
+        store = fixture.p7c.store
+        claim = prepared["claim"]
+        ticket = prepared["ticket"]
+        grant = prepared["grant"]
+        store.claim_effect(claim)
+        ticket_sha256 = canonical_sha256(ticket.model_dump(mode="json"))
+        grant_sha256 = canonical_sha256(grant.model_dump(mode="json"))
+        generation = store.get_generation(claim.request_id)
+        assert generation is not None
+        assert generation.owner_instance_id is not None
+        ticket_consumer = (
+            "composition-inprocess-" + generation.owner_instance_id
+        )
+        handler_consumer = (
+            "composition-runtime-" + generation.owner_instance_id
+        )
+        handler_kwargs = {
+            "effect_id": claim.effect_id,
+            "ticket_id": ticket.payload.ticket_id,
+            "ticket_nonce": ticket.payload.nonce,
+            "ticket_sha256": ticket_sha256,
+            "grant_nonce": grant.payload.nonce,
+            "grant_sha256": grant_sha256,
+            "gateway_epoch": 1,
+            "expected_ticket_consumer_instance_id": ticket_consumer,
+            "handler_consumer_instance_id": handler_consumer,
+            "now_ms": 1_701,
+        }
+
+        with pytest.raises(StoreConflictError, match="Effect permit"):
+            store.consume_composition_handler_permit(**handler_kwargs)
+
+        store.acquire_dispatch_permit(
+            effect_id=claim.effect_id,
+            attempt=claim.attempt,
+            expected_fence_epoch=fixture.record.request.action_fence_epoch,
+            nonce_sha256=canonical_sha256(
+                {
+                    "execution_ticket_nonce": ticket.payload.nonce,
+                    "omni_grant_nonce": grant.payload.nonce,
+                }
+            ),
+            ticket_id=ticket.payload.ticket_id,
+            ticket_sha256=ticket_sha256,
+            grant_sha256=grant_sha256,
+            expected_request_id=claim.request_id,
+            expected_run_id=claim.run_id,
+            expected_generation=claim.generation,
+            expected_gateway_epoch=1,
+            expected_owner_instance_id=generation.owner_instance_id,
+            required_parent_effect_id=prepared["parent_effect_id"],
+            now_ms=1_702,
+        )
+        store.consume_security_nonce(
+            issuer=ticket.payload.issuer,
+            audience=ticket.payload.audience,
+            purpose="execution_ticket",
+            nonce=ticket.payload.nonce,
+            payload_sha256=ticket_sha256,
+            gateway_epoch=ticket.payload.gateway_epoch,
+            consumer_instance_id=ticket_consumer,
+            consumed_at_ms=1_703,
+            expires_at_ms=ticket.payload.expires_at_ms,
+        )
+        handler_kwargs["now_ms"] = 1_704
+        admitted = store.consume_composition_handler_permit(**handler_kwargs)
+        assert admitted == {
+            "effect_id": claim.effect_id,
+            "attempt": 1,
+            "handler_consumer_instance_id": handler_consumer,
+        }
+        assert _nonce_count(store) == fixture.baseline_nonce_count + 2
+
+        with pytest.raises(StoreConflictError, match="already consumed"):
+            store.consume_composition_handler_permit(**handler_kwargs)
+
+
+def test_real_bound_embedded_route_runs_only_through_gateway_permit(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "real-embedded-route") as fixture:
+        runner_calls: list[dict[str, Any]] = []
+
+        def runner(payload: dict[str, Any]) -> dict[str, Any]:
+            runner_calls.append(payload)
+            return {"ok": True, "result": {"source": "real-embedded-route"}}
+
+        backend = EmbeddedBackendRuntime.__new__(EmbeddedBackendRuntime)
+        backend._lock = threading.RLock()
+        backend._closed = False
+        backend._closing = False
+        backend.qiaojie = SimpleNamespace(
+            _core_execution_lock=threading.RLock()
+        )
+        backend.scheduler = SimpleNamespace()
+        client = CompatibilityJsonClient(backend)
+        worker = object.__new__(GatewayOrchestrationWorker)
+        worker._store = fixture.p7c.store
+        worker._epoch = 1
+        generation = fixture.p7c.store.get_generation(
+            fixture.record.request.request_id
+        )
+        assert generation is not None
+        assert generation.owner_instance_id is not None
+        worker._instance_id = generation.owner_instance_id
+        worker._authority = SimpleNamespace(
+            execution_trust_bundle=lambda **_kwargs: fixture.p7c.trust
+        )
+        client.set_composition_dispatch_authorizer(
+            worker._authorize_composition_handler_entry
+        )
+        fixture.coordinator._backend = client  # noqa: SLF001
+
+        def import_module(name: str):
+            assert name == "v3.jineng.jirou_ceng"
+            return SimpleNamespace(_run_omni_body_tool=runner)
+
+        with mock.patch(
+            "total_gateway.embedded_backend.time.time_ns",
+            return_value=1_700_000_000,
+        ), mock.patch(
+            "total_gateway.embedded_backend.importlib.import_module",
+            side_effect=import_module,
+        ):
+            outcome = fixture.coordinator.dispatch_record(
+                fixture.record,
+                now_ms=1_700,
+            )
+
+        assert outcome.status == "SUCCEEDED"
+        assert len(runner_calls) == 1
+        assert runner_calls[0]["action"] == fixture.record.request.action_id
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count + 2
+        assert fixture.facts.get_batch_for_effect(outcome.effect_id) is not None
+
+
+def test_valid_nonempty_opaque_target_reaches_handler(tmp_path: Path) -> None:
+    with _runtime_fixture(
+        tmp_path / "opaque-target",
+        action_id="skill.get",
+        target="word_delivery",
+        arguments={},
+    ) as fixture:
+        outcome = fixture.coordinator.dispatch_record(
+            fixture.record, now_ms=1_700
+        )
+
+        assert outcome.status == "SUCCEEDED"
+        assert fixture.backend.calls == 1
+        assert fixture.record.request.target == "word_delivery"
+
+
+def test_handler_attempt_substitution_is_ambiguous_and_writes_no_fact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with _runtime_fixture(tmp_path / "attempt-substitution") as fixture:
+        canonical_transport = execution_module.CompositionBackendExecutionTransport
+
+        class _AttemptSubstitutionTransport:
+            def __init__(self, *args, **kwargs) -> None:
+                self._delegate = canonical_transport(*args, **kwargs)
+
+            def execute(
+                self, body: bytes, *, timeout_seconds: float
+            ) -> dict[str, Any]:
+                response = self._delegate.execute(
+                    body, timeout_seconds=timeout_seconds
+                )
+                execution_result = dict(response["execution_result"])
+                execution_result["attempt"] = 2
+                return {**response, "execution_result": execution_result}
+
+        monkeypatch.setattr(
+            execution_module,
+            "CompositionBackendExecutionTransport",
+            _AttemptSubstitutionTransport,
+        )
+        outcome = fixture.coordinator.dispatch_record(
+            fixture.record, now_ms=1_700
+        )
+
+        assert outcome.status == "AMBIGUOUS"
+        assert fixture.backend.calls == 1
+        assert fixture.facts.get_batch_for_effect(outcome.effect_id) is None
+        assert fixture.p7c.store.get_effect(outcome.effect_id).state == "AMBIGUOUS"
+        assert fixture.events == [
+            ("step.prepared", "CLAIMED", False),
+            ("step.dispatched", "SIDE_EFFECT_STARTED", False),
+            ("step.ambiguous", "AMBIGUOUS", False),
+        ]
+
+
+def test_exact_scope_plan_with_missing_or_expired_receipt_fails_closed(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "receipt-obligation") as fixture:
+        store = fixture.p7c.store
+        assert store.get_executable_composition_plan_for_request(
+            **_exact_scope(fixture)
+        ) is not None
+
+        class _MissingReceiptStore:
+            def __getattr__(self, name: str):
+                return getattr(store, name)
+
+            def get_composition_step_authorization(self, *args, **kwargs):
+                del args, kwargs
+                return None
+
+        fixture.coordinator._store = _MissingReceiptStore()  # noqa: SLF001
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.authorization_missing",
+        ):
+            fixture.coordinator.dispatch_next(
+                now_ms=1_700, **_exact_scope(fixture)
+            )
+
+        fixture.coordinator._store = store  # noqa: SLF001
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.authorization_not_live",
+        ):
+            fixture.coordinator.dispatch_next(
+                now_ms=fixture.record.request.expires_at_ms + 1,
+                **_exact_scope(fixture),
+            )
+
+        assert fixture.backend.calls == 0
+        assert store.get_effect(fixture.record.request.prebound_effect_id) is None
+        assert _nonce_count(store) == fixture.baseline_nonce_count
+
+
+def test_exact_succeeded_effect_and_fact_survive_receipt_expiry(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "terminal-success") as fixture:
+        first = fixture.coordinator.dispatch_record(
+            fixture.record, now_ms=1_700
+        )
+        replay = fixture.coordinator.dispatch_next(
+            now_ms=fixture.record.request.expires_at_ms + 1,
+            **_exact_scope(fixture),
+        )
+
+        assert first.status == "SUCCEEDED"
+        assert replay is not None
+        assert replay.status == "SUCCEEDED"
+        assert replay.effect_id == first.effect_id
+        assert replay.fact_ids == first.fact_ids
+        assert replay.recovered is True
+        assert fixture.backend.calls == 1
+
+
+@pytest.mark.parametrize("status", ("FAILED_FINAL", "AMBIGUOUS"))
+def test_exact_terminal_failure_is_returned_and_never_hidden(
+    tmp_path: Path, status: str
+) -> None:
+    with _runtime_fixture(tmp_path / f"terminal-{status}") as fixture:
+        prepared = fixture.coordinator._preflight(  # noqa: SLF001
+            fixture.record, now_ms=1_700
+        )
+        claim = prepared["claim"]
+        fixture.p7c.store.claim_effect(claim)
+        if status == "AMBIGUOUS":
+            fixture.p7c.store.mark_effect_started(
+                claim.effect_id, started_at_ms=1_700
+            )
+        result = EffectResult(
+            result_id="effect-result-existing-" + status.casefold(),
+            effect_id=claim.effect_id,
+            status=status,
+            fact_id="fact-existing-" + status.casefold(),
+            evidence_sha256=canonical_sha256(
+                {"effect_id": claim.effect_id, "status": status}
+            ),
+            error_code="p7d1.test.existing_terminal",
+            observed_at_ms=1_701,
+            result_sha256="0" * 64,
+        ).with_computed_sha256()
+        fixture.p7c.store.complete_effect(result)
+
+        outcome = fixture.coordinator.dispatch_next(
+            now_ms=fixture.record.request.expires_at_ms + 1,
+            **_exact_scope(fixture),
+        )
+
+        assert outcome is not None
+        assert outcome.status == status
+        assert outcome.effect_id == claim.effect_id
+        assert outcome.fact_ids == (result.fact_id,)
+        assert outcome.recovered is True
+        assert fixture.backend.calls == 0
+
+
+def test_partial_dispatch_scope_is_rejected(tmp_path: Path) -> None:
+    with _runtime_fixture(tmp_path / "partial-scope") as fixture:
+        exact = _exact_scope(fixture)
+        partial_scopes = (
+            {"request_id": exact["request_id"]},
+            {"run_id": exact["run_id"]},
+            {"generation": exact["generation"]},
+            {
+                "request_id": exact["request_id"],
+                "run_id": exact["run_id"],
+            },
+            {
+                "request_id": exact["request_id"],
+                "generation": exact["generation"],
+            },
+            {
+                "run_id": exact["run_id"],
+                "generation": exact["generation"],
+            },
+        )
+        for scope in partial_scopes:
+            with pytest.raises(
+                ValueError, match="composition dispatch scope is incomplete"
+            ):
+                fixture.coordinator.dispatch_next(now_ms=1_700, **scope)
+
+        assert fixture.backend.calls == 0
+
+
+def test_current_trust_rejection_is_handler_zero_effect_zero_nonce_zero(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "trust") as fixture:
+        fixture.coordinator._trust_bundle_provider = (  # noqa: SLF001
+            lambda _now_ms: p7c1._trust_bundle(Ed25519PrivateKey.generate())
+        )
+
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.grant_invalid",
+        ):
+            fixture.coordinator.dispatch_record(fixture.record, now_ms=1_700)
+
+        assert fixture.backend.calls == 0
+        assert fixture.p7c.store.get_effect(
+            fixture.record.request.prebound_effect_id
+        ) is None
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count
+
+
+def test_claimed_epoch_one_receipt_fails_closed_after_real_epoch_two_restart(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "gateway-epoch-restart") as fixture:
+        prepared = fixture.coordinator._preflight(  # noqa: SLF001
+            fixture.record, now_ms=1_700
+        )
+        claim = prepared["claim"]
+        fixture.p7c.store.claim_effect(claim)
+        pre_restart_backend = fixture.backend
+        epoch_two_trust = fixture.p7c.trust.model_copy(
+            update={"gateway_epoch": 2, "bundle_sha256": "0" * 64}
+        ).with_computed_sha256()
+
+        _reopen_runtime(
+            fixture,
+            now_ms=1_800,
+            gateway_epoch=2,
+            trust_bundle=epoch_two_trust,
+        )
+        outcome = fixture.coordinator.dispatch_next(
+            now_ms=1_800, **_exact_scope(fixture)
+        )
+
+        assert outcome is not None
+        assert outcome.status == "FAILED_FINAL"
+        effect = fixture.p7c.store.get_effect(claim.effect_id)
+        assert effect.state == "FAILED_FINAL"
+        assert effect.result is not None
+        assert (
+            effect.result.error_code
+            == "composition.execution.current_authority_mismatch"
+        )
+        assert pre_restart_backend.calls == 0
+        assert fixture.backend.calls == 0
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count
+
+
+def test_receipt_plan_registry_and_schema_drift_all_fail_before_claim(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "drift") as fixture:
+        coordinator = fixture.coordinator
+        original_store = coordinator._store  # noqa: SLF001
+        original_registry = coordinator._registry  # noqa: SLF001
+        original_schemas = coordinator._schemas  # noqa: SLF001
+
+        invalid_record = replace(
+            fixture.record, authorization_record_sha256="f" * 64
+        )
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.authorization_invalid",
+        ):
+            coordinator.dispatch_record(invalid_record, now_ms=1_700)
+
+        class _InactivePlanStore:
+            def __getattr__(self, name: str):
+                return getattr(original_store, name)
+
+            def get_active_executable_composition_plan(
+                self, registration_id: str, *, now_ms: int
+            ):
+                del registration_id, now_ms
+                return None
+
+        coordinator._store = _InactivePlanStore()  # noqa: SLF001
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.plan_inactive",
+        ):
+            coordinator.dispatch_record(fixture.record, now_ms=1_700)
+        coordinator._store = original_store  # noqa: SLF001
+
+        coordinator._registry = p7c1._registry_with_permission(  # noqa: SLF001
+            fixture.p7c, handler="drifted.handler"
+        )
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.plan_mismatch",
+        ):
+            coordinator.dispatch_record(fixture.record, now_ms=1_700)
+        coordinator._registry = original_registry  # noqa: SLF001
+
+        action_id = fixture.record.request.action_id
+        entries = tuple(
+            replace(item, argument_schema_sha256="e" * 64)
+            if item.action_id == action_id
+            else item
+            for item in original_schemas.entries
+        )
+        coordinator._schemas = p7c1._catalog_with_entry(  # noqa: SLF001
+            original_schemas,
+            action_id,
+            argument_schema_sha256="e" * 64,
+        )
+        assert coordinator._schemas.entries == entries  # noqa: SLF001
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.schema_rejected",
+        ):
+            coordinator.dispatch_record(fixture.record, now_ms=1_700)
+
+        assert fixture.backend.calls == 0
+        assert original_store.get_effect(
+            fixture.record.request.prebound_effect_id
+        ) is None
+        assert _nonce_count(original_store) == fixture.baseline_nonce_count
+
+
+def test_raw_windows_target_is_rejected_before_claim_even_if_materialized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with _runtime_fixture(tmp_path / "target") as fixture:
+        materialized = execution_module.materialize_static_root_step(
+            fixture.p7c.plan, step_id=fixture.record.request.step_id
+        )
+        monkeypatch.setattr(
+            execution_module,
+            "materialize_static_root_step",
+            lambda _plan, *, step_id: replace(
+                materialized,
+                target=r"C:\\Users\\example\\raw-target.txt",
+            ),
+        )
+
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.schema_rejected",
+        ):
+            fixture.coordinator.dispatch_record(fixture.record, now_ms=1_700)
+
+        assert fixture.backend.calls == 0
+        assert fixture.p7c.store.get_effect(
+            fixture.record.request.prebound_effect_id
+        ) is None
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count
+
+
+def test_object_content_drift_is_checked_from_current_bytes() -> None:
+    body = b"sealed-input"
+    grant = ObjectGrant(
+        object_id="object-p7d1",
+        revision=1,
+        sha256=hashlib.sha256(body).hexdigest(),
+        size_bytes=len(body),
+        mime="application/octet-stream",
+        tenant_id="tenant-p7d1",
+        link_account_id="account-p7d1",
+        conversation_scope_hash="a" * 64,
+    )
+    request = SimpleNamespace(
+        object_grants=[grant.model_dump(mode="json")]
+    )
+    ticket = SimpleNamespace(
+        payload=SimpleNamespace(input_objects=(grant,))
+    )
+    reference = SimpleNamespace(
+        object_id=grant.object_id,
+        sha256=grant.sha256,
+        size_bytes=grant.size_bytes,
+        tenant_id=grant.tenant_id,
+        link_account_id=grant.link_account_id,
+        conversation_scope_hash=grant.conversation_scope_hash,
+        has_valid_sha256=lambda: True,
+    )
+    coordinator = object.__new__(CompositionStepExecutionCoordinator)
+    coordinator._objects = SimpleNamespace(  # noqa: SLF001
+        get_reference=lambda _object_id: reference,
+        read_bytes=lambda _object_id: b"changed-input",
+    )
+
+    with pytest.raises(
+        CompositionStepExecutionError,
+        match="composition.execution.object_changed",
+    ):
+        coordinator._verify_objects(request, ticket)  # noqa: SLF001
+
+
+@pytest.mark.parametrize("commit_first", (False, True))
+def test_restart_never_replays_started_effect_and_recovers_only_exact_fact(
+    tmp_path: Path, commit_first: bool
+) -> None:
+    with _runtime_fixture(tmp_path / f"restart-{commit_first}") as fixture:
+        pre_restart_backend = fixture.backend
+        fixture.coordinator._facts = _FactCrashProxy(  # noqa: SLF001
+            fixture.facts, commit_first=commit_first
+        )
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.fact_commit_unknown",
+        ):
+            fixture.coordinator.dispatch_record(fixture.record, now_ms=1_700)
+
+        effect_id = fixture.record.request.prebound_effect_id
+        assert pre_restart_backend.calls == 1
+        assert fixture.p7c.store.get_effect(effect_id).state == (
+            "SIDE_EFFECT_STARTED"
+        )
+        assert (fixture.facts.get_batch_for_effect(effect_id) is not None) is (
+            commit_first
+        )
+
+        # Reopen every durable authority and construct a fresh coordinator.
+        # Its new backend probe makes any accidental post-restart replay
+        # independently visible.
+        _reopen_runtime(fixture, now_ms=2_000)
+        outcomes = fixture.coordinator.recover_started(now_ms=2_000)
+
+        assert len(outcomes) == 1
+        assert outcomes[0].status == (
+            "SUCCEEDED" if commit_first else "AMBIGUOUS"
+        )
+        assert outcomes[0].recovered is True
+        assert pre_restart_backend.calls == 1
+        assert fixture.backend.calls == 0
+        assert fixture.p7c.store.get_effect(effect_id).state == outcomes[0].status
+        assert fixture.coordinator.dispatch_next(now_ms=2_001) is None
+        assert fixture.backend.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("action_id", "skill.get"),
+        ("action_version", "9.9.9"),
+        ("attempt", 2),
+    ),
+)
+def test_recovery_rejects_fact_identity_mismatch(
+    tmp_path: Path, field: str, value: Any
+) -> None:
+    with _runtime_fixture(tmp_path / f"restart-mismatch-{field}") as fixture:
+        fixture.coordinator._facts = _FactCrashProxy(  # noqa: SLF001
+            fixture.facts, commit_first=True
+        )
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.fact_commit_unknown",
+        ):
+            fixture.coordinator.dispatch_record(fixture.record, now_ms=1_700)
+
+        effect_id = fixture.record.request.prebound_effect_id
+        batch = fixture.facts.get_batch_for_effect(effect_id)
+        assert batch is not None
+        mismatched_result = batch.result.model_copy(update={field: value})
+        mismatched_batch = replace(batch, result=mismatched_result)
+        canonical_facts = fixture.facts
+        fixture.coordinator._facts = SimpleNamespace(  # noqa: SLF001
+            get_batch_for_effect=lambda *_args, **_kwargs: mismatched_batch,
+            get_batch_for_ticket=canonical_facts.get_batch_for_ticket,
+            record_execution=canonical_facts.record_execution,
+        )
+
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.recovery_fact_mismatch",
+        ):
+            fixture.coordinator.recover_started(now_ms=2_000)
+
+        assert fixture.p7c.store.get_effect(effect_id).state == (
+            "SIDE_EFFECT_STARTED"
+        )
+        assert fixture.backend.calls == 1
+
+
+def test_fact_missing_recovery_survives_wall_clock_rollback(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "restart-clock-rollback") as fixture:
+        pre_restart_backend = fixture.backend
+        fixture.coordinator._facts = _FactCrashProxy(  # noqa: SLF001
+            fixture.facts, commit_first=False
+        )
+        with pytest.raises(
+            CompositionStepExecutionError,
+            match="composition.execution.fact_commit_unknown",
+        ):
+            fixture.coordinator.dispatch_record(fixture.record, now_ms=1_700)
+
+        effect_id = fixture.record.request.prebound_effect_id
+        started = fixture.p7c.store.get_effect(effect_id)
+        assert started.state == "SIDE_EFFECT_STARTED"
+        assert started.side_effect_started_at_ms == 1_700
+
+        _reopen_runtime(fixture, now_ms=1_600)
+        outcomes = fixture.coordinator.recover_started(now_ms=1_600)
+
+        assert len(outcomes) == 1
+        assert outcomes[0].status == "AMBIGUOUS"
+        assert outcomes[0].recovered is True
+        terminal = fixture.p7c.store.get_effect(effect_id)
+        assert terminal.state == "AMBIGUOUS"
+        assert terminal.result.observed_at_ms == 1_700
+        assert pre_restart_backend.calls == 1
+        assert fixture.backend.calls == 0
+
+
+def test_recovery_excludes_composition_pipeline_from_generic_recovery(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "generic-recovery") as fixture:
+        fixture.coordinator._facts = _FactCrashProxy(  # noqa: SLF001
+            fixture.facts, commit_first=False
+        )
+        with pytest.raises(CompositionStepExecutionError):
+            fixture.coordinator.dispatch_record(fixture.record, now_ms=1_700)
+        effect_id = fixture.record.request.prebound_effect_id
+
+        recovered = fixture.p7c.store.recover_started_effects(
+            now_ms=1_900,
+            exclude_pipeline_versions=(COMPOSITION_STEP_PIPELINE_VERSION,),
+        )
+
+        assert recovered == ()
+        assert fixture.p7c.store.get_effect(effect_id).state == (
+            "SIDE_EFFECT_STARTED"
+        )
+
+
+def test_fence_advance_between_preflight_and_permit_keeps_handler_zero(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "fence") as fixture:
+        original_claim = fixture.p7c.store.claim_effect
+
+        def claim_then_fence(claim):
+            result = original_claim(claim)
+            fixture.p7c.store.increment_action_fence(
+                reason="p7d1-test-race", now_ms=1_700
+            )
+            return result
+
+        fixture.p7c.store.claim_effect = claim_then_fence  # type: ignore[method-assign]
+        outcome = fixture.coordinator.dispatch_record(
+            fixture.record, now_ms=1_700
+        )
+
+        assert outcome.status == "FAILED_FINAL"
+        assert fixture.backend.calls == 0
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count
+        effect = fixture.p7c.store.get_effect(outcome.effect_id)
+        assert effect.state == "FAILED_FINAL"
+        assert fixture.p7c.store.action_fence_status()["inflight_count"] == 0
+
+
+def test_permit_rejects_closed_fence_even_when_caller_uses_new_epoch(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "fence-current-epoch") as fixture:
+        prepared = fixture.coordinator._preflight(  # noqa: SLF001
+            fixture.record, now_ms=1_700
+        )
+        claim = prepared["claim"]
+        fixture.p7c.store.claim_effect(claim)
+        closed_epoch = fixture.p7c.store.increment_action_fence(
+            reason="p7d1-test-closed", now_ms=1_700
+        )
+
+        with pytest.raises(StoreConflictError, match="action fence is closed"):
+            fixture.p7c.store.acquire_dispatch_permit(
+                effect_id=claim.effect_id,
+                attempt=claim.attempt,
+                expected_fence_epoch=closed_epoch,
+                nonce_sha256="a" * 64,
+                now_ms=1_700,
+            )
+
+        assert fixture.p7c.store.get_effect(claim.effect_id).state == "CLAIMED"
+        assert fixture.p7c.store.action_fence_status()["inflight_count"] == 0
+        assert fixture.backend.calls == 0
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count
+
+
+def test_legacy_started_boundary_rejects_claim_created_after_fence(
+    tmp_path: Path,
+) -> None:
+    with _runtime_fixture(tmp_path / "legacy-fence-current-epoch") as fixture:
+        prepared = fixture.coordinator._preflight(  # noqa: SLF001
+            fixture.record, now_ms=1_700
+        )
+        claim = prepared["claim"]
+        fixture.p7c.store.increment_action_fence(
+            reason="p7d1-test-before-claim", now_ms=1_700
+        )
+        fixture.p7c.store.claim_effect(claim)
+
+        with pytest.raises(StoreConflictError, match="action fence is closed"):
+            fixture.p7c.store.mark_effect_started(
+                claim.effect_id, started_at_ms=1_700
+            )
+
+        assert fixture.p7c.store.get_effect(claim.effect_id).state == "CLAIMED"
+        assert fixture.p7c.store.action_fence_status()["inflight_count"] == 0
+        assert fixture.backend.calls == 0
+        assert _nonce_count(fixture.p7c.store) == fixture.baseline_nonce_count
+
+
+@pytest.mark.parametrize("transition", ("cancel", "supersede"))
+def test_generation_change_between_preflight_and_permit_keeps_handler_zero(
+    tmp_path: Path, transition: str
+) -> None:
+    with _runtime_fixture(tmp_path / f"generation-{transition}") as fixture:
+        store = fixture.p7c.store
+        original_claim = store.claim_effect
+
+        def claim_then_change_generation(claim):
+            result = original_claim(claim)
+            current = store.get_generation(claim.request_id)
+            assert current is not None
+            if transition == "cancel":
+                store.cancel_generation(
+                    claim.request_id,
+                    reason_code="p7d1.test.cancelled",
+                    cancelled_at_ms=1_700,
+                )
+            else:
+                next_sequence = current.run_sequence + 1
+                store.acquire_generation_lease(
+                    request_id=claim.request_id,
+                    run_id=derive_run_identity(
+                        claim.request_id, next_sequence
+                    ).run_id,
+                    run_sequence=next_sequence,
+                    generation=current.generation + 1,
+                    gateway_epoch=current.gateway_epoch,
+                    lease_id="lease_p7d1_successor",
+                    owner_instance_id=current.owner_instance_id,
+                    issued_at_ms=1_700,
+                    lease_duration_ms=10_000,
+                )
+            return result
+
+        store.claim_effect = claim_then_change_generation  # type: ignore[method-assign]
+        outcome = fixture.coordinator.dispatch_record(
+            fixture.record, now_ms=1_700
+        )
+
+        assert outcome.status == "FAILED_FINAL"
+        assert fixture.backend.calls == 0
+        assert _nonce_count(store) == fixture.baseline_nonce_count
+        assert store.get_effect(outcome.effect_id).state == "FAILED_FINAL"
+        assert store.action_fence_status()["inflight_count"] == 0

--- a/tests/test_execution_contract_epoch.py
+++ b/tests/test_execution_contract_epoch.py
@@ -48,14 +48,16 @@ class ExecutionContractEpochTests(unittest.TestCase):
         # 无 fence → 拒绝
         with self.assertRaises(StoreConflictError):
             self.store.activate_execution_contract_epoch(contract_epoch="vNext", dispositions=[], now_ms=1_000)
-        self.store.increment_action_fence(reason="cutover", now_ms=1_100)
-        # 有非终态 effect → 拒绝
+        # 先启动一个既有 effect，再进入 cutover fence；fence 生效后不得
+        # 新跨越 side-effect boundary，但已启动项仍必须被 disposition。
         claim = make_claim()
         self.store.claim_effect(claim)
+        self.store.mark_effect_started(claim.effect_id, started_at_ms=1_050)
+        self.store.increment_action_fence(reason="cutover", now_ms=1_100)
+        # 有非终态 effect → 拒绝
         with self.assertRaises(StoreConflictError):
             self.store.activate_execution_contract_epoch(contract_epoch="vNext", dispositions=[], now_ms=1_200)
         # 完成 disposition → 允许
-        self.store.mark_effect_started(claim.effect_id, started_at_ms=1_150)
         self.store.complete_effect(make_result(claim.effect_id))
         digest = self.store.activate_execution_contract_epoch(
             contract_epoch="vNext",

--- a/tests/test_gateway_worker_composition_integration_p7d1.py
+++ b/tests/test_gateway_worker_composition_integration_p7d1.py
@@ -1,0 +1,306 @@
+"""P7D.1 integration guards for the one Gateway orchestration worker.
+
+These tests deliberately cover the worker seam rather than duplicating the
+coordinator's Effect/Fact tests.  The structural guard fixes the only safe
+place for child execution, while the state-machine test proves that a child
+failure cannot leave a delivery path open.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from contracts import InboundEnvelope, InboundScope, derive_inbound_scope_keys
+from total_gateway.active_requests import ActiveRequestActivator
+from total_gateway.composition_activation_adapter import (
+    CompositionActivationAdapter,
+    CompositionActivationAdapterError,
+)
+from total_gateway.orchestration import GatewayOrchestrationWorker
+from total_gateway.store import GatewayStateStore
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ORCHESTRATION_SOURCE = ROOT / "src" / "total_gateway" / "orchestration.py"
+HASH_A = "a" * 64
+
+
+def _method(tree: ast.Module, class_name: str, method_name: str) -> ast.FunctionDef:
+    owner = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    return next(
+        node
+        for node in owner.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+
+
+def _attribute_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        owner = _attribute_name(node.value)
+        return None if owner is None else f"{owner}.{node.attr}"
+    return None
+
+
+def _calls(method: ast.FunctionDef, name: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call) and _attribute_name(node.func) == name
+    ]
+
+
+def _constant_argument(call: ast.Call, index: int, value: object) -> bool:
+    return (
+        len(call.args) > index
+        and isinstance(call.args[index], ast.Constant)
+        and call.args[index].value == value
+    )
+
+
+def _envelope(message_ref: str) -> InboundEnvelope:
+    scope = InboundScope(
+        channel="wechat",
+        tenant_id="tenant_001",
+        link_account_id="wechat_001",
+        conversation_ref="conversation_001",
+        channel_message_ref=message_ref,
+        sender_ref="sender_001",
+    )
+    keys = derive_inbound_scope_keys(scope)
+    return InboundEnvelope(
+        inbound_id=f"inbound_{message_ref}",
+        channel=scope.channel,
+        tenant_id=scope.tenant_id,
+        link_account_id=scope.link_account_id,
+        conversation_ref=scope.conversation_ref,
+        conversation_scope_hash=keys.conversation_scope_hash,
+        principal_scope_hash=keys.principal_scope_hash,
+        message_scope_hash=keys.message_scope_hash,
+        channel_message_ref=scope.channel_message_ref,
+        sender_ref=scope.sender_ref,
+        received_at_ms=1_000,
+        idempotency_key=keys.idempotency_key,
+        channel_metadata_hash=HASH_A,
+        text="run the authorized composition",
+    )
+
+
+def test_unavailable_executor_rejects_before_calling_composition_issuer() -> None:
+    tree = ast.parse(
+        ORCHESTRATION_SOURCE.read_text(encoding="utf-8"),
+        filename=str(ORCHESTRATION_SOURCE),
+    )
+    constructor = _method(tree, "GatewayOrchestrationWorker", "__init__")
+    adapter_calls = _calls(constructor, "CompositionActivationAdapter")
+    assert len(adapter_calls) == 1
+    availability = next(
+        item.value
+        for item in adapter_calls[0].keywords
+        if item.arg == "execution_available"
+    )
+    assert ast.unparse(availability) == "composition_execution_available"
+    binder_calls = _calls(
+        constructor,
+        "binder",
+    )
+    assert len(binder_calls) == 1
+    assert ast.unparse(binder_calls[0].args[0]) == (
+        "self._authorize_composition_handler_entry"
+    )
+
+    calls: list[dict[str, object]] = []
+
+    class Issuer:
+        def issue_composition_step(self, **kwargs):  # pragma: no cover - forbidden
+            calls.append(kwargs)
+            return {"status": "OK"}
+
+    adapter = CompositionActivationAdapter(Issuer(), execution_available=False)
+
+    with pytest.raises(CompositionActivationAdapterError) as caught:
+        adapter.authorize_step(
+            parent_ticket_id="ticket_parent",
+            registration_id="registration_001",
+            step_id="step.01",
+            now_ms=1_500,
+        )
+
+    assert caught.value.code == "composition.authorization.execution_unavailable"
+    assert calls == []
+
+
+def test_process_dispatches_composition_only_at_parent_durable_success_boundary() -> None:
+    tree = ast.parse(
+        ORCHESTRATION_SOURCE.read_text(encoding="utf-8"),
+        filename=str(ORCHESTRATION_SOURCE),
+    )
+    process = _method(tree, "GatewayOrchestrationWorker", "process")
+    run_loop = _method(tree, "GatewayOrchestrationWorker", "_run")
+
+    # There is exactly one composition scheduling entry point, scoped to the
+    # activation currently owned by process(); the idle loop is not a second
+    # scheduler over globally recoverable receipts.
+    dispatches = _calls(process, "self._dispatch_next_composition_step")
+    assert len(dispatches) == 1
+    assert _calls(run_loop, "self._dispatch_next_composition_step") == []
+    dispatch = dispatches[0]
+    assert {item.arg for item in dispatch.keywords} >= {
+        "now_ms",
+        "request_id",
+        "run_id",
+        "generation",
+    }
+
+    parent_facts = _calls(process, "self._facts.record_execution")
+    assert len(parent_facts) == 1
+    parent_unregisters = _calls(process, "self._omni_grants.unregister")
+    assert len(parent_unregisters) == 1
+    parent_effect_commits = [
+        call
+        for call in _calls(process, "self._store.complete_effect")
+        if call.args
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "effect_result"
+    ]
+    assert len(parent_effect_commits) == 1
+
+    aggregate_successes = [
+        call
+        for call in _calls(process, "self._advance")
+        if _constant_argument(call, 0, "execution")
+        and len(call.args) > 1
+        and isinstance(call.args[1], ast.Name)
+        and call.args[1].id == "execution_entity"
+        and _constant_argument(call, 2, "SUCCEEDED")
+    ]
+    assert len(aggregate_successes) == 1
+
+    result_payload_assignments = [
+        node
+        for node in ast.walk(process)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "result_payload"
+            for target in node.targets
+        )
+    ]
+    assert len(result_payload_assignments) == 1
+    reply_assignments = [
+        node
+        for node in ast.walk(process)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "reply"
+            for target in node.targets
+        )
+    ]
+    assert reply_assignments
+    first_reply_assignment = min(reply_assignments, key=lambda node: node.lineno)
+    life_commits = _calls(process, "self._commit_life_execution")
+    delivery_builds = _calls(process, "build_delivery_outbox_payload")
+    assert len(life_commits) == 1
+    assert len(delivery_builds) == 1
+
+    assert (
+        parent_unregisters[0].lineno
+        < parent_facts[0].lineno
+        < parent_effect_commits[0].lineno
+        < dispatch.lineno
+        < aggregate_successes[0].lineno
+        < result_payload_assignments[0].lineno
+        < first_reply_assignment.lineno
+        < life_commits[0].lineno
+        < delivery_builds[0].lineno
+    )
+
+
+@pytest.mark.parametrize(
+    ("ambiguous", "expected_execution_state"),
+    ((False, "FAILED_FINAL"), (True, "RECONCILE_REQUIRED")),
+)
+def test_composition_failure_terminalizes_request_and_cancels_delivery_without_outbox(
+    tmp_path: Path,
+    ambiguous: bool,
+    expected_execution_state: str,
+) -> None:
+    store = GatewayStateStore.open(tmp_path / "gateway.sqlite3", now_ms=900)
+    try:
+        registration = store.register_request(
+            _envelope(f"message_{int(ambiguous)}"),
+            ingress_sha256=HASH_A,
+            created_at_ms=1_100,
+        )
+        activator = ActiveRequestActivator(
+            store,
+            gateway_epoch=7,
+            owner_instance_id="gateway-instance-001",
+            lease_duration_ms=10_000,
+        )
+        activation = activator.claim(
+            registration.entry.request_id,
+            registration.entry.session_scope_hash,
+            now_ms=1_200,
+        )
+
+        worker = object.__new__(GatewayOrchestrationWorker)
+        worker._store = store
+        execution_entity = "execution-" + activation.generation.run_id
+        delivery_entity = "delivery-" + activation.generation.run_id
+        worker._initialize("execution", execution_entity, activation, 1_300)
+        worker._initialize("delivery", delivery_entity, activation, 1_300)
+        worker._advance(
+            "request", activation.entry.request_id, "PLANNING", now_ms=1_301
+        )
+        worker._advance(
+            "request", activation.entry.request_id, "EXECUTING", now_ms=1_302
+        )
+        worker._advance("execution", execution_entity, "PLANNED", now_ms=1_301)
+        worker._advance(
+            "execution", execution_entity, "TICKET_ISSUED", now_ms=1_302
+        )
+        worker._advance("execution", execution_entity, "CLAIMED", now_ms=1_303)
+        worker._advance("execution", execution_entity, "RUNNING", now_ms=1_304)
+
+        assert store.list_outbox_for_request(
+            activation.entry.request_id,
+            run_id=activation.generation.run_id,
+            generation=activation.generation.generation,
+        ) == ()
+
+        worker._terminalize_composition_failure(
+            activation,
+            execution_entity=execution_entity,
+            delivery_entity=delivery_entity,
+            code=(
+                "composition.execution.result_unknown"
+                if ambiguous
+                else "composition.execution.failed"
+            ),
+            ambiguous=ambiguous,
+            observed_at_ms=2_000,
+        )
+
+        assert store.get_snapshot("execution", execution_entity).state == (
+            expected_execution_state
+        )
+        assert store.get_snapshot("request", activation.entry.request_id).state == (
+            "FAILED"
+        )
+        assert store.get_snapshot("delivery", delivery_entity).state == "CANCELLED"
+        assert store.get_generation(activation.entry.request_id).status == "RELEASED"
+        assert store.list_outbox_for_request(
+            activation.entry.request_id,
+            run_id=activation.generation.run_id,
+            generation=activation.generation.generation,
+        ) == ()
+    finally:
+        store.close()

--- a/tests/test_gateway_worker_composition_recovery_p7d1.py
+++ b/tests/test_gateway_worker_composition_recovery_p7d1.py
@@ -1,0 +1,457 @@
+"""Focused P7D.1 recovery and watchdog regressions for orchestration.
+
+The recovery cases use the real Effect store but a minimal immutable Fact
+source.  No backend transport is installed: recovery must decide only from
+durable state and must never replay a handler.
+"""
+
+from __future__ import annotations
+
+import ast
+import concurrent.futures
+import copy
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+
+import pytest
+
+from contracts import (
+    ExecutionResult,
+    FactRecord,
+    canonical_sha256,
+    derive_effect_identity,
+    derive_run_identity,
+)
+from total_gateway.backend_client import BackendClientError
+from total_gateway.effects import EffectClaim
+from total_gateway.fact_ledger import FactBatchRecord
+from total_gateway.orchestration import GatewayOrchestrationWorker, OrchestrationError
+import total_gateway.orchestration as orchestration_module
+from total_gateway.store import GatewayStateStore
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ORCHESTRATION_SOURCE = ROOT / "src" / "total_gateway" / "orchestration.py"
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+HASH_C = "c" * 64
+REQUEST_ID = "req_" + "1" * 64
+RUN_ID = derive_run_identity(REQUEST_ID, 1).run_id
+
+
+class _FactSource:
+    def __init__(self, batch: FactBatchRecord | None) -> None:
+        self.batch = batch
+        self.lookups: list[tuple[str, bool]] = []
+
+    def get_batch_for_effect(
+        self,
+        effect_id: str,
+        *,
+        verify_payload: bool = True,
+    ) -> FactBatchRecord | None:
+        self.lookups.append((effect_id, verify_payload))
+        return self.batch
+
+
+class _ForbiddenExecutionPool:
+    """Recovery has no authority to schedule an execution handler."""
+
+    def __init__(self) -> None:
+        self.submit_calls = 0
+
+    def submit(self, *args, **kwargs):  # pragma: no cover - forbidden path
+        del args, kwargs
+        self.submit_calls += 1
+        raise AssertionError("recovery replayed the backend handler")
+
+
+def _started_parent(
+    store: GatewayStateStore,
+    *,
+    pipeline_version: str = "unspecified",
+) -> EffectClaim:
+    intent_sha256 = canonical_sha256(
+        {"case": "p7d1-parent-recovery", "pipeline": pipeline_version}
+    )
+    identity = derive_effect_identity(
+        request_id=REQUEST_ID,
+        run_id=RUN_ID,
+        run_sequence=1,
+        generation=1,
+        effect_kind="execution",
+        ordinal=0,
+        intent_sha256=intent_sha256,
+    )
+    claim = EffectClaim(
+        effect_id=identity.effect_id,
+        request_id=REQUEST_ID,
+        run_id=RUN_ID,
+        run_sequence=1,
+        generation=1,
+        effect_kind="execution",
+        ordinal=0,
+        intent_sha256=intent_sha256,
+        pipeline_version=pipeline_version,
+        attempt=1,
+        owner_component_id="tiangong-backend",
+        claimed_at_ms=1_000,
+        claim_sha256="0" * 64,
+    ).with_computed_sha256()
+    store.claim_effect(claim)
+    store.mark_effect_started(claim.effect_id, started_at_ms=1_100)
+    return claim
+
+
+def _exact_parent_batch(claim: EffectClaim) -> FactBatchRecord:
+    result = ExecutionResult(
+        result_id="execution_result_parent_recovery_p7d1",
+        ticket_id="ticket_parent_recovery_p7d1",
+        request_id=claim.request_id,
+        run_id=claim.run_id,
+        generation=claim.generation,
+        effect_id=claim.effect_id,
+        action_id="gateway.model.run",
+        action_version="1.0.0",
+        status="SUCCEEDED",
+        attempt=claim.attempt,
+        started_at_ms=1_100,
+        finished_at_ms=1_200,
+        side_effect_started=True,
+        result_payload_sha256=HASH_A,
+        receipt_sha256=HASH_B,
+        output_object_refs=(),
+        fact_ids=("fact_parent_recovery_p7d1",),
+    )
+    fact = FactRecord(
+        fact_id=result.fact_ids[0],
+        fact_type="execution.succeeded",
+        source_component_id="tiangong-backend",
+        request_id=result.request_id,
+        run_id=result.run_id,
+        generation=result.generation,
+        ticket_id=result.ticket_id,
+        effect_id=result.effect_id,
+        action_id=result.action_id,
+        action_version=result.action_version,
+        observed_at_ms=1_200,
+        payload_sha256=HASH_A,
+        evidence_sha256=HASH_B,
+        verification_method="component_receipt",
+        fact_sha256="0" * 64,
+    ).with_computed_sha256()
+    return FactBatchRecord(
+        result=result,
+        facts=(fact,),
+        source_component_id="tiangong-backend",
+        observed_at_ms=1_200,
+        tenant_id="tenant_p7d1",
+        link_account_id="account_p7d1",
+        conversation_scope_hash=HASH_C,
+        workspace_id="workspace_p7d1",
+        max_output_bytes=1_000_000,
+        result_payload_object_id="object_parent_recovery_p7d1",
+        result_payload_sha256=HASH_A,
+        response_sha256=HASH_B,
+        batch_sha256=HASH_C,
+    )
+
+
+def _recovery_worker(
+    store: GatewayStateStore,
+    facts: _FactSource,
+) -> GatewayOrchestrationWorker:
+    worker = object.__new__(GatewayOrchestrationWorker)
+    worker._store = store
+    worker._facts = facts
+    return worker
+
+
+def test_exact_parent_fact_recovers_success_without_handler_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GatewayStateStore.open(tmp_path / "gateway.sqlite3", now_ms=900)
+    try:
+        claim = _started_parent(store)
+        facts = _FactSource(_exact_parent_batch(claim))
+        pool = _ForbiddenExecutionPool()
+        monkeypatch.setattr(orchestration_module, "_EXECUTION_WATCHDOG_POOL", pool)
+
+        recovered = _recovery_worker(store, facts)._recover_parent_started_effects(
+            now_ms=1_300
+        )
+
+        head = store.get_effect(claim.effect_id)
+        assert recovered == 1
+        assert head is not None
+        assert head.state == "SUCCEEDED"
+        assert head.result is not None
+        assert head.result.fact_id == "fact_parent_recovery_p7d1"
+        assert facts.lookups == [(claim.effect_id, True)]
+        assert pool.submit_calls == 0
+    finally:
+        store.close()
+
+
+def test_started_parent_without_fact_closes_ambiguous_without_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GatewayStateStore.open(tmp_path / "gateway.sqlite3", now_ms=900)
+    try:
+        claim = _started_parent(store)
+        facts = _FactSource(None)
+        pool = _ForbiddenExecutionPool()
+        monkeypatch.setattr(orchestration_module, "_EXECUTION_WATCHDOG_POOL", pool)
+
+        recovered = _recovery_worker(store, facts)._recover_parent_started_effects(
+            now_ms=1_050
+        )
+
+        head = store.get_effect(claim.effect_id)
+        assert recovered == 1
+        assert head is not None
+        assert head.state == "AMBIGUOUS"
+        assert head.result is not None
+        assert head.result.error_code == "effect.result_missing_after_restart"
+        assert head.result.observed_at_ms == 1_100
+        assert facts.lookups == [(claim.effect_id, True)]
+        assert pool.submit_calls == 0
+    finally:
+        store.close()
+
+
+def test_parent_fact_must_match_full_execution_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GatewayStateStore.open(tmp_path / "gateway.sqlite3", now_ms=900)
+    try:
+        claim = _started_parent(store)
+        exact = _exact_parent_batch(claim)
+        facts = _FactSource(exact)
+        pool = _ForbiddenExecutionPool()
+        monkeypatch.setattr(orchestration_module, "_EXECUTION_WATCHDOG_POOL", pool)
+        worker = _recovery_worker(store, facts)
+        mismatches = {
+            "fact identity": {"fact_ids": ("fact_other_parent",)},
+            "effect identity": {"effect_id": "eff_" + "9" * 64},
+            "request identity": {"request_id": "req_" + "9" * 64},
+            "run identity": {"run_id": "run_" + "9" * 64},
+            "generation identity": {"generation": 2},
+            "action": {"action_id": "gateway.other.run"},
+            "action version": {"action_version": "2.0.0"},
+            "attempt": {"attempt": 2},
+            "dispatch boundary": {"side_effect_started": False},
+        }
+
+        for label, updates in mismatches.items():
+            facts.batch = replace(
+                exact,
+                result=exact.result.model_copy(update=updates),
+            )
+            with pytest.raises(OrchestrationError) as caught:
+                worker._recover_parent_started_effects(now_ms=1_300)
+            assert caught.value.code == "orchestration.parent.recovery_fact_mismatch", label
+            assert caught.value.ambiguous is True, label
+            assert store.get_effect(claim.effect_id).state == "SIDE_EFFECT_STARTED", label
+
+        assert pool.submit_calls == 0
+    finally:
+        store.close()
+
+
+def test_parent_recovery_is_limited_to_the_unspecified_pipeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GatewayStateStore.open(tmp_path / "gateway.sqlite3", now_ms=900)
+    try:
+        claim = _started_parent(store, pipeline_version="other-parent-pipeline.v1")
+        facts = _FactSource(_exact_parent_batch(claim))
+        pool = _ForbiddenExecutionPool()
+        monkeypatch.setattr(orchestration_module, "_EXECUTION_WATCHDOG_POOL", pool)
+
+        recovered = _recovery_worker(store, facts)._recover_parent_started_effects(
+            now_ms=1_300
+        )
+
+        assert recovered == 0
+        assert store.get_effect(claim.effect_id).state == "SIDE_EFFECT_STARTED"
+        assert facts.lookups == []
+        assert pool.submit_calls == 0
+    finally:
+        store.close()
+
+
+def test_composition_watchdog_slot_stays_owned_until_timed_out_call_really_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=2,
+        thread_name_prefix="p7d1-watchdog-test",
+    )
+    slot = threading.BoundedSemaphore(value=1)
+    monkeypatch.setattr(orchestration_module, "_EXECUTION_WATCHDOG_POOL", executor)
+    monkeypatch.setattr(orchestration_module, "_COMPOSITION_WATCHDOG_SLOT", slot)
+    started = threading.Event()
+    release = threading.Event()
+    exited = threading.Event()
+    caller_done = threading.Event()
+    first_errors: list[BaseException] = []
+    calls = {"first": 0, "second": 0, "third": 0}
+
+    def hanging_handler() -> dict[str, bool]:
+        calls["first"] += 1
+        started.set()
+        if not release.wait(timeout=2):  # pragma: no cover - test cleanup guard
+            raise AssertionError("test did not release the hanging handler")
+        exited.set()
+        return {"first": True}
+
+    def invoke_first() -> None:
+        try:
+            orchestration_module._run_backend_transport_with_watchdog(
+                hanging_handler,
+                timeout_seconds=0.05,
+            )
+        except BaseException as exc:  # captured for assertions in the test thread
+            first_errors.append(exc)
+        finally:
+            caller_done.set()
+
+    caller = threading.Thread(target=invoke_first, name="p7d1-watchdog-caller")
+    caller.start()
+    try:
+        assert started.wait(timeout=1)
+        assert caller_done.wait(timeout=1)
+        caller.join(timeout=1)
+        assert not caller.is_alive()
+        assert len(first_errors) == 1
+        first_error = first_errors[0]
+        assert isinstance(first_error, BackendClientError)
+        assert first_error.code == "backend.composition.execution_timeout"
+        assert first_error.ambiguous is True
+
+        def forbidden_second_handler() -> dict[str, bool]:
+            calls["second"] += 1
+            return {"second": True}
+
+        with pytest.raises(BackendClientError) as caught:
+            orchestration_module._run_backend_transport_with_watchdog(
+                forbidden_second_handler,
+                timeout_seconds=0.2,
+            )
+        assert caught.value.code == "backend.composition.watchdog_capacity_exhausted"
+        assert caught.value.ambiguous is True
+        assert calls["second"] == 0
+        assert slot.acquire(blocking=False) is False
+
+        release.set()
+        assert exited.wait(timeout=1)
+        # The Future done callback, rather than the caller timeout, returns the
+        # slot.  Acquire with a bound to avoid racing that callback.
+        assert slot.acquire(timeout=1)
+        slot.release()
+
+        def third_handler() -> dict[str, bool]:
+            calls["third"] += 1
+            return {"third": True}
+
+        assert orchestration_module._run_backend_transport_with_watchdog(
+            third_handler,
+            timeout_seconds=0.2,
+        ) == {"third": True}
+        assert calls == {"first": 1, "second": 0, "third": 1}
+    finally:
+        release.set()
+        caller.join(timeout=1)
+        executor.shutdown(wait=True, cancel_futures=True)
+
+
+def _parent_execution_timeout_try() -> ast.Try:
+    """Return the exact parent execution-future wait from process()."""
+
+    tree = ast.parse(
+        ORCHESTRATION_SOURCE.read_text(encoding="utf-8"),
+        filename=str(ORCHESTRATION_SOURCE),
+    )
+    worker = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "GatewayOrchestrationWorker"
+    )
+    process = next(
+        node
+        for node in worker.body
+        if isinstance(node, ast.FunctionDef) and node.name == "process"
+    )
+    candidates = [
+        node
+        for node in ast.walk(process)
+        if isinstance(node, ast.Try)
+        and any(
+            handler.type is not None
+            and ast.unparse(handler.type) == "concurrent.futures.TimeoutError"
+            for handler in node.handlers
+        )
+        and any(
+            isinstance(item, ast.Call)
+            and ast.unparse(item.func) == "execution_future.result"
+            for item in ast.walk(node)
+        )
+    ]
+    assert len(candidates) == 1
+    return candidates[0]
+
+
+def test_parent_execution_future_timeout_calls_cancel_on_the_actual_branch() -> None:
+    # Execute the production try/except statements with a controlled Future.
+    # This reaches the parent path without constructing the unrelated policy,
+    # Life, object-store, and delivery authorities required by process().
+    wrapper = ast.parse(
+        "def exercise(self, effect, execution_future, watchdog_ms):\n"
+        "    pass\n"
+    ).body[0]
+    assert isinstance(wrapper, ast.FunctionDef)
+    wrapper.body = [copy.deepcopy(_parent_execution_timeout_try())]
+    module = ast.fix_missing_locations(ast.Module(body=[wrapper], type_ignores=[]))
+    namespace = {
+        "BackendClientError": BackendClientError,
+        "concurrent": concurrent,
+    }
+    exec(compile(module, str(ORCHESTRATION_SOURCE), "exec"), namespace)
+
+    class _TimeoutFuture:
+        def __init__(self) -> None:
+            self.cancel_calls = 0
+            self.timeouts: list[float] = []
+
+        def result(self, *, timeout: float):
+            self.timeouts.append(timeout)
+            raise concurrent.futures.TimeoutError
+
+        def cancel(self) -> bool:
+            self.cancel_calls += 1
+            return True
+
+    future = _TimeoutFuture()
+    effect = SimpleNamespace(effect_id="eff_" + "7" * 64)
+    owner = SimpleNamespace(
+        _store=SimpleNamespace(
+            get_effect=lambda effect_id: SimpleNamespace(
+                state="SIDE_EFFECT_STARTED"
+            )
+        )
+    )
+
+    with pytest.raises(BackendClientError) as caught:
+        namespace["exercise"](owner, effect, future, 250)
+
+    assert future.timeouts == [0.25]
+    assert future.cancel_calls == 1
+    assert caught.value.code == "effect_execution_timeout"
+    assert caught.value.ambiguous is True

--- a/tests/test_policy_evidence_concurrency.py
+++ b/tests/test_policy_evidence_concurrency.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from contracts import canonical_json_bytes
+from total_gateway.policy_evidence import PolicyEvidenceLedger
+
+
+def test_separate_ledgers_publish_one_content_address_without_overwrite(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "policy-evidence"
+    ledgers = (PolicyEvidenceLedger(root), PolicyEvidenceLedger(root))
+    payload = {
+        "schema": "tiangong.gateway.policy-evidence-test.v1",
+        "decision_id": "policy-decision-concurrent",
+        "outcome": "ALLOW",
+    }
+    original_link = os.link
+    publish_barrier = threading.Barrier(2)
+    link_outcomes: list[str] = []
+    outcomes_lock = threading.Lock()
+
+    def synchronized_link(source, destination, *args, **kwargs):
+        publish_barrier.wait(timeout=10)
+        try:
+            original_link(source, destination, *args, **kwargs)
+        except FileExistsError:
+            with outcomes_lock:
+                link_outcomes.append("exists")
+            raise
+        else:
+            with outcomes_lock:
+                link_outcomes.append("created")
+
+    monkeypatch.setattr(os, "link", synchronized_link)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        rows = tuple(
+            pool.map(
+                lambda ledger: ledger.record(
+                    "policy-decision",
+                    "policy-decision-concurrent",
+                    payload,
+                ),
+                ledgers,
+            )
+        )
+
+    assert rows[0] == rows[1]
+    assert sorted(link_outcomes) == ["created", "exists"]
+    path = Path(rows[0]["path"])
+    assert path.read_bytes() == canonical_json_bytes(payload) + b"\n"
+    assert tuple(path.parent.glob("~*.tmp")) == ()
+
+
+def test_publish_failure_without_winner_fails_closed_and_cleans_staging(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "policy-evidence"
+    ledger = PolicyEvidenceLedger(root)
+
+    def reject_link(*_args, **_kwargs):
+        raise PermissionError("publication denied")
+
+    monkeypatch.setattr(os, "link", reject_link)
+    with pytest.raises(PermissionError, match="publication denied"):
+        ledger.record(
+            "policy-decision",
+            "policy-decision-denied",
+            {"schema": "tiangong.gateway.policy-evidence-test.v1"},
+        )
+
+    evidence_directory = root / "d"
+    assert tuple(evidence_directory.glob("*.json")) == ()
+    assert tuple(evidence_directory.glob("~*.tmp")) == ()

--- a/tests/test_v21_g4_store_engine.py
+++ b/tests/test_v21_g4_store_engine.py
@@ -291,6 +291,10 @@ def test_t26b_security_surface_files_match_reviewed_lineage() -> None:
                 "p7c1-composition-execution-binding",
                 "cbbed31ee82fb9c3973ffaf14427495562be12fb9eeb2fb6abd3330acfb44f63",
             ),
+            (
+                "p7d1-composition-effect-intent-cycle-break",
+                "f58945c978567df9facce05216ac7141fcf682bcc3cfd8397459de049e8549de",
+            ),
         ),
     }
     root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Scope

P7D.1 wires one persisted static A0 composition root through the existing `GatewayOrchestrationWorker` and existing PolicyEngine -> ExecutionTicket -> OmniCapabilityGrant chain into the compatibility Backend, private embedded route, Omni Body and BodyRuntime.

## Authority and recovery invariants

- no second Gateway, scheduler, Runtime, Store, Policy, Effect/Fact ledger, P19 plane or Completion authority
- re-read and verify the exact receipt, executable plan, registration, registry/schema, object/fence/generation and current trust before dispatch
- consume the existing ticket nonce and grant nonce only at the handler boundary; rejected preflight invokes no handler
- write the Gateway Fact batch before terminal child Effect; recover an exact Fact after restart, otherwise close unknown STARTED work AMBIGUOUS without replay
- keep both the watchdog slot and Store inflight permit occupied while a timed-out in-process handler is still running
- fail the parent before aggregate success, artifact/Life or outbox work when the required child fails or is ambiguous

## Deliberate non-goals

This is not P7D production completion. Multi-step DAG scheduling, dynamic `STEP_OUTPUT`, result/value schema authority, current-epoch continuation authorization, P19 exact readiness/repair and all-leaf CompletionGate closeout remain P7D.2.

## Local evidence

- focused Runtime/Effect/Fact/restart/timeout: 97 passed
- P19 Golden: 55 passed
- P19/verification/repair selection: 316 passed
- P14 focused: 109 passed
- full Python: 3969 passed, 17 skipped, 847 subtests
- canonical Node suite: 224 passed, 2 skipped, 0 failed
- generated-source committed mirror, Omni manifest, Source Authority and diff checks: PASS
- independent final correctness review: no P0/P1